### PR TITLE
force UTF-8 encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mo encoding=UTF-8 text=auto


### PR DESCRIPTION
[stackoverflow](https://stackoverflow.com/questions/48907049/what-is-the-appropriate-character-encoding-for-a-git-repo)