### PR TITLE
Fixes to make all (!) Examples work with Modelon Impact

### DIFF
--- a/ThermofluidStream/Boundaries/PhaseSeperator.mo
+++ b/ThermofluidStream/Boundaries/PhaseSeperator.mo
@@ -1,7 +1,8 @@
 within ThermofluidStream.Boundaries;
 model PhaseSeperator "Parent to Reciever and Accumulator models"
   extends Boundaries.Internal.PartialVolume(
-    redeclare replaceable package Medium = Media.myMedia.Interfaces.PartialTwoPhaseMedium,
+    redeclare replaceable package Medium =
+        Media.myMedia.Interfaces.PartialTwoPhaseMedium,
     useHeatport=false,
     final useInlet=true,
     final useOutlet=true,
@@ -15,10 +16,10 @@ model PhaseSeperator "Parent to Reciever and Accumulator models"
   parameter SI.Volume V_par(displayUnit="l")=0.01 "Volume of phase seperator";
   parameter Real pipe_low(unit="1", min=0, max=1) "Low end of pipe";
   parameter Real pipe_high(unit="1", min=0, max=1) "High end of pipe";
-  parameter Boolean density_derp_h_from_media=false   "EXPERIMENTAL: get density_derp_h from media model. The function is only implemented for some Media."
-    annotation(Dialog(tab="Advanced", group="Damping", enable=(k_volume_damping > 0)));
-  parameter SI.DerDensityByPressure density_derp_h_set = 1e-6 "Derivative of density by pressure estimation; Approx. 1e-5 for air, 1e-7 for water"
-    annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
+//   parameter Boolean density_derp_h_from_media=false   "EXPERIMENTAL: get density_derp_h from media model. The function is only implemented for some Media."
+//     annotation(Dialog(tab="Advanced", group="Damping", enable=(k_volume_damping > 0)));
+//   parameter SI.DerDensityByPressure density_derp_h_set = 1e-6 "Derivative of density by pressure estimation; Approx. 1e-5 for air, 1e-7 for water"
+//     annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
   parameter Init init_method = ThermofluidStream.Boundaries.Internal.InitializationMethodsPhaseSeperator.l "Initialization Method"
     annotation(choicesAllMatching=true, Dialog(tab="Initialization"));
   parameter SI.SpecificEnthalpy h_0 = Medium.h_default "Initial specific enthalpy"
@@ -44,8 +45,8 @@ protected
   SI.SpecificEnthalpy h_bubble = Medium.bubbleEnthalpy(Medium.setSat_p(medium.p))-1 "Bubble Enthalpy of Medium";
   SI.SpecificEnthalpy h_dew = Medium.dewEnthalpy(Medium.setSat_p(medium.p))+1 "Dew Enthalpy of Medium";
 
-  Modelica.Blocks.Interfaces.RealInput tmp_dddp(unit="s2/m2") = Medium.density_derp_h(medium.state) if density_derp_h_from_media;
-  Modelica.Blocks.Interfaces.RealOutput tmp2_dddp(unit="s2/m2");
+//   Modelica.Blocks.Interfaces.RealInput tmp_dddp(unit="s2/m2") = Medium.density_derp_h(medium.state) if density_derp_h_from_media;
+//   Modelica.Blocks.Interfaces.RealOutput tmp2_dddp(unit="s2/m2");
 
 initial equation
   if init_method == Init.h then
@@ -61,13 +62,13 @@ initial equation
 
 equation
   //this workaround is necessary, because the method density_derp_h is not implemented in all media, and therefore has to be removed conditionally when not implemented"
-  connect(tmp_dddp, tmp2_dddp);
-  if density_derp_h_from_media then
-    density_derp_h = tmp2_dddp;
-  else
-    density_derp_h = density_derp_h_set;
-    tmp2_dddp = 0;
-  end if;
+//   connect(tmp_dddp, tmp2_dddp);
+//   if density_derp_h_from_media then
+  density_derp_h = Medium.density_derp_h(medium.state);
+//   else
+//     density_derp_h = density_derp_h_set;
+//     tmp2_dddp = 0;
+//   end if;
 
   V = V_par;
   W_v = 0;

--- a/ThermofluidStream/Boundaries/Volume.mo
+++ b/ThermofluidStream/Boundaries/Volume.mo
@@ -3,23 +3,17 @@ model Volume "Model of a vessel with fixed volume"
   extends Internal.PartialVolume;
 
   parameter SI.Volume V_par(displayUnit="l") = 0.001                    "Volume of the Model";
-  parameter Boolean density_derp_h_from_media=false   "EXPERIMENTAL: get density_derp_h from media model. The function is only implemented for some Media."
-    annotation(Dialog(tab="Advanced", group="Damping", enable=(k_volume_damping > 0)));
-  parameter SI.DerDensityByPressure density_derp_h_set = 1e-6 "Derivative of density by pressure estimation; Approx. 1e-5 for air, 1e-7 for water"
-    annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
-
-protected
-  Modelica.Blocks.Interfaces.RealInput tmp_dddp(unit="s2/m2") = Medium.density_derp_h(medium.state) if density_derp_h_from_media;
-  Modelica.Blocks.Interfaces.RealOutput tmp2_dddp(unit="s2/m2");
+//  parameter Boolean density_derp_h_from_media=false   "EXPERIMENTAL: get density_derp_h from media model. The function is only implemented for some Media."
+//    annotation(Dialog(tab="Advanced", group="Damping", enable=(k_volume_damping > 0)));
+//  parameter SI.DerDensityByPressure density_derp_h_set = 1e-6 "Derivative of density by pressure estimation; Approx. 1e-5 for air, 1e-7 for water"
+//    annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
+//
+// protected
+//   Modelica.Blocks.Interfaces.RealInput tmp_dddp(unit="s2/m2") = Medium.density_derp_h(medium.state) if density_derp_h_from_media;
+//  Modelica.Blocks.Interfaces.RealOutput tmp2_dddp(unit="s2/m2");
 equation
   //this workaround is necessary, because the method density_derp_h is not implemented in all media, and therefore has to be removed conditionally when not implemented"
-  connect(tmp_dddp, tmp2_dddp);
-  if density_derp_h_from_media then
-    density_derp_h = tmp2_dddp;
-  else
-    density_derp_h = density_derp_h_set;
-    tmp2_dddp = 0;
-  end if;
+    density_derp_h = Medium.density_derp_h(medium.state);
 
   V = V_par;
   W_v = 0;

--- a/ThermofluidStream/Boundaries/VolumeMix.mo
+++ b/ThermofluidStream/Boundaries/VolumeMix.mo
@@ -3,23 +3,23 @@ model VolumeMix "Volume with N inlets that allows mixing"
   extends Internal.PartialVolumeN;
 
   parameter SI.Volume V_par(displayUnit="l") = 0.001 "Volume of the Model";
-  parameter Boolean density_derp_h_from_media = false "EXPERIMENTAL: get density_derp_h from media model. The function is only implemented for some Media."
-    annotation(Dialog(tab="Advanced", group="Damping", enable=(k_volume_damping > 0)));
-  parameter SI.DerDensityByPressure density_derp_h_set = 1e-6 "Derivative of density by pressure estimation; Approx. 1e-5 for air, 1e-7 for water"
-    annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
-
-protected
-  Modelica.Blocks.Interfaces.RealInput tmp_dddp(unit="s2/m2") = Medium.density_derp_h(medium.state) if density_derp_h_from_media;
-  Modelica.Blocks.Interfaces.RealOutput tmp2_dddp(unit="s2/m2");
+//   parameter Boolean density_derp_h_from_media = false "EXPERIMENTAL: get density_derp_h from media model. The function is only implemented for some Media."
+//     annotation(Dialog(tab="Advanced", group="Damping", enable=(k_volume_damping > 0)));
+//   parameter SI.DerDensityByPressure density_derp_h_set = 1e-6 "Derivative of density by pressure estimation; Approx. 1e-5 for air, 1e-7 for water"
+//     annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
+//
+// protected
+//   Modelica.Blocks.Interfaces.RealInput tmp_dddp(unit="s2/m2") = Medium.density_derp_h(medium.state) if density_derp_h_from_media;
+//   Modelica.Blocks.Interfaces.RealOutput tmp2_dddp(unit="s2/m2");
 equation
   //this workaround is necessary, because the method density_derp_h is not implemented in all media, and therefore has to be removed conditionally when not implemented"
-  connect(tmp_dddp, tmp2_dddp);
-  if density_derp_h_from_media then
-    density_derp_h = tmp2_dddp;
-  else
-    density_derp_h = density_derp_h_set;
-    tmp2_dddp = 0;
-  end if;
+//   connect(tmp_dddp, tmp2_dddp);
+//   if density_derp_h_from_media then
+  density_derp_h = Medium.density_derp_h(medium.state);
+//   else
+//     density_derp_h = density_derp_h_set;
+//     tmp2_dddp = 0;
+//   end if;
 
   V = V_par;
   W_v = 0;

--- a/ThermofluidStream/DropOfCommons.mo
+++ b/ThermofluidStream/DropOfCommons.mo
@@ -18,7 +18,7 @@ model DropOfCommons "model for global parameters"
     annotation(Dialog(group="Regularization"));
   parameter SI.Acceleration g = Modelica.Constants.g_n "Acceleration of gravity";
 
-  AssertionLevel assertionLevel = if (stopOnFailedAssert) then AssertionLevel.error else AssertionLevel.warning;
+  parameter AssertionLevel assertionLevel = if (stopOnFailedAssert) then AssertionLevel.error else AssertionLevel.warning;
 
   annotation (defaultComponentName="dropOfCommons",
     defaultComponentPrefixes="inner",

--- a/ThermofluidStream/Examples/HeatPump.mo
+++ b/ThermofluidStream/Examples/HeatPump.mo
@@ -2,9 +2,11 @@ within ThermofluidStream.Examples;
 model HeatPump
   extends Modelica.Icons.Example;
 
-  replaceable package Medium = Media.XRGMedia.R1234yf_ph constrainedby Media.myMedia.Interfaces.PartialMedium "Refrigerant Medium"
+  replaceable package Medium = Media.XRGMedia.R1234yf_ph constrainedby
+    Media.myMedia.Interfaces.PartialMedium                                                                    "Refrigerant Medium"
     annotation(choicesAllMatching=true);
-  replaceable package Air = Media.myMedia.Air.DryAirNasa constrainedby Media.myMedia.Interfaces.PartialMedium "Air Medium"
+  replaceable package Air = Media.myMedia.Air.DryAirNasa constrainedby
+    Media.myMedia.Interfaces.PartialMedium                                                                    "Air Medium"
     annotation(choicesAllMatching=true);
 
   HeatExchangers.DiscretizedHEX                      condenser(
@@ -256,7 +258,7 @@ model HeatPump
   ThermofluidStream.Utilities.showRealValue showRealValue(
     use_numberPort=false,
     description="COP",
-    number=condenser.Q_flow_air/max(0.00001 + compressor.W_t)) annotation (Placement(transformation(extent={{80,-94},{154,-56}})));
+    number=condenser.Q_flow_air/max(0.00001,compressor.W_t)) annotation (Placement(transformation(extent={{80,-94},{154,-56}})));
   ThermofluidStream.Utilities.Icons.DLRLogo dLRLogo annotation (Placement(transformation(extent={{134,-156},{190,-100}})));
 equation
   connect(source1.outlet, flowResistance2.inlet) annotation (Line(

--- a/ThermofluidStream/Examples/HeatPump.mo
+++ b/ThermofluidStream/Examples/HeatPump.mo
@@ -2,11 +2,9 @@ within ThermofluidStream.Examples;
 model HeatPump
   extends Modelica.Icons.Example;
 
-  replaceable package Medium = Media.XRGMedia.R1234yf_ph constrainedby
-    Media.myMedia.Interfaces.PartialMedium                                                                    "Refrigerant Medium"
+  replaceable package Medium = Media.XRGMedia.R1234yf_ph constrainedby Media.myMedia.Interfaces.PartialMedium "Refrigerant Medium"
     annotation(choicesAllMatching=true);
-  replaceable package Air = Media.myMedia.Air.DryAirNasa constrainedby
-    Media.myMedia.Interfaces.PartialMedium                                                                    "Air Medium"
+  replaceable package Air = Media.myMedia.Air.DryAirNasa constrainedby Media.myMedia.Interfaces.PartialMedium "Air Medium"
     annotation(choicesAllMatching=true);
 
   HeatExchangers.DiscretizedHEX                      condenser(
@@ -258,7 +256,7 @@ model HeatPump
   ThermofluidStream.Utilities.showRealValue showRealValue(
     use_numberPort=false,
     description="COP",
-    number=condenser.Q_flow_air/max(0.00001,compressor.W_t)) annotation (Placement(transformation(extent={{80,-94},{154,-56}})));
+    number=condenser.Q_flow_air/max({0.00001 + compressor.W_t})) annotation (Placement(transformation(extent={{80,-94},{154,-56}})));
   ThermofluidStream.Utilities.Icons.DLRLogo dLRLogo annotation (Placement(transformation(extent={{134,-156},{190,-100}})));
 equation
   connect(source1.outlet, flowResistance2.inlet) annotation (Line(

--- a/ThermofluidStream/Examples/SimpleCoolingCycle.mo
+++ b/ThermofluidStream/Examples/SimpleCoolingCycle.mo
@@ -6,7 +6,8 @@ extends Modelica.Icons.Example;
       ThermofluidStream.Media.myMedia.Water.ConstantPropertyLiquidWater
     constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium      annotation(choicesAllMatching = true);
 
-  replaceable package medium_air = ThermofluidStream.Media.myMedia.Air.DryAirNasa
+  replaceable package medium_air =
+      ThermofluidStream.Media.myMedia.Air.DryAirNasa
     constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium      annotation(choicesAllMatching = true);
 
   ThermofluidStream.HeatExchangers.CounterFlowNTU heatExchange_CounterFlowNTU(
@@ -41,8 +42,8 @@ extends Modelica.Icons.Example;
     r=0.05,
     l=1,
     redeclare function pLoss =
-        ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
-         k=1e5))
+        ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss
+        (k=1e5))
     annotation (Placement(transformation(extent={{60,50},{80,70}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm multiSensor_Tpm1(redeclare package Medium =
                medium_liquid, temperatureUnit="degC")
@@ -88,7 +89,8 @@ extends Modelica.Icons.Example;
     annotation (Placement(transformation(extent={{98,-70},{118,-50}})));
 
   ThermofluidStream.Processes.Fan fan(redeclare package Medium = medium_air,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,redeclare function dp_tau_fan =
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,redeclare
+      function                                                                                  dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=100))
     annotation (Placement(transformation(extent={{140,-36},{160,-16}})));
   Modelica.Blocks.Sources.RealExpression pump_speed(y=80 + 273.15)

--- a/ThermofluidStream/Media/myMedia.mo
+++ b/ThermofluidStream/Media/myMedia.mo
@@ -2659,13 +2659,15 @@ points, e.g., when an isentropic reference state is computed.
 
       model DryAir1 "Example 1 for dry air"
         extends Modelica.Icons.Example;
-        extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Air.ReferenceAir.Air_pT);
+        extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium =
+              myMedia.Air.ReferenceAir.Air_pT);
         annotation (experiment_X(StopTime=1.01));
       end DryAir1;
 
       model DryAir2 "Example 2 for dry air"
         extends Modelica.Icons.Example;
-        extends myMedia.Examples.Utilities.PartialTestModel2(redeclare package Medium = myMedia.Air.ReferenceAir.Air_pT);
+        extends myMedia.Examples.Utilities.PartialTestModel2(redeclare package Medium =
+              myMedia.Air.ReferenceAir.Air_pT);
         annotation (experiment_X(StopTime=1.01));
       end DryAir2;
 
@@ -2715,13 +2717,15 @@ points, e.g., when an isentropic reference state is computed.
 
       model MoistAir1 "Example 1 for moist air"
         extends Modelica.Icons.Example;
-        extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Air.ReferenceMoistAir);
+        extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium =
+              myMedia.Air.ReferenceMoistAir);
         annotation (experiment_X(StopTime=1.01));
       end MoistAir1;
 
       model MoistAir2 "Example 2 for moist air"
         extends Modelica.Icons.Example;
-        extends myMedia.Examples.Utilities.PartialTestModel2(redeclare package Medium = myMedia.Air.ReferenceMoistAir);
+        extends myMedia.Examples.Utilities.PartialTestModel2(redeclare package Medium =
+              myMedia.Air.ReferenceMoistAir);
         annotation (experiment_X(StopTime=1.01));
       end MoistAir2;
 
@@ -2979,7 +2983,8 @@ output window.
         "Solve h = h_T(T), s = s_T(T) for T, if h or s is given for ideal gas NASA"
         extends Modelica.Icons.Example;
 
-        replaceable package Medium = myMedia.Air.DryAirNasa constrainedby myMedia.IdealGases.Common.SingleGasNasa
+        replaceable package Medium = myMedia.Air.DryAirNasa constrainedby
+          myMedia.IdealGases.Common.SingleGasNasa
           "Medium model"
           annotation (choicesAllMatching=true);
 
@@ -3100,7 +3105,8 @@ output window.
         extends Modelica.Icons.Example;
 
         replaceable package Medium =
-            myMedia.IdealGases.MixtureGases.FlueGasLambdaOnePlus constrainedby myMedia.IdealGases.Common.MixtureGasNasa
+            myMedia.IdealGases.MixtureGases.FlueGasLambdaOnePlus constrainedby
+          myMedia.IdealGases.Common.MixtureGasNasa
           "Medium model" annotation (choicesAllMatching=true);
 
         parameter SI.Temperature T_min=300
@@ -4478,7 +4484,9 @@ no mass or energy is stored in the pipe.
           extends Modelica.Icons.ObsoleteModel;
           model SimpleAir "Test Modelica.Media.Air.SimpleAir"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Air.SimpleAir);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Air.SimpleAir);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4488,7 +4496,9 @@ no mass or energy is stored in the pipe.
 
           model DryAirNasa "Test Modelica.Media.Air.DryAirNasa"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Air.DryAirNasa);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Air.DryAirNasa);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4498,7 +4508,9 @@ no mass or energy is stored in the pipe.
 
           model MoistAir "Test Modelica.Media.Air.MoistAir"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Air.MoistAir);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Air.MoistAir);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4516,7 +4528,9 @@ no mass or energy is stored in the pipe.
 
           model Air "Test single gas Modelica.Media.IdealGases.SingleGases.Air"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Air.DryAirNasa);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Air.DryAirNasa);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4527,7 +4541,9 @@ no mass or energy is stored in the pipe.
           model Nitrogen
             "Test single gas Modelica.Media.IdealGases.SingleGases.N2"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.IdealGases.SingleGases.N2);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.IdealGases.SingleGases.N2);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4538,7 +4554,9 @@ no mass or energy is stored in the pipe.
           model SimpleNaturalGas
             "Test mixture gas Modelica.Media.IdealGases.MixtureGases.SimpleNaturalGas"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.IdealGases.MixtureGases.SimpleNaturalGas);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.IdealGases.MixtureGases.SimpleNaturalGas);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4549,7 +4567,8 @@ no mass or energy is stored in the pipe.
           model SimpleNaturalGasFixedComposition
             "Test mixture gas Modelica.Media.IdealGases.MixtureGases.SimpleNaturalGas"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium =
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
                   myMedia.IdealGases.MixtureGases.SimpleNaturalGasFixedComposition);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
@@ -4568,7 +4587,9 @@ no mass or energy is stored in the pipe.
           extends Modelica.Icons.ObsoleteModel;
           model Glycol47 "Test Modelica.Media.Incompressible.Examples.Glycol47"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Incompressible.Examples.Glycol47 (final
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Incompressible.Examples.Glycol47 (                                                                         final
                     singleState=true, final enthalpyOfT=true));
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
@@ -4580,7 +4601,9 @@ no mass or energy is stored in the pipe.
           model Essotherm650
             "Test Modelica.Media.Incompressible.Examples.Essotherm65"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Incompressible.Examples.Essotherm650);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Incompressible.Examples.Essotherm650);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4598,7 +4621,9 @@ no mass or energy is stored in the pipe.
           model ConstantPropertyLiquidWater
             "Test Modelica.Media.Water.ConstantPropertyLiquidWater"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Water.ConstantPropertyLiquidWater);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Water.ConstantPropertyLiquidWater);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4608,7 +4633,9 @@ no mass or energy is stored in the pipe.
 
           model IdealSteam "Test Modelica.Media.Water.IdealSteam"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Water.IdealSteam);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Water.IdealSteam);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4632,7 +4659,9 @@ no mass or energy is stored in the pipe.
 
           model WaterIF97_pT "Test Modelica.Media.Water.WaterIF97_pT"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.Water.WaterIF97_pT);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.Water.WaterIF97_pT);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4664,7 +4693,9 @@ no mass or energy is stored in the pipe.
           model LinearColdWater
             "Test Modelica.Media.Incompressible.Examples.Glycol47"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.CompressibleLiquids.LinearColdWater);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.CompressibleLiquids.LinearColdWater);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -4675,7 +4706,9 @@ no mass or energy is stored in the pipe.
           model LinearWater_pT
             "Test Modelica.Media.Incompressible.Examples.Essotherm65"
             extends Modelica.Icons.Example;
-            extends myMedia.Examples.Utilities.PartialTestModel(redeclare package Medium = myMedia.CompressibleLiquids.LinearWater_pT_Ambient);
+            extends myMedia.Examples.Utilities.PartialTestModel(redeclare
+                package                                                           Medium =
+                  myMedia.CompressibleLiquids.LinearWater_pT_Ambient);
             extends Modelica.Icons.ObsoleteModel;
             annotation (Documentation(info="<html>
 
@@ -6205,7 +6238,9 @@ to the above list of assumptions</li>
 
     partial package PartialRealCondensingGases
       "Base class for mixtures of real condensing and non-condensing gases"
-      extends myMedia.Interfaces.PartialMixtureMedium(redeclare replaceable record FluidConstants = myMedia.Interfaces.Types.TwoPhase.FluidConstants);
+      extends myMedia.Interfaces.PartialMixtureMedium(redeclare replaceable
+          record                                                                   FluidConstants =
+            myMedia.Interfaces.Types.TwoPhase.FluidConstants);
 
       replaceable partial function saturationPressure
         "Return saturation pressure of condensing fluid"
@@ -18622,6 +18657,13 @@ Temperature T (= "       + String(T) + " K) is not in the allowed range
           annotation(Inline=true,smoothOrder=2);
         end density_derX;
 
+        redeclare function extends density_derp_h
+          "Returns the partial derivative of density with respect to pressure at constant enthalpy"
+        algorithm
+          ddph := specificHeatCapacityCp(state)/(state.T*data.R*data.R);
+          annotation(Inline=true,smoothOrder=2);
+        end density_derp_h;
+
         redeclare replaceable function extends dynamicViscosity "Dynamic viscosity"
         algorithm
           assert(fluidConstants[1].hasCriticalData,
@@ -19612,11 +19654,18 @@ average of the pure component conductivities.
           annotation(Inline=true,smoothOrder=2);
         end density_derX;
 
-        redeclare function extends molarMass "Return molar mass of mixture"
+        redeclare function extends density_derp_h
+          "Returns the partial derivative of density with respect to pressure at constant enthalpy"
         algorithm
+          ddph := specificHeatCapacityCp(state)/(state.T*data.R*data.R);
+          annotation(Inline=true,smoothOrder=2);
+        end density_derp_h;
+
+          redeclare function extends molarMass "Return molar mass of mixture"
+          algorithm
           MM := 1/sum(state.X[j]/data[j].MM for j in 1:size(state.X, 1));
           annotation(Inline=true,smoothOrder=2);
-        end molarMass;
+          end molarMass;
 
         function T_hX "Return temperature from specific enthalpy and mass fraction"
           extends Modelica.Icons.Function;

--- a/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_centrifugal.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_centrifugal.mo
@@ -64,6 +64,7 @@ protected
   constant Real v_i_ref(unit="N.m.s2/rad2") =      1.218e-6;
   constant Real v_s_ref(unit="N.m.s/rad") =        1.832e-4;
 
+// the next for were used in the input but why?
   constant Integer f_q_ref =             1;
   constant Real K_D_ref(unit="m3/rad") = 9.73e-06;
   constant SI.Density rho_ref_ref =      1.00e3;
@@ -78,10 +79,10 @@ protected
   Real v_i(unit="N.m.s2/rad2") =     if parametrizeByScaling then sqrt(alpha)*gamma/beta*              v_i_ref else v_i_input;
   Real v_s(unit="N.m.s/rad") =       if parametrizeByScaling then alpha^(-1/4)*beta^(1/2)*gamma^(3/2)* v_s_ref else v_s_input;
 
-  constant Integer f_q =             if parametrizeByScaling then                 f_q_ref else f_q_input;
-  constant Real K_D(unit="m3/rad") = if parametrizeByScaling then gamma/beta*     K_D_ref else f_q_input;
-  constant SI.Density rho_ref =      if parametrizeByScaling then             rho_ref_ref else rho_ref_input;
-  constant SI.Length r =             if parametrizeByScaling then sqrt(alpha)/beta* r_ref else r_input;
+  Integer f_q =             if parametrizeByScaling then                 f_q_ref else f_q_input;
+  Real K_D(unit="m3/rad") = if parametrizeByScaling then gamma/beta*     K_D_ref else f_q_input;
+  SI.Density rho_ref =      if parametrizeByScaling then             rho_ref_ref else rho_ref_input;
+  SI.Length r =             if parametrizeByScaling then sqrt(alpha)/beta* r_ref else r_input;
 
   Real omega_s(unit="1") = ((K_D/f_q)^0.5)/((g_n*( a_h+b_h*K_D+c_h*K_D^2)) ^0.75);
   SI.VolumeFlowRate V_flow_BEP "optimal volume flow at omega";

--- a/ThermofluidStream/Sensors/DifferenceSensorSelect.mo
+++ b/ThermofluidStream/Sensors/DifferenceSensorSelect.mo
@@ -96,7 +96,9 @@ equation
         Text(
           extent={{-60,30},{60,-30}},
           lineColor={28,108,200},
-          textString=DynamicSelect("value", realString(value, 1, integer(digits)))),
+          textString=DynamicSelect("value", String(
+              value,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{0,25},{60,75}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Sensors/DifferenceSensor_Tp.mo
+++ b/ThermofluidStream/Sensors/DifferenceSensor_Tp.mo
@@ -106,17 +106,15 @@ equation
         Text(
           extent={{-60,55},{60,5}},
           lineColor={28,108,200},
-          textString=DynamicSelect("T", realString(
-                  T,
-                  1,
-                  integer(digits)))),
+          textString=DynamicSelect("T", String(
+              T,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{-60,-5},{60,-55}},
           lineColor={28,108,200},
-          textString=DynamicSelect("p", realString(
-                  p,
-                  1,
-                  integer(digits)))),
+          textString=DynamicSelect("p", String(
+              p,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{-120,55},{-60,5}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Sensors/DifferenceTwoPhaseSensorSensorSelect.mo
+++ b/ThermofluidStream/Sensors/DifferenceTwoPhaseSensorSensorSelect.mo
@@ -93,7 +93,9 @@ equation
         Text(
           extent={{-60,30},{60,-30}},
           lineColor={28,108,200},
-          textString=DynamicSelect("value", realString(value, 1, integer(digits)))),
+          textString=DynamicSelect("value", String(
+              value,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{0,25},{60,75}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Sensors/MultiSensor_Tp.mo
+++ b/ThermofluidStream/Sensors/MultiSensor_Tp.mo
@@ -82,17 +82,15 @@ equation
         Text(
           extent={{-60,55},{60,5}},
           lineColor={28,108,200},
-          textString=DynamicSelect("T", realString(
-                  T,
-                  1,
-                  integer(digits)))),
+          textString=DynamicSelect("T", String(
+              T,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{-60,-5},{60,-55}},
           lineColor={28,108,200},
-          textString=DynamicSelect("p", realString(
-                  p,
-                  1,
-                  integer(digits)))),
+          textString=DynamicSelect("p", String(
+              p,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{-120,55},{-60,5}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Sensors/MultiSensor_Tpm.mo
+++ b/ThermofluidStream/Sensors/MultiSensor_Tpm.mo
@@ -113,24 +113,21 @@ equation
         Text(
           extent={{-60,80},{60,30}},
           lineColor={28,108,200},
-          textString=DynamicSelect("T", realString(
-                  T,
-                  1,
-                  integer(digits)))),
+          textString=DynamicSelect("T", String(
+              T,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{-60,30},{60,-20}},
           lineColor={28,108,200},
-          textString=DynamicSelect("p", realString(
-                  p,
-                  1,
-                  integer(digits)))),
+          textString=DynamicSelect("p", String(
+              p,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{-60,-20},{60,-70}},
           lineColor={28,108,200},
-          textString=DynamicSelect("m", realString(
-                  m_flow,
-                  2,
-                  integer(digits)))),
+          textString=DynamicSelect("m", String(
+              m_flow,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{-120,80},{-60,28}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Sensors/SingleFlowSensor.mo
+++ b/ThermofluidStream/Sensors/SingleFlowSensor.mo
@@ -89,7 +89,9 @@ equation
         Text(
           extent={{-60,30},{60,-30}},
           lineColor={28,108,200},
-          textString=DynamicSelect("value", realString(value, 1, integer(digits)))),
+          textString=DynamicSelect("value", String(
+              value,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{0,25},{60,75}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Sensors/SingleSensorSelect.mo
+++ b/ThermofluidStream/Sensors/SingleSensorSelect.mo
@@ -72,7 +72,9 @@ equation
         Text(
           extent={{-60,30},{60,-30}},
           lineColor={28,108,200},
-          textString=DynamicSelect("value", realString(value, 1, integer(digits)))),
+          textString=DynamicSelect("value", String(
+              value,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{0,25},{60,75}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Sensors/SingleSensorX.mo
+++ b/ThermofluidStream/Sensors/SingleSensorX.mo
@@ -67,7 +67,9 @@ equation
         Text(
           extent={{-60,30},{60,-30}},
           lineColor={28,108,200},
-          textString=DynamicSelect("value", realString(display_value, 1, integer(digits)))),
+          textString=DynamicSelect("value", String(
+              display_value,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{-26,22},{60,69}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Sensors/TwoPhaseSensorSelect.mo
+++ b/ThermofluidStream/Sensors/TwoPhaseSensorSelect.mo
@@ -68,7 +68,9 @@ equation
         Text(
           extent={{-60,30},{60,-30}},
           lineColor={28,108,200},
-          textString=DynamicSelect("value", realString(value, 1, digits))),
+          textString=DynamicSelect("value", String(
+              value,
+              format="1."+String(digits)+"f"))),
         Text(
           extent={{0,21},{60,71}},
           lineColor={175,175,175},

--- a/ThermofluidStream/Undirected/Topology/JunctionMN.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionMN.mo
@@ -75,16 +75,16 @@ equation
   sum(rears.m_flow) + sum(fores.m_flow) = 0;
   //compute p_mix for rs computation
   if assumeConstantDensity then
-    p_mix =sum(ps*inflows)/sum(inflows);
+    p_mix =(ps*inflows)/sum(inflows);
   else
-    p_mix =sum(ps*(inflows./rhos))/sum((inflows./rhos));
+    p_mix =(ps*(inflows./rhos))/sum((inflows./rhos));
   end if;
 
   // compute output quantities
   for i in 1:M+N loop
     Xis_out[:,i] = (Xis*inflows - Xis[:,i]*inflows[i]) /(sum(inflows) - inflows[i]);
-    hs_out[i] = (sum(hs*inflows) - hs[i]*inflows[i]) /(sum(inflows) - inflows[i]);
-    ps_out[i] = (sum(ps*inflows) - ps[i]*inflows[i]) /(sum(inflows) - inflows[i]);
+    hs_out[i] = (hs*inflows - hs[i]*inflows[i]) /(sum(inflows) - inflows[i]);
+    ps_out[i] = (ps*inflows - ps[i]*inflows[i]) /(sum(inflows) - inflows[i]);
   end for;
   annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
         Line(


### PR DESCRIPTION
I have been able to make all examples work (compile and give reasonable results) with Modelon Impact. I did not do a detailed result comparison, but all results looked reasonable. The strange workaround in the Volume component was fixed by adding the proper density_derp_h function to myMedia. Even the on-canvas displays work all fine now. I'll link the pull request in the related issue, where there is a much more detailed discussion about what was fixed, and why.  