### PR TITLE
Usage of rho_min in Nozzle.mo

### DIFF
--- a/ThermofluidStream/Processes/Nozzle.mo
+++ b/ThermofluidStream/Processes/Nozzle.mo
@@ -8,8 +8,6 @@ model Nozzle "Model for dynamic pressure difference"
     annotation(Dialog(tab="Advanced"));
   parameter Boolean assumeConstantDensity=true    "if true only inlet density is applied"
     annotation(Dialog(tab="Advanced"));
-  parameter SI.Density rho_min = dropOfCommons.rho_min "Minimal input density"
-    annotation(Dialog(tab="Advanced"));
 
 protected
   SI.Density rho_in = Medium.density(inlet.state) "density of medium entering";


### PR DESCRIPTION
Hello, 

while studying the nozzle component I have seen that rho_min is declared as a parameter in the beginning of the script. rho_min is defined as the minimal input density from the dropofCommons.

As far as I understand, rho_min is not further used within the nozzle component. What is the use of rho_min?

In case the parameter is redundant, could this parameter be deleted?

Bests,