### PR TITLE
Html code: omit usage of 'span' tag

### DIFF
--- a/ThermofluidStream/Boundaries/Internal/InitializationMethodsPhaseSeperator.mo
+++ b/ThermofluidStream/Boundaries/Internal/InitializationMethodsPhaseSeperator.mo
@@ -3,9 +3,11 @@ type InitializationMethodsPhaseSeperator = enumeration(
     h "specific enthalpy h_0",
     M "Mass M_0",
     l "Liquid Level l_0",
-    x "Vapor Quality x_0") "Choices for Initialization of state h of PhaseSeperator"
+    x "Vapor Quality x_0") "Choices for initialization of state h of PhaseSeperator"
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)),
     Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-        <p><span style=\"font-family: Courier New;\">Choices for Initailtaion of a state h.</span></p>
-        </html>"));
+<p>
+Choices for initialization of a state h.
+</p>
+</html>"));

--- a/ThermofluidStream/Boundaries/Internal/PartialVolume.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialVolume.mo
@@ -4,7 +4,10 @@ partial model PartialVolume "Partial parent class for Volumes with one inlet and
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model" annotation (
       choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Volume. Make sure it is the same as the inlets and outlets the volume is connected to.</span></p>
+<p>
+Medium package used in the Volume. Make sure it is the same as the
+inlets and outlets the volume is connected to.
+</p>
 </html>"));
 
   parameter Boolean useHeatport = false "If true heatport is added";

--- a/ThermofluidStream/Boundaries/Internal/PartialVolumeM.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialVolumeM.mo
@@ -2,7 +2,10 @@ within ThermofluidStream.Boundaries.Internal;
 partial model PartialVolumeM "Partial parent class for Volumes with one inlet and M outlet"
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium "Medium model" annotation (
       choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Volume. Make sure it is the same as the inlets and outlets the volume is connected to.</span></p>
+<p>
+Medium package used in the Volume. Make sure it is the same as the
+inlets and outlets the volume is connected to.
+</p>
 </html>"));
 
   parameter Integer M_outlets = 1 "Number if outlets";

--- a/ThermofluidStream/Boundaries/Internal/PartialVolumeN.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialVolumeN.mo
@@ -3,7 +3,10 @@ partial model PartialVolumeN "Partial parent class for Volumes with N inlets and
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model" annotation (
       choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Volume. Make sure it is the same as the inlets and outlets the volume is connected to.</span></p>
+<p>
+Medium package used in the Volume. Make sure it is the same as the
+inlets and outlets the volume is connected to.
+</p>
 </html>"));
 
   parameter Integer N = 1 "Number if inlets";

--- a/ThermofluidStream/Boundaries/Reservoir.mo
+++ b/ThermofluidStream/Boundaries/Reservoir.mo
@@ -69,9 +69,23 @@ equation
           fillPattern=FillPattern.Solid)}),
             Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>This is a volume, that is open at the top and therefore maintains environmental pressure at the top and adds pressure depending on fill height. </p>
-<p>Conceptually it is a Sink and a Source. It therefore defines the level of inertial pressure r and acts as a loop breaker in a closed loop.</p>
-<p>This component uses a simplification (medium.p is set to p_env + height*g, which is only correct at the bottom of the reservoir) which is intended to hold for media with low compressibility. </p>
-<p><span style=\"color: #ff5500;\">Note that the energy equation requires the mass in the system to be positive and will not give valid results otherwise (if the assert of height &gt; 0 fails).</span></p>
+<p>
+This is a volume, that is open at the top and therefore maintains environmental
+pressure at the top and adds pressure depending on fill height.
+</p>
+<p>
+Conceptually it is a Sink and a Source. It therefore defines the level of inertial
+pressure r and acts as a loop breaker in a closed loop.
+</p>
+<p>
+This component uses a simplification (medium.p is set to p_env + height*g, which
+is only correct at the bottom of the reservoir) which is intended to hold for
+media with low compressibility.
+</p>
+<p>
+<strong>Note that the energy equation requires the mass in the system to be
+positive and will not give valid results otherwise (if the assert of
+height &gt; 0 fails).</strong>
+</p>
 </html>"));
 end Reservoir;

--- a/ThermofluidStream/Boundaries/Sink.mo
+++ b/ThermofluidStream/Boundaries/Sink.mo
@@ -2,7 +2,10 @@ within ThermofluidStream.Boundaries;
 model Sink "Boundary model of sink"
     replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model" annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Sink. Make sure it is the same as the one the outlet the sink is connected to.</span></p>
+<p>
+Medium package used in the Sink. Make sure it is the same as the one
+the outlet the sink is connected to.
+</p>
 </html>"));
 
   parameter Boolean pressureFromInput = false "If true pressure comes from real input";

--- a/ThermofluidStream/Boundaries/Source.mo
+++ b/ThermofluidStream/Boundaries/Source.mo
@@ -4,8 +4,11 @@ model Source "Boundary model of a source"
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model"
      annotation (choicesAllMatching=true, Documentation(info="<html>
-       <p><span style=\"font-family: Courier New;\">Medium package used in the Source. Make sure it is the same as the one the inlet the source is connected to.</span></p>
-       </html>"));
+<p>
+Medium package used in the Source. Make sure it is the same as the one
+the inlet the source is connected to.
+</p>
+</html>"));
 
   parameter Boolean setEnthalpy = false "Prescribe specific enthalpy instead of temperature?";
   parameter Boolean pressureFromInput = false "Use input connector for pressure?";

--- a/ThermofluidStream/Boundaries/TerminalSink.mo
+++ b/ThermofluidStream/Boundaries/TerminalSink.mo
@@ -3,8 +3,11 @@ model TerminalSink "Sink that imposes m_flow=0"
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model"
-    annotation (choicesAllMatching=true, Documentation(info = "<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Source. Make sure it is the same as the one the inlet the source is connected to.</span></p>
+    annotation (choicesAllMatching=true, Documentation(info="<html>
+<p>
+Medium package used in the Source. Make sure it is the same as the one
+the inlet the source is connected to.
+</p>
 </html>"));
 
   Interfaces.Inlet inlet(redeclare package Medium=Medium)

--- a/ThermofluidStream/Boundaries/TerminalSource.mo
+++ b/ThermofluidStream/Boundaries/TerminalSource.mo
@@ -3,8 +3,11 @@ model TerminalSource "Source that impoeses m_flow = 0"
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model"
-    annotation (choicesAllMatching=true, Documentation(info = "<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Source. Make sure it is the same as the one the inlet the source is connected to.</span></p>
+    annotation (choicesAllMatching=true, Documentation(info="<html>
+<p>
+Medium package used in the Source. Make sure it is the same as the one
+the inlet the source is connected to.
+</p>
 </html>"));
 
   parameter SI.Time TC = 0.1 "Time constant for pressure adaption"

--- a/ThermofluidStream/Boundaries/Tests/SourceSink.mo
+++ b/ThermofluidStream/Boundaries/Tests/SourceSink.mo
@@ -6,7 +6,9 @@ model SourceSink "Test for source and sink model"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons

--- a/ThermofluidStream/Boundaries/Tests/TerminalSourceSink.mo
+++ b/ThermofluidStream/Boundaries/Tests/TerminalSourceSink.mo
@@ -5,7 +5,9 @@ model TerminalSourceSink "Test for Terminal source and sink model"
   replaceable package Medium = Media.myMedia.Air.SimpleAir
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package" annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons

--- a/ThermofluidStream/Boundaries/Tests/Volumes.mo
+++ b/ThermofluidStream/Boundaries/Tests/Volumes.mo
@@ -5,13 +5,17 @@ model Volumes "Test Volumes"
   replaceable package Medium = Media.myMedia.Air.SimpleAir
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package" annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   package MediumMix = Media.myMedia.IdealGases.MixtureGases.CombustionAir
     "Medium package"
     annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test of the MixVolumes.</span> </p>
+<p>
+Medium package used in the Test of the MixVolumes.
+</p>
 </html>"));
 
 

--- a/ThermofluidStream/Boundaries/Tests/VolumesDirectCoupling.mo
+++ b/ThermofluidStream/Boundaries/Tests/VolumesDirectCoupling.mo
@@ -6,13 +6,17 @@ model VolumesDirectCoupling "Test Volumes"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-        <p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
-        </html>"));
+<p>
+Medium package used in the Test.
+</p>
+</html>"));
 
   package MediumMix = Media.myMedia.IdealGases.MixtureGases.CombustionAir
     "Medium package"
     annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test of the MixVolumes.</span> </p>
+<p>
+Medium package used in the Test of the MixVolumes.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons(

--- a/ThermofluidStream/Boundaries/Tests/package.mo
+++ b/ThermofluidStream/Boundaries/Tests/package.mo
@@ -3,6 +3,8 @@ package Tests "Tests for the Boundary Packge"
 extends Modelica.Icons.ExamplesPackage;
 
   annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Test Package for the Boundaries Package of ThermofluidStream.</span></p>
+<p>
+Test package for the Boundaries package of ThermofluidStream.
+</p>
 </html>"));
 end Tests;

--- a/ThermofluidStream/Examples/EspressoMachine.mo
+++ b/ThermofluidStream/Examples/EspressoMachine.mo
@@ -5,7 +5,9 @@ model EspressoMachine "Get your simulated coffe!"
   package Water = Media.myMedia.Water.StandardWater
     "Medium Model for Water"
     annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium&nbsp;Model&nbsp;for&nbsp;Water</span></p>
+<p>
+Medium model for water.
+</p>
 </html>"));
 
   Utilities.BoilerEspresso boiler(

--- a/ThermofluidStream/Examples/Utilities/BoilerEspresso.mo
+++ b/ThermofluidStream/Examples/Utilities/BoilerEspresso.mo
@@ -5,7 +5,10 @@ model BoilerEspresso
   replaceable package Medium = Media.myMedia.Interfaces.PartialTwoPhaseMedium
     "Medium model"
     annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium model for the water in the boiler. We alwails want both phases of the water in the boiler.</span></p>
+<p>
+Medium model for the water in the boiler. We always want both
+phases of the water in the boiler.
+</p>
 </html>"));
 
   parameter SI.Pressure p_0 = 1e5 "Start pressure";
@@ -176,6 +179,13 @@ equation
      Diagram(
         coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">A boiler with a heatport to add heat and a heat port to connect a tube as an heat exchanger. </p><p>Also there is a inlet for water and two outlets, one for water, one for steam.</span></p>
+<p>
+A boiler with a heatport to add heat and a heat port to connect
+a tube as an heat exchanger.
+</p>
+<p>
+Also there is a inlet for water and two outlets, one for water,
+one for steam.
+</p>
 </html>"));
 end BoilerEspresso;

--- a/ThermofluidStream/Examples/Utilities/CoffeeStrainer.mo
+++ b/ThermofluidStream/Examples/Utilities/CoffeeStrainer.mo
@@ -2,7 +2,10 @@ within ThermofluidStream.Examples.Utilities;
 model CoffeeStrainer "Holds coffee in the machine."
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model" annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium model for the coffee strainer. It is expected to be water of some sorts.</span></p>
+<p>
+Medium model for the coffee strainer. It is expected to be
+water of some sorts.
+</p>
 </html>"));
 
   Interfaces.Inlet inlet(redeclare package Medium=Medium)
@@ -62,6 +65,8 @@ equation
           pattern=LinePattern.None)}), Diagram(
         coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">This is a flow resistance, with the icon of a coffee strainer.</span></p>
+<p>
+This is a flow resistance, with the icon of a coffee strainer.
+</p>
 </html>"));
 end CoffeeStrainer;

--- a/ThermofluidStream/Examples/Utilities/CrankDrive.mo
+++ b/ThermofluidStream/Examples/Utilities/CrankDrive.mo
@@ -88,7 +88,12 @@ equation
         coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{300,
             100}})),
     Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">This model is a equation based model of a crank drive. It can be ised to convet linear motion into circular motion.</span></p>
-<p><span style=\"font-family: Courier New;\">Phi is the angle of the flyweel, 0 is the right-most position. </span></p>
+<p>
+This model is a equation based model of a crank drive. It can be ised to convet
+linear motion into circular motion.
+</p>
+<p>
+Phi is the angle of the flyweel, 0 is the right-most position.
+</p>
 </html>"));
 end CrankDrive;

--- a/ThermofluidStream/Examples/Utilities/CupSink.mo
+++ b/ThermofluidStream/Examples/Utilities/CupSink.mo
@@ -4,7 +4,9 @@ model CupSink "Sink with fancy cup animation"
   replaceable package Medium=Media.myMedia.Interfaces.PartialMedium
     "Medium Model"
     annotation(choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium&nbsp;Model in cup. </span></p>
+<p>
+Medium model in cup.
+</p>
 </html>"));
 
   parameter SI.Mass M = 3.448e-2 "Mass of medium that fits in the cup";
@@ -79,7 +81,11 @@ equation
           pattern=LinePattern.None)}),
       Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>Sink with fancy cup animation. </p>
-<p><span style=\"font-family: Courier New;\">x is the level of medium in the cup for the animation.</span></p>
+<p>
+Sink with fancy cup animation.
+</p>
+<p>
+x is the level of medium in the cup for the animation.
+</p>
 </html>"));
 end CupSink;

--- a/ThermofluidStream/Examples/Utilities/Piston.mo
+++ b/ThermofluidStream/Examples/Utilities/Piston.mo
@@ -151,9 +151,19 @@ equation
     Diagram(
         coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>In a piston a different pressure of fluids perform mechanical linar work. </p>
-<p>Depending on <span style=\"font-family: Courier New;\">push_left, the left (when pushleft is true) side or the right (when pushleft is false) side is connected to the input, and the other side is connected to the output. </span></p>
-<p><span style=\"font-family: Courier New;\">x is a nondimensional piston position, 0 being left and 1 being right. </span></p>
-<p><span style=\"font-family: Courier New;\">The piston has soft stops and a dead volume at both ends.</span></p>
+<p>
+In a piston a different pressure of fluids perform mechanical linar work.
+</p>
+<p>
+Depending on <code>push_left</code>, the left (when pushleft is true) side or
+the right (when pushleft is false) side is connected to the input, and the other
+side is connected to the output.
+</p>
+<p>
+<code>x</code> is a nondimensional piston position, 0 being left and 1 being right.
+</p>
+<p>
+The piston has soft stops and a dead volume at both ends.
+</p>
 </html>"));
 end Piston;

--- a/ThermofluidStream/Examples/Utilities/SteamSink.mo
+++ b/ThermofluidStream/Examples/Utilities/SteamSink.mo
@@ -52,7 +52,12 @@ equation
           endAngle=80,
           closure=EllipseClosure.None)}), Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Sink&nbsp;with&nbsp;fancy&nbsp;steam&nbsp;animation.</span></p>
-<p><span style=\"font-family: Courier New;\">x is a nondimensional mass flow. @x=1 the animation is at original size. It is low-passed to look better at very high flow peaks.</span></p>
+<p>
+Sink with fancy steam animation.
+</p>
+<p>
+x is a nondimensional mass flow. @x=1 the animation is at original size.
+It is low-passed to look better at very high flow peaks.
+</p>
 </html>"));
 end SteamSink;

--- a/ThermofluidStream/Examples/Utilities/Tests/Piston.mo
+++ b/ThermofluidStream/Examples/Utilities/Tests/Piston.mo
@@ -34,7 +34,7 @@ model Piston "Test for Piston model"
     p0_par=1000000)
     annotation (Placement(transformation(extent={{-106,0},{-86,20}})));
   SteamSink steamSink(
-                       redeclare package Medium = Medium,
+    redeclare package Medium = Medium,
     p0_par=200000,
     m_flow_animate=1.3)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
@@ -46,13 +46,13 @@ model Piston "Test for Piston model"
     startTime=1)
     annotation (Placement(transformation(extent={{-64,46},{-44,66}})));
   ThermofluidStream.Utilities.showRealValue showRealValue annotation (Placement(transformation(extent={{32,-82},{52,-62}})));
-  Undirected.Topology.ConnectorInletOutletFore switchConnector(redeclare
-      package Medium = Medium) annotation (Placement(transformation(
+  Undirected.Topology.ConnectorInletOutletFore switchConnector(
+    redeclare package Medium = Medium) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
         origin={-10,-20})));
-  Undirected.Topology.ConnectorInletOutletFore switchConnector1(redeclare
-      package Medium = Medium) annotation (Placement(transformation(
+  Undirected.Topology.ConnectorInletOutletFore switchConnector1(
+    redeclare package Medium = Medium) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
         origin={16,10})));

--- a/ThermofluidStream/Examples/Utilities/WaterSink.mo
+++ b/ThermofluidStream/Examples/Utilities/WaterSink.mo
@@ -22,7 +22,11 @@ equation
           origin={100,0},
           rotation=90)}), Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Sink with fancy water animation.</span></p>
-<p><span style=\"font-family: Courier New;\">x is a nondimensional mass flow. @x=1 the animation looks best.</span></p>
+<p>
+Sink with fancy water animation.
+</p>
+<p>
+x is a nondimensional mass flow. @x=1 the animation looks best.
+</p>
 </html>"));
 end WaterSink;

--- a/ThermofluidStream/Examples/VenturiPump.mo
+++ b/ThermofluidStream/Examples/VenturiPump.mo
@@ -17,7 +17,7 @@ model VenturiPump "pumping of liquid water using the venturi effect"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=0.25,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss(
+    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-30,-70},{-10,-50}})));
   Boundaries.Source source2_1(
@@ -51,7 +51,7 @@ model VenturiPump "pumping of liquid water using the venturi effect"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=0.1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss(
+    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=270,

--- a/ThermofluidStream/Examples/package.mo
+++ b/ThermofluidStream/Examples/package.mo
@@ -6,6 +6,9 @@ package Examples "Application Examples for the Library"
     Documentation(revisions="<html>
 <p><img src=\"modelica:/ThermofluidStream/Resources/dlr_logo.png\"/>(c) 2020-2021, DLR, Institute of System Dynamics and Control</p>
 </html>", info="<html>
-<p><span style=\"font-family: Courier New;\">This package contains several application examples that demonstarte the capabilities of the library and can act as a stating point for the user.</span></p>
+<p>
+This package contains several application examples that demonstarte the capabilities
+of the library and can act as a stating point for the user.
+</p>
 </html>"));
 end Examples;

--- a/ThermofluidStream/FlowControl/Tests/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/BasicControlValve.mo
@@ -6,7 +6,9 @@ model BasicControlValve "Test for BasicControlValve"
     constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner ThermofluidStream.DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/FlowControl/Tests/CheckValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/CheckValve.mo
@@ -6,7 +6,9 @@ model CheckValve "Test for CheckValve"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/FlowControl/Tests/MCV.mo
+++ b/ThermofluidStream/FlowControl/Tests/MCV.mo
@@ -5,7 +5,9 @@ model MCV "Test for MCV"
   replaceable package Medium = ThermofluidStream.Media.myMedia.Air.SimpleAir
     constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner ThermofluidStream.DropOfCommons dropOfCommons(assertionLevel=AssertionLevel.warning)

--- a/ThermofluidStream/FlowControl/Tests/PCV.mo
+++ b/ThermofluidStream/FlowControl/Tests/PCV.mo
@@ -6,7 +6,9 @@ model PCV "Test for PCV"
     constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner ThermofluidStream.DropOfCommons dropOfCommons(assertionLevel=AssertionLevel.warning)

--- a/ThermofluidStream/FlowControl/Tests/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/Tests/SpecificValveType.mo
@@ -6,7 +6,9 @@ model SpecificValveType "Test for SpecificValveType"
     constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner ThermofluidStream.DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/FlowControl/Tests/Switch.mo
+++ b/ThermofluidStream/FlowControl/Tests/Switch.mo
@@ -5,7 +5,9 @@ model Switch "Test for Switches"
   replaceable package Medium = Media.myMedia.Air.SimpleAir
     constrainedby Media.myMedia.Interfaces.PartialMedium "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/FlowControl/Tests/TanValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/TanValve.mo
@@ -5,7 +5,9 @@ model TanValve "Test for TanValve"
   replaceable package Medium = Media.myMedia.Air.SimpleAir
     constrainedby Media.myMedia.Interfaces.PartialMedium "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/HeatExchangers/DiscretizedCrossFlowHEX_FR.mo
+++ b/ThermofluidStream/HeatExchangers/DiscretizedCrossFlowHEX_FR.mo
@@ -229,7 +229,16 @@ equation
           pattern=LinePattern.Dash,
           textString="1")}),
     Documentation(info="<html>
-<p>The cross-flow discretized heat exchanger uses a number of conduction elements (which is set by the parameter nCells) as discrete control volumes to exchange heat between two fluid streams. This model differes from DiscretizedCrossFlowHEX by introducing flow-resistances after each control volume, but otherwise is the same, therefore consider the documentation of DiscretizedCrossFlowHEX. </p>
-<p>The flowResistances are parametrized by the parameters in the group <span style=\"font-family: Courier New;\">laminar-turbolent&nbsp;flowRes.</span></p>
+<p>
+The cross-flow discretized heat exchanger uses a number of conduction elements
+(which is set by the parameter nCells) as discrete control volumes to exchange
+heat between two fluid streams. This model differes from DiscretizedCrossFlowHEX
+by introducing flow-resistances after each control volume, but otherwise is the
+same, therefore consider the documentation of DiscretizedCrossFlowHEX.
+</p>
+<p>
+The flowResistances are parametrized by the parameters in the group 
+<strong>laminar-turbolent&nbsp;flowRes.</strong>
+</p>
 </html>"));
 end DiscretizedCrossFlowHEX_FR;

--- a/ThermofluidStream/Interfaces/Tests/Test_p_out_clipping.mo
+++ b/ThermofluidStream/Interfaces/Tests/Test_p_out_clipping.mo
@@ -5,8 +5,10 @@ model Test_p_out_clipping "Test for the lower limit of p_out in SISOFlow compone
   replaceable package Medium = Media.myMedia.Air.SimpleAir
     constrainedby Media.myMedia.Interfaces.PartialMedium "Medium package"
     annotation (Documentation(info="<html>
-      <p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
-      </html>"));
+<p>
+Medium package used in the Test.
+</p>
+</html>"));
 
   Boundaries.Source source(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-100,-10},{-80,10}})));

--- a/ThermofluidStream/Media/myMedia/IdealGases/Common/MixtureGasNasa.mo
+++ b/ThermofluidStream/Media/myMedia/IdealGases/Common/MixtureGasNasa.mo
@@ -117,27 +117,27 @@ required from medium model \"" + mediumName + "\".");
       annotation(Inline=true,smoothOrder=2);
     end setState_dTX;
 
-      redeclare function extends setSmoothState
-    "Return thermodynamic state so that it smoothly approximates: if x > 0 then state_a else state_b"
-      algorithm
-    state := ThermodynamicState(
-            p=myMedia.Common.smoothStep(
-              x,
-              state_a.p,
-              state_b.p,
-              x_small),
-            T=myMedia.Common.smoothStep(
-              x,
-              state_a.T,
-              state_b.T,
-              x_small),
-            X=myMedia.Common.smoothStep(
-              x,
-              state_a.X,
-              state_b.X,
-              x_small));
-        annotation(Inline=true,smoothOrder=2);
-      end setSmoothState;
+    redeclare function extends setSmoothState
+      "Return thermodynamic state so that it smoothly approximates: if x > 0 then state_a else state_b"
+    algorithm
+      state := ThermodynamicState(
+              p=myMedia.Common.smoothStep(
+                x,
+                state_a.p,
+                state_b.p,
+                x_small),
+              T=myMedia.Common.smoothStep(
+                x,
+                state_a.T,
+                state_b.T,
+                x_small),
+              X=myMedia.Common.smoothStep(
+                x,
+                state_a.X,
+                state_b.X,
+                x_small));
+          annotation(Inline=true,smoothOrder=2);
+    end setSmoothState;
 
     redeclare function extends pressure "Return pressure of ideal gas"
     algorithm
@@ -486,8 +486,7 @@ end gasMixtureViscosity;
   etaMixture := etam*1e-7; // conversion from microPoise->Pa.s
 
     annotation (smoothOrder=2,
-              Documentation(info="<html>
-
+      Documentation(info="<html>
 <p>
 Equation to estimate the viscosity of gas mixtures at low pressures.<br>
 It is a simplification of an extension of the rigorous kinetic theory
@@ -503,87 +502,61 @@ Values of kappa for a few such materials:
 </p>
 
 <table style=\"text-align: left; width: 302px; height: 200px;\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-<tbody>
-<tr>
-<td style=\"vertical-align: top;\">Compound<br>
-</td>
-<td style=\"vertical-align: top; text-align: center;\">Kappa<br>
-</td>
-<td style=\"vertical-align: top;\">Compound<br>
-</td>
-<td style=\"vertical-align: top;\">Kappa<br>
-</td>
-</tr>
-<tr>
-<td style=\"vertical-align: top;\">Methanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.215<br>
-</td>
-<td style=\"vertical-align: top;\">n-Pentanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.122<br>
-</td>
-</tr>
-<tr>
-<td style=\"vertical-align: top;\">Ethanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.175<br>
-</td>
-<td style=\"vertical-align: top;\">n-Hexanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.114<br>
-</td>
-</tr>
-<tr>
-<td style=\"vertical-align: top;\">n-Propanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.143<br>
-</td>
-<td style=\"vertical-align: top;\">n-Heptanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.109<br>
-</td>
-</tr>
-<tr>
-<td style=\"vertical-align: top;\">i-Propanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.143<br>
-</td>
-<td style=\"vertical-align: top;\">Acetic Acid<br>
-</td>
-<td style=\"vertical-align: top;\">0.0916<br>
-</td>
-</tr>
-<tr>
-<td style=\"vertical-align: top;\">n-Butanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.132<br>
-</td>
-<td style=\"vertical-align: top;\">Water<br>
-</td>
-<td style=\"vertical-align: top;\">0.076<br>
-</td>
-</tr>
-<tr>
-<td style=\"vertical-align: top;\">i-Butanol<br>
-</td>
-<td style=\"vertical-align: top;\">0.132</td>
-<td style=\"vertical-align: top;\"><br>
-</td>
-<td style=\"vertical-align: top;\"><br>
-</td>
-</tr>
-</tbody>
+  <tbody>
+    <tr>
+      <th>Compound</th>
+      <th>Kappa</th>
+      <th>Compound</th>
+      <th>Kappa</th>
+    </tr>
+    <tr>
+      <td>Methanol</td>
+      <td>0.215</td>
+      <td>n-Pentanol</td>
+      <td>0.122</td>
+    </tr>
+    <tr>
+      <td>Ethanol</td>
+      <td>0.175</td>
+      <td>n-Hexanol</td>
+      <td>0.114</td>
+    </tr>
+    <tr>
+      <td>n-Propanol</td>
+      <td>0.143</td>
+      <td>n-Heptanol</td>
+      <td>0.109</td>
+    </tr>
+    <tr>
+      <td>i-Propanol</td>
+      <td>0.143</td>
+      <td>Acetic Acid</td>
+      <td>0.0916</td>
+    </tr>
+    <tr>
+      <td>n-Butanol</td>
+      <td>0.132</td>
+      <td>Water</td>
+      <td>0.076</td>
+    </tr>
+    <tr>
+      <td>i-Butanol</td>
+      <td>0.132</td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
 </table>
 <p>
 Chung, et al. (1984) suggest that for other alcohols not shown in the
-table:<br>
+table:
+<br>
 &nbsp;&nbsp;&nbsp;&nbsp;<br>
 &nbsp;&nbsp;&nbsp; kappa = 0.0682 + 4.704*[(number of -OH
 groups)]/[molecular weight]<br>
 <br>
-<span style=\"font-weight: normal;\">S.I. units relation for the
-debyes:&nbsp;</span><br>
+S.I. units relation for the debyes:
+<br>
 &nbsp;&nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;
 &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;
 &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;

--- a/ThermofluidStream/Processes/Compressor.mo
+++ b/ThermofluidStream/Processes/Compressor.mo
@@ -12,8 +12,10 @@ model Compressor
         choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select function",
         choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop "Fixed isentropic efficency"),
       Documentation(info="<html>
-        <p><span style=\"font-size: 12pt;\">Selectable function to choose beween different compressor models.</span></p>
-        </html>"));
+<p>
+Selectable function to choose beween different compressor models.
+</p>
+</html>"));
 
   parameter Real max_rel_R(min=0, max=1, unit="1") = 0.05 "Maximum relative allowed divergence from ideal gas"
     annotation(Dialog(tab="Advanced"));

--- a/ThermofluidStream/Processes/ConductionElement.mo
+++ b/ThermofluidStream/Processes/ConductionElement.mo
@@ -17,9 +17,23 @@ equation
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)),
     Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>This model is an element with a fixed volume (fig. 1). The mass in the volume is assumed quasi-stationary (statically computed with volume and density), and the inlet massflow is coupled to the outlet massflow. </p>
-<p><span style=\"color: #f47d23;\">Because of this the ConductionElement cannot be used as a loop breaker</span><span style=\"color: #b83d00;\">. </span></p>
-<p>The advantage is that multiple ConductionElements can be put behind each other without worrying about oscillations or fast eigenvalues between their masses. The ConductionElement implements equations for conservation of mass and energy for the fluid mass contained in the component.</p>
-<p>For further documentation see the documentation of the <a href=\"ThermofluidStream.Processes.Internal.PartialConductionElement\">motherclass</a>.</p>
+<p>
+This model is an element with a fixed volume (fig. 1). The mass in the volume is
+assumed quasi-stationary (statically computed with volume and density), and the
+inlet massflow is coupled to the outlet massflow.
+</p>
+<p>
+<strong>Because of this the ConductionElement cannot be used as a loop breaker.</strong>
+</p>
+<p>
+The advantage is that multiple ConductionElements can be put behind each other
+without worrying about oscillations or fast eigenvalues between their masses.
+The ConductionElement implements equations for conservation of mass and energy
+for the fluid mass contained in the component.
+</p>
+<p>
+For further documentation see the documentation of the
+<a href=\"ThermofluidStream.Processes.Internal.PartialConductionElement\">motherclass</a>.
+</p>
 </html>"));
 end ConductionElement;

--- a/ThermofluidStream/Processes/Fan.mo
+++ b/ThermofluidStream/Processes/Fan.mo
@@ -9,8 +9,10 @@ model Fan "Fan under ideal gas assumption"
         choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select function",
         choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop "Fixed isentropic efficency"),
         Documentation(info="<html>
-          <p><span style=\"font-size: 12pt;\">Selectable function to choose beween different fan models.</span></p>
-          </html>"));
+<p>
+Selectable function to choose beween different fan models.
+</p>
+</html>"));
 
   parameter Real max_rel_R(min=0, max=1, unit="1") = 0.05 "Maximum relative allowed divergence from ideal gas"
     annotation(Dialog(tab="Advanced"));

--- a/ThermofluidStream/Processes/FlowResistance.mo
+++ b/ThermofluidStream/Processes/FlowResistance.mo
@@ -87,6 +87,9 @@ equation
           origin={0,25},
           rotation=180)}), Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Implementation of a flow resistance pipe with different selectable flow resistance functions (laminar, laminar-turbulent, linear-quadratic).</span></p>
+<p>
+Implementation of a flow resistance pipe with different selectable
+flow resistance functions (laminar, laminar-turbulent, linear-quadratic).
+</p>
 </html>"));
 end FlowResistance;

--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarPressureLoss.mo
@@ -9,7 +9,11 @@ algorithm
   pressureLoss := m_flow * (8*mu*l)/(pi*rho*r^4);
 
   annotation (Documentation(info="<html>
-<p>Pressure loss after Hagen-Poiseuille:</p>
-<p><span style=\"font-family: Courier New;\">pressureLoss&nbsp;:=&nbsp;m_flow&nbsp;*&nbsp;(8*mu*l)/(pi*rho*r^4);</span></p>
+<p>
+Pressure loss after Hagen-Poiseuille:
+</p>
+<blockquote><pre>
+pressureLoss := m_flow * (8*mu*l)/(pi*rho*r^4);
+</pre></blockquote>
 </html>"));
 end laminarPressureLoss;

--- a/ThermofluidStream/Processes/Internal/FlowResistance/linearQuadraticPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/linearQuadraticPressureLoss.mo
@@ -12,9 +12,12 @@ algorithm
   pressureLoss :=k*m_flow + k2*m_flow*abs(m_flow);
 
   annotation (Documentation(info="<html>
-<p>This pressure loss is linear-quadratic in the massflow with the linear factor k and the quadratic factor k2: </p>
+<p>
+This pressure loss is linear-quadratic in the massflow with the linear factor k 
+and the quadratic factor k2: 
+</p>
 <blockquote><pre>
-dp := k*m_flow&nbsp;+&nbsp;k2*m_flow*<span style=\"color: #ff0000;font-family: Courier New;\">abs</span>(m_flow);
+dp := k*m_flow + k2*m_flow*<span style=\"color: #ff0000;font-family: Courier New;\">abs</span>(m_flow);
 </pre></blockquote>
 <p>
 For a pure linear pressure loss choose k2&nbsp;=&nbsp;0;

--- a/ThermofluidStream/Processes/Internal/PartialConductionElement.mo
+++ b/ThermofluidStream/Processes/Internal/PartialConductionElement.mo
@@ -117,18 +117,69 @@ equation
          color={238,46,47})}),
     Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>This model is an element with a fixed volume (fig. 1). The mass in the volume is assumed quasi-stationary (statically computed with volume and density), and the fore massflow is coupled to the rear massflow. <span style=\"color: #f47d23;\">Because of this the ConductionElement cannot be used as a loop breaker</span><span style=\"color: #b83d00;\">. </span>The advantage is that multiple ConductionElements can be put behind each other without worrying about oscillations or fast eigenvalues between their masses. The ConductionElement implements equations for conservation of mass and energy for the fluid mass contained within it.</p>
-<p>Initialization can be done by initial temperature, initial enthalpy or by using the inlet state.</p>
-<p>The ConductionElement makes different assumptions:</p>
+<p>
+This model is an element with a fixed volume (fig. 1). The mass in the volume is
+assumed quasi-stationary (statically computed with volume and density), and the
+fore massflow is coupled to the rear massflow. <strong>Because of this the
+ConductionElement cannot be used as a loop breaker.</strong>
+The advantage is that multiple ConductionElements can be put behind each other
+without worrying about oscillations or fast eigenvalues between their masses.
+The ConductionElement implements equations for conservation of mass and energy
+for the fluid mass contained within it.
+</p>
+<p>
+Initialization can be done by initial temperature, initial enthalpy or by using
+the inlet state.
+</p>
+<p>
+The ConductionElement makes different assumptions:
+</p>
 <ul>
-<li>Quasistationary mass:<br>m_flow_rear = - m_flow_fore &amp; M = rho * V (this assumption violates the conservation of mass for changing densities, since the mass in the element can change although inflow and outflow are the same)<br>der(H) = der(M*h) = M*der(h) (This assumption violates the conservation of energy for changing densities, since then the mass M of fluid in the element is no longer constant)</li>
-<li>Neglection of der(p) in the energy equation<br>V*der(p) = 0 (this assumption violates the conservation of energy for changing pressures. For a noticable difference in the testcase the der(p) must be in the order of 1e5 Pa/s). <br>This assumption can be turned off by setting neglectPressureChanges=false (true by default) in the Advanced tab. <span style=\"color: #f47d23;\">This option requires the fore and rear input pressures to be smooth.</span><br></li>
-<li>Due to stability reasons the component exhibits a different behavior for negative massflows (see fig. 2). For negative massflows, the ingoing and outgoing massflows get decoupled from the fluid remaining in the component. The fluid exits with the same state as it enters, and the heatport is connected to the fluid left in the volume (which is decoupled to the mass flowing).<br></li>
+  <li>
+    Quasistationary mass:<br>m_flow_rear = - m_flow_fore &amp; M = rho * V
+    (this assumption violates the conservation of mass for changing densities,
+    since the mass in the element can change although inflow and outflow are
+    the same)
+    <br>
+    der(H) = der(M*h) = M*der(h) (This assumption violates the conservation of
+    energy for changing densities, since then the mass M of fluid in the
+    element is no longer constant)
+  </li>
+  <li>
+    Neglection of der(p) in the energy equation<br>V*der(p) = 0 (this assumption
+    violates the conservation of energy for changing pressures. For a noticable
+    difference in the testcase the der(p) must be in the order of 1e5 Pa/s).
+    <br>
+    This assumption can be turned off by setting neglectPressureChanges=false
+    (true by default) in the Advanced tab. <strong>This option requires the fore
+    and rear input pressures to be smooth.</strong>
+  </li>
+  <li>
+    Due to stability reasons the component exhibits a different behavior for
+    negative massflows (see fig. 2). For negative massflows, the ingoing and 
+    outgoing massflows get decoupled from the fluid remaining in the component. 
+    The fluid exits with the same state as it enters, and the heatport is 
+    connected to the fluid left in the volume (which is decoupled to the 
+    mass flowing).
+  </li>
 </ul>
-<p>Due to these assumptions minor violations in the global energy conservation can occur. With the flag enforce_global_energy_conservation in the &quot;Advanced&quot; tab is set true (Default: false), long-term energy storage in the ConductionElement is sacrificed to hold global energy conservation.</p>
-<p><img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.ConductionElement_positive.png\"/></p>
-<p>fig. 1: positive massflow model</p>
-<p><img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.ConductionElement_negative.png\"/></p>
-<p>fig. 2: negative massflow model </p>
+<p>
+Due to these assumptions minor violations in the global energy conservation can 
+occur. With the flag enforce_global_energy_conservation in the &quot;Advanced&quot; 
+tab is set true (Default: false), long-term energy storage in the ConductionElement 
+is sacrificed to hold global energy conservation.
+</p>
+<div>
+<img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.ConductionElement_positive.png\"/>
+</div>
+<p>
+fig. 1: positive massflow model
+</p>
+<div>
+<img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.ConductionElement_negative.png\"/>
+</div>
+<p>
+fig. 2: negative massflow model
+</p>
 </html>"));
 end PartialConductionElement;

--- a/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_const_isentrop.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_const_isentrop.mo
@@ -66,23 +66,81 @@ algorithm
   tau_st := tau_st + V_ref*dp* omega_norm^2/(omega^2 + omega_norm^2);
 
   annotation (Documentation(info="<html>
-<p>This is a model of isentropic expansion or compression of an ideal gas with a fixed isentropic efficency.</p>
-<p>The isentropic exponent (kappa) by default is retrieved from the media model at the inlet. It can be set to a fixed value to allow compressor operation in two-phase region.</p>
-<p><br>The computation is as follows:</p>
+<p>
+This is a model of isentropic expansion or compression of an ideal gas with a fixed
+isentropic efficency.
+</p>
+<p>
+The isentropic exponent (kappa) by default is retrieved from the media model at
+the inlet. It can be set to a fixed value to allow compressor operation in
+two-phase region.
+</p>
+<p>
+<br>The computation is as follows:
+</p>
 <ol>
-<li>with the scaling factors <code>omega_ref</code>, <code>m_flow_ref</code> and the scewness factor <code>skew</code>, the pressure ratio <code> pr=p_outlet/p_inlet</code> is computed as quadratic function of <code>omega/omega_ref</code>, <code>m_flow/m_flow_ref:</code></li>
-<p><span style=\"font-family: Courier New;\">pr&nbsp;&nbsp;:=<span style=\"color: #ff0000;\">&nbsp;abs</span>(omega)*omega/(omega_ref^2)&nbsp;-&nbsp;skew*omega*m_flow/(omega_ref*m_flow_ref)&nbsp;-<span style=\"font-family: Courier New; color: #ff0000;\">&nbsp;abs</span>(m_flow)*m_flow/(m_flow_ref^2)&nbsp;+&nbsp;1;</p>
-<li>if the pressure ratio is smaller then 1 (expansion of gas), to limit it to 0 compute:</li>
-<p><span style=\"font-family: Courier New;\">pr&nbsp;:=&nbsp;k^(pr-1);</span></p>
-<li>compute specific technical work w_t from pr using a isenthalpic process</li>
-<li>apply constant isentropic efficency </li>
-<li>compute static moment by the following law: <br>- if m_dot and omega both &gt; 0 (nominal operation): W_t = w_t*m_flow = tau*omega<br>- else (not nominal operation; with area of fluid A and radius of pump r) tau = F*r = dp*A*r = dp*V_ref<br>both are scaled so they are smooth at the border to nominal operation. Additionally for small omega, a small tau is added, so the standing pump can be pushed by the fluid.</li>
+  <li>
+    with the scaling factors <code>omega_ref</code>, <code>m_flow_ref</code> and
+    the scewness factor <code>skew</code>, the pressure ratio
+    <code>pr=p_outlet/p_inlet</code> is computed as quadratic function of
+    <code>omega/omega_ref</code>, <code>m_flow/m_flow_ref:</code>
+    <br>
+    <span style=\"font-family: Courier New;\">pr&nbsp;&nbsp;:=<span style=\"color: #ff0000;\">&nbsp;abs</span>(omega)*omega/(omega_ref^2)&nbsp;-&nbsp;skew*omega*m_flow/(omega_ref*m_flow_ref)&nbsp;-<span style=\"font-family: Courier New; color: #ff0000;\">&nbsp;abs</span>(m_flow)*m_flow/(m_flow_ref^2)&nbsp;+&nbsp;1;
+  </li>
+  <li>
+    if the pressure ratio is smaller then 1 (expansion of gas), to limit it
+    to 0 compute:
+    <br>
+    <span style=\"font-family: Courier New;\">pr&nbsp;:=&nbsp;k^(pr-1);</span>
+  </li>
+  <li>
+    compute specific technical work w_t from pr using a isenthalpic process
+  </li>
+  <li>
+    apply constant isentropic efficency
+  </li>
+  <li>
+    compute static moment by the following law:
+    <ul>
+      <li>
+        if m_dot and omega both &gt; 0 (nominal operation):
+        W_t = w_t*m_flow = tau*omega
+      </li>
+      <li>
+        else (not nominal operation; with area of fluid A and radius of pump r)
+        tau = F*r = dp*A*r = dp*V_ref
+      </li>
+    </ul>
+    both are scaled so they are smooth at the border to nominal operation.
+    Additionally for small omega, a small tau is added, so the standing pump can
+    be pushed by the fluid.
+  </li>
 </ol>
-<p><code>omega_ref</code> and <code>m_flow_ref</code> are supposed to be scaling factors for omega and m_flow respectiveley. <code>omega_ref</code> is the angular velocity that produces a pressure ratio of 2 at m_flow=0. <code>m_flow_ref</code> is the massflow, that produces a negative pressure ratio of 1 at <code>omega=omega_ref</code>. The skewness factor can be used to shape the characteristic curve inbetween (see fig. 1).</p>
-<p>When pr &lt; 1, the reciprocal pressure ratio 1/pr = p_inlet/p_outlet is more interesting. It can be seen for different values of skew in fig. 2.</p>
-<p><img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.Internal.dp_tau_const_polytrop_skewness.PNG\"/> </p>
-<p>Fig. 1: different skewness factors for omega/omega_ref=1. pressure ratio pr over m_dot/m_dot_ref</p>
-<p><img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.Internal.dp_tau_const_polytrop_skewness2.PNG\"/> </p>
-<p>Fig. 2: different skewness factors for omega/omega_ref=1. Reciprocal pressure ratio 1/pr over m_dot/m_dot_ref</p>
+<p>
+<code>omega_ref</code> and <code>m_flow_ref</code> are supposed to be scaling
+factors for omega and m_flow respectiveley. <code>omega_ref</code> is the angular
+velocity that produces a pressure ratio of 2 at m_flow=0. <code>m_flow_ref</code>
+is the massflow, that produces a negative pressure ratio of 1 at
+<code>omega=omega_ref</code>. The skewness factor can be used to shape the
+characteristic curve inbetween (see fig. 1).
+</p>
+<p>
+When pr&nbsp;&lt;&nbsp;1, the reciprocal pressure ratio 1/pr&nbsp;= p_inlet/p_outlet
+is more interesting. It can be seen for different values of skew in fig. 2.
+</p>
+<div>
+<img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.Internal.dp_tau_const_polytrop_skewness.PNG\"/>
+</div>
+<p>
+Fig. 1: different skewness factors for omega/omega_ref=1. pressure ratio pr over
+m_dot/m_dot_ref
+</p>
+<div>
+<img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.Internal.dp_tau_const_polytrop_skewness2.PNG\"/>
+</div>
+<p>
+Fig. 2: different skewness factors for omega/omega_ref=1. Reciprocal pressure ratio
+1/pr over m_dot/m_dot_ref
+</p>
 </html>"));
 end dp_tau_const_isentrop;

--- a/ThermofluidStream/Processes/Internal/TurboComponent/package.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/package.mo
@@ -3,6 +3,10 @@ package TurboComponent "Helper funtions for all turbo component models"
 extends Modelica.Icons.FunctionsPackage;
 
   annotation (Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">This package implements dp_tau functions (computing pressure difference and stationary tourque from current state) for the TurboComponents (Pumps, Compressors, Fans, Turbines ect.)</span></p>
+<p>
+This package implements dp_tau functions (computing pressure difference and 
+stationary tourque from current state) for the TurboComponents (Pumps, Compressors, 
+Fans, Turbines ect.)
+</p>
 </html>"));
 end TurboComponent;

--- a/ThermofluidStream/Processes/Internal/TurboComponent/partial_dp_tau.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/partial_dp_tau.mo
@@ -3,7 +3,9 @@ partial function partial_dp_tau "Compute dp and tau_st of a TurboComponent from 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model"
     annotation(choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Medium model needet to compute properties from the inlet_state.</span></p>
+<p>
+Medium model needet to compute properties from the inlet_state.
+</p>
 </html>"));
 
   input SI.MassFlowRate m_flow "Mass flow through component";

--- a/ThermofluidStream/Processes/Pump.mo
+++ b/ThermofluidStream/Processes/Pump.mo
@@ -15,8 +15,10 @@ model Pump "A simple pump model"
        choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal "Centrifugal Pump",
        choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_nominal_flow "Nominal Flow Pump"),
     Documentation(info="<html>
-      <p><span style=\"font-size: 12pt;\">Selectable function to choose beween different pump models.</span></p>
-      </html>"));
+<p>
+Selectable function to choose beween different pump models.
+</p>
+</html>"));
 
   Real eta(unit="1") = if noEvent(abs(W_t)>1e-4) then dp*v_in*m_flow/W_t else 0.0;
 

--- a/ThermofluidStream/Processes/Tests/Compressor.mo
+++ b/ThermofluidStream/Processes/Tests/Compressor.mo
@@ -6,7 +6,9 @@ model Compressor "Test for compressors"
 
   replaceable package Medium = ThermofluidStream.Media.myMedia.CompressibleLiquids.LinearWater_pT_Ambient
     "Medium model" annotation (Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Medium model for the test. Should be an ideal gas or close to that.</span></p>
+<p>
+Medium model for the test. Should be an ideal gas or close to that.
+</p>
 </html>"));  // ThermofluidStream.myMedia.Air.SimpleAir;
 
 

--- a/ThermofluidStream/Processes/Tests/ConductionElement.mo
+++ b/ThermofluidStream/Processes/Tests/ConductionElement.mo
@@ -6,7 +6,10 @@ model ConductionElement "Test for ConductionElement"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium Model"
     annotation(choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Medium Model for the test. Be aware that the Component is mainly ment for liquids with low compressablility.</span></p>
+<p>
+Medium Model for the test. Be aware that the Component is mainly
+ment for liquids with low compressablility.
+</p>
 </html>"));
 
   ThermofluidStream.Processes.ConductionElement conductionElement(

--- a/ThermofluidStream/Processes/Tests/Flow_Resistance.mo
+++ b/ThermofluidStream/Processes/Tests/Flow_Resistance.mo
@@ -6,7 +6,9 @@ model Flow_Resistance "Test for flow resistance"
   replaceable package Medium = tf.Media.myMedia.Air.SimpleAir
     "Medium model"
     annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium model for the test. Can be anything. </span></p>
+<p>
+Medium model for the test. Can be anything.
+</p>
 </html>"));
 
   tf.Boundaries.Source source(
@@ -70,8 +72,8 @@ model Flow_Resistance "Test for flow resistance"
     r=0.075,
     l=10,
     redeclare function pLoss =
-        tf.Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland
-        (material=ThermofluidStream.Processes.Internal.Material.steel))
+        tf.Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland(
+      material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));
 
   tf.Boundaries.Sink sink1(redeclare package Medium = Medium, p0_par=100000)

--- a/ThermofluidStream/Processes/Tests/Nozzle.mo
+++ b/ThermofluidStream/Processes/Tests/Nozzle.mo
@@ -5,7 +5,9 @@ model Nozzle
   replaceable package Medium = Media.myMedia.Air.MoistAir
     constrainedby Media.myMedia.Interfaces.PartialMedium "Medium Model"
     annotation (choicesAllMatching=true,Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Medium model for the test. Can be anything. </span></p>
+<p>
+Medium model for the test. Can be anything.
+</p>
 </html>"));
 
 

--- a/ThermofluidStream/Processes/Tests/Pump.mo
+++ b/ThermofluidStream/Processes/Tests/Pump.mo
@@ -8,8 +8,10 @@ model Pump "Test for pumps"
     annotation (
       choicesAllMatching=true,
       Documentation(info="<html>
-        <p><span style=\"font-size: 12pt;\">Medium model for the test. Should be incompressible or with low compressibility.</span></p>
-        </html>"));
+<p>
+Medium model for the test. Should be incompressible or with low compressibility.
+</p>
+</html>"));
 
   tf.Boundaries.Source source(
     redeclare package Medium = Medium,

--- a/ThermofluidStream/Processes/Tests/TransportDelay.mo
+++ b/ThermofluidStream/Processes/Tests/TransportDelay.mo
@@ -5,7 +5,9 @@ model TransportDelay "Test for transport delay "
   replaceable package Medium = Media.myMedia.Air.DryAirNasa
     constrainedby Media.myMedia.Interfaces.PartialMedium "Medium Model"
     annotation (Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Medium model for the test. Can be anything. </span></p>
+<p>
+Medium model for the test. Can be anything.
+</p>
 </html>"));
 
   Processes.TransportDelay transportDelay(

--- a/ThermofluidStream/Processes/Tests/Turbine.mo
+++ b/ThermofluidStream/Processes/Tests/Turbine.mo
@@ -7,7 +7,9 @@ model Turbine "Test for turbines"
   replaceable package Medium = ThermofluidStream.Media.myMedia.Air.SimpleAir
     "Medium model"
     annotation (Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Medium model for the test. Should be an ideal gas or close to that.</span></p>
+<p>
+Medium model for the test. Should be an ideal gas or close to that.
+</p>
 </html>"));
 
   tf.Boundaries.Source source(

--- a/ThermofluidStream/Processes/Tests/package.mo
+++ b/ThermofluidStream/Processes/Tests/package.mo
@@ -3,7 +3,9 @@ package Tests "Test package for processes"
   extends Modelica.Icons.ExamplesPackage;
 
 annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New; font-size: 12pt;\">Test&nbsp;package&nbsp;for&nbsp;processes</span></p>
+<p>
+Test package for processes.
+</p>
 </html>", revisions="<html>
 
 </html>"));

--- a/ThermofluidStream/Processes/Turbine.mo
+++ b/ThermofluidStream/Processes/Turbine.mo
@@ -10,8 +10,11 @@ model Turbine "Turbine under ideal gas assumption"
     annotation(choices(
         choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select function",
         choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop(omega_ref=1e6) "Fixed isentropic efficency"),
-      Documentation(info="<html><p><span style=\"font-size: 12pt;\">Selectable function to choose beween different turbine models.</span></p>
-        </html>"));
+      Documentation(info="<html>
+<p>
+Selectable function to choose beween different turbine models.
+</p>
+</html>"));
 
   parameter Real max_rel_R(min=0, max=1, unit="1") = 0.05 "Maximum relative allowed divergence from ideal gas"
     annotation(Dialog(tab="Advanced"));

--- a/ThermofluidStream/Sensors/Internal/Types.mo
+++ b/ThermofluidStream/Sensors/Internal/Types.mo
@@ -68,6 +68,8 @@ package Types "Types used in the Sensor Package"
       steadyState "Steady state initialization",
       state "Initial output state") "Initaization modes for sensor lowpass";
    annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Types used in the Sensor Package. </span></p>
+<p>
+Types used in the Sensor Package.
+</p>
 </html>"));
 end Types;

--- a/ThermofluidStream/Sensors/Tests/package.mo
+++ b/ThermofluidStream/Sensors/Tests/package.mo
@@ -3,6 +3,8 @@ package Tests "Tests for Sensor package"
   extends Modelica.Icons.ExamplesPackage;
 
 annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Tests&nbsp;for&nbsp;Sensor&nbsp;package.</span></p>
+<p>
+Tests for Sensor package.
+</p>
 </html>"));
 end Tests;

--- a/ThermofluidStream/Topology/Tests/TestDynamicTopology.mo
+++ b/ThermofluidStream/Topology/Tests/TestDynamicTopology.mo
@@ -6,8 +6,10 @@ model TestDynamicTopology
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium Model"
     annotation (choicesAllMatching=
-       true, Documentation(info = "<html>
-<p><span style=\"font-size: 12pt;\">Medium model for the test. Can be anything. </span></p>
+       true, Documentation(info="<html>
+<p>
+Medium model for the test. Can be anything.
+</p>
 </html>"));
 
   DynamicJunctionNM dynamicJunctionNM(

--- a/ThermofluidStream/Topology/Tests/TestJunctionNM.mo
+++ b/ThermofluidStream/Topology/Tests/TestJunctionNM.mo
@@ -6,8 +6,10 @@ model TestJunctionNM
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium Model"
     annotation (choicesAllMatching=
-       true, Documentation(info = "<html>
-<p><span style=\"font-size: 12pt;\">Medium model for the test. Can be anything. </span></p>
+       true, Documentation(info="<html>
+<p>
+Medium model for the test. Can be anything.
+</p>
 </html>"));
 
   JunctionNM junctionNM(

--- a/ThermofluidStream/Undirected/Boundaries/Internal/PartialVolume.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Internal/PartialVolume.mo
@@ -3,7 +3,10 @@ partial model PartialVolume "Partial parent class for Volumes with one fore and 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model" annotation (
       choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Volume. Make sure it is the same as the fores and rears the volume is connected to.</span></p>
+<p>
+Medium package used in the Volume. Make sure it is the same as
+the fores and rears the volume is connected to.
+</p>
 </html>"));
 
   parameter Boolean useHeatport = false "If true heatport is added";

--- a/ThermofluidStream/Undirected/Boundaries/Internal/PartialVolumeN.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Internal/PartialVolumeN.mo
@@ -3,7 +3,10 @@ partial model PartialVolumeN "Partial parent class for Volumes with N_fore fores
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model" annotation (
       choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Volume. Make sure it is the same as the fores and rears the volume is connected to.</span></p>
+<p>
+Medium package used in the Volume. Make sure it is the same as
+the fores and rears the volume is connected to.
+</p>
 </html>"));
 
   parameter Integer N_rear = 1 "Number if rears";

--- a/ThermofluidStream/Undirected/Boundaries/Reservoir.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Reservoir.mo
@@ -70,9 +70,23 @@ equation
           fillPattern=FillPattern.Solid)}),
             Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>This is a volume, that is open at the top and therefore maintains environmental pressure at the top and adds pressure depending on fill height. </p>
-<p>Conceptually it is a Sink and a Source. It therefore defines the level of inertial pressure r and acts as a loop breaker in a closed loop.</p>
-<p>This component uses a simplification (medium.p is set to p_env + height*g, which is only correct at the bottom of the reservoir) which is intended to hold for media with low compressibility. </p>
-<p><span style=\"color: #ff5500;\">Note that the energy equation requires the mass in the system to be positive and will not give valid results otherwise (if the assert of height &gt; 0 fails).</span></p>
+<p>
+This is a volume, that is open at the top and therefore maintains environmental
+pressure at the top and adds pressure depending on fill height.
+</p>
+<p>
+Conceptually it is a Sink and a Source. It therefore defines the level of inertial
+pressure r and acts as a loop breaker in a closed loop.
+</p>
+<p>
+This component uses a simplification (medium.p is set to p_env + height*g, which
+is only correct at the bottom of the reservoir) which is intended to hold for
+media with low compressibility.
+</p>
+<p>
+<strong>Note that the energy equation requires the mass in the system to be 
+positive and will not give valid results otherwise (if the assert of 
+height &gt; 0 fails).</strong>
+</p>
 </html>"));
 end Reservoir;

--- a/ThermofluidStream/Undirected/Boundaries/TerminalFore.mo
+++ b/ThermofluidStream/Undirected/Boundaries/TerminalFore.mo
@@ -3,8 +3,11 @@ model TerminalFore "Rear Boundary that impoeses m_flow = 0"
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model"
-    annotation (choicesAllMatching=true, Documentation(info = "<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Source. Make sure it is the same as the one the inlet the source is connected to.</span></p>
+    annotation (choicesAllMatching=true, Documentation(info="<html>
+<p>
+Medium package used in the Source. Make sure it is the same as
+the one the inlet the source is connected to.
+</p>
 </html>"));
 
   parameter SI.Time TC = 0.1 "Time constant for pressure adaption"

--- a/ThermofluidStream/Undirected/Boundaries/TerminalRear.mo
+++ b/ThermofluidStream/Undirected/Boundaries/TerminalRear.mo
@@ -3,8 +3,11 @@ model TerminalRear "Fore Boundary that impoeses m_flow = 0"
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium
     "Medium model"
-    annotation (choicesAllMatching=true, Documentation(info = "<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Source. Make sure it is the same as the one the inlet the source is connected to.</span></p>
+    annotation (choicesAllMatching=true, Documentation(info="<html>
+<p>
+Medium package used in the Source. Make sure it is the same as
+the one the inlet the source is connected to.
+</p>
 </html>"));
 
   parameter SI.Time TC = 0.1 "Time constant for pressure adaption"

--- a/ThermofluidStream/Undirected/Boundaries/Tests/PhaseSeperator.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/PhaseSeperator.mo
@@ -126,7 +126,8 @@ model PhaseSeperator
     digits=2,
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.p_bar) annotation (Placement(transformation(extent={{-76,40},{-56,60}})));
   BoundaryFore boundaryFore(
-                                          redeclare package Medium = Medium, p0_par=100000)
+    redeclare package Medium = Medium,
+    p0_par=100000)
     annotation (Placement(transformation(extent={{120,10},{140,30}})));
   ThermofluidStream.Sensors.TwoPhaseSensorSelect twoPhaseSensorSelect7(
     redeclare package Medium = Medium,

--- a/ThermofluidStream/Undirected/Boundaries/Tests/TestVolumes.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/TestVolumes.mo
@@ -5,8 +5,10 @@ model TestVolumes "Test for undirected Volumes"
   replaceable package Medium = Media.myMedia.Air.SimpleAir constrainedby
     Media.myMedia.Interfaces.PartialMedium "Medium package"
     annotation (Documentation(info="<html>
-      <p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
-      </html>"));
+<p>
+Medium package used in the Test.
+</p>
+</html>"));
 
   package MediumMix = Media.myMedia.IdealGases.MixtureGases.CombustionAir "Medium package"
       annotation (Documentation(info="<html>

--- a/ThermofluidStream/Undirected/Boundaries/Tests/VolumesDirectCoupling.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/VolumesDirectCoupling.mo
@@ -6,13 +6,17 @@ model VolumesDirectCoupling "Test Volumes"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-        <p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
-        </html>"));
+<p>
+Medium package used in the Test.
+</p>
+</html>"));
 
   package MediumMix = Media.myMedia.IdealGases.MixtureGases.CombustionAir
     "Medium package"
     annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test of the MixVolumes.</span> </p>
+<p>
+Medium package used in the Test of the MixVolumes.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons(k_volume_damping=0.5)

--- a/ThermofluidStream/Undirected/Boundaries/package.mo
+++ b/ThermofluidStream/Undirected/Boundaries/package.mo
@@ -3,6 +3,8 @@ package Boundaries "Boundary models for undirected thermofluid simulation"
   extends Modelica.Icons.SourcesPackage;
 
 annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Boundary&nbsp;models&nbsp;for&nbsp;undirected&nbsp;thermofluid&nbsp;simulation.</span></p>
+<p>
+Boundary models for undirected thermofluid simulation.
+</p>
 </html>"));
 end Boundaries;

--- a/ThermofluidStream/Undirected/FlowControl/Tests/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/BasicControlValve.mo
@@ -7,7 +7,9 @@ model BasicControlValve "Test for undirected BasicControlValve"
     constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner ThermofluidStream.DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/Undirected/FlowControl/Tests/CheckValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/CheckValve.mo
@@ -6,7 +6,9 @@ model CheckValve "Test for undirected CheckValve"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/Undirected/FlowControl/Tests/MCV.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/MCV.mo
@@ -6,7 +6,9 @@ model MCV "Test for undirected MCV"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package"
       annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons(assertionLevel=

--- a/ThermofluidStream/Undirected/FlowControl/Tests/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/SpecificValveType.mo
@@ -7,7 +7,9 @@ model SpecificValveType "Test for undirected SpecificValveType"
     constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner ThermofluidStream.DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/Undirected/FlowControl/Tests/TanValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/TanValve.mo
@@ -6,7 +6,9 @@ model TanValve "Test for undirected TanValve"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium package"
     annotation (choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
+<p>
+Medium package used in the Test.
+</p>
 </html>"));
 
   inner DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)

--- a/ThermofluidStream/Undirected/Interfaces/Tests/Test_p_out_clipping.mo
+++ b/ThermofluidStream/Undirected/Interfaces/Tests/Test_p_out_clipping.mo
@@ -5,8 +5,10 @@ model Test_p_out_clipping "Test for the lower limit of p_out in SISOFlow compone
   replaceable package Medium = Media.myMedia.Air.SimpleAir
     constrainedby Media.myMedia.Interfaces.PartialMedium "Medium package"
     annotation (Documentation(info="<html>
-      <p><span style=\"font-family: Courier New;\">Medium package used in the Test.</span></p>
-      </html>"));
+<p>
+Medium package used in the Test.
+</p>
+</html>"));
 
   Boundaries.BoundaryRear boundary_rear(redeclare package Medium = Medium) annotation (Placement(transformation(extent={{-60,40},{-40,60}})));
   Boundaries.BoundaryFore boundary_fore(redeclare package Medium = Medium) annotation (Placement(transformation(extent={{40,40},{60,60}})));

--- a/ThermofluidStream/Undirected/Interfaces/package.mo
+++ b/ThermofluidStream/Undirected/Interfaces/package.mo
@@ -3,6 +3,9 @@ package Interfaces "Interfaces package for undirected thermofluid simulation"
 extends Modelica.Icons.InterfacesPackage;
 
 annotation (Documentation(info="<html>
-<p><span style=\"font-family: Courier New; color: #006400;\">Interfaces&nbsp;package&nbsp;for&nbsp;undirected&nbsp;thermofluid&nbsp;simulation. It contains the connectors and base classes.</span></p>
+<p>
+Interfaces package for undirected thermofluid simulation. It contains the connectors
+and base classes.
+</p>
 </html>"));
 end Interfaces;

--- a/ThermofluidStream/Undirected/Processes/ConductionElement.mo
+++ b/ThermofluidStream/Undirected/Processes/ConductionElement.mo
@@ -17,10 +17,26 @@ equation
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)),
     Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>Undirected implementation of the Conduction Element.</p>
-<p>This model is an element with a fixed volume (fig. 1). The mass in the volume is assumed quasi-stationary (statically computed with volume and density), and the fore massflow is coupled to the rear massflow. </p>
-<p><span style=\"color: #f47d23;\">Because of this the ConductionElement cannot be used as a loop breaker</span><span style=\"color: #b83d00;\">. </span></p>
-<p>The advantage is that multiple ConductionElements can be put behind each other without worrying about oscillations or fast eigenvalues between their masses. The ConductionElement implements equations for conservation of mass and energy for the fluid mass contained within it.</p>
-<p>For further documentation see the documentation of the <a href=\"ThermofluidStream.Undirected.Processes.Internal.PartialConductionElement\">motherclass</a>.</p>
+<p>
+Undirected implementation of the Conduction Element.
+</p>
+<p>
+This model is an element with a fixed volume (fig. 1). The mass in the volume is
+assumed quasi-stationary (statically computed with volume and density), and the
+fore massflow is coupled to the rear massflow.
+</p>
+<p>
+<strong>Because of this the ConductionElement cannot be used as a loop breaker.</strong>
+</p>
+<p>
+The advantage is that multiple ConductionElements can be put behind each other
+without worrying about oscillations or fast eigenvalues between their masses.
+The ConductionElement implements equations for conservation of mass and energy
+for the fluid mass contained within it.
+</p>
+<p>
+For further documentation see the documentation of the
+<a href=\"ThermofluidStream.Undirected.Processes.Internal.PartialConductionElement\">motherclass</a>.
+</p>
 </html>"));
 end ConductionElement;

--- a/ThermofluidStream/Undirected/Processes/Internal/InitializationMethodsCondElement.mo
+++ b/ThermofluidStream/Undirected/Processes/Internal/InitializationMethodsCondElement.mo
@@ -4,9 +4,12 @@ type InitializationMethodsCondElement = enumeration(
     h "specific enthalpy h_0",
     fore "input state from fore",
     rear "input state from rear",
-    port "regularized input state from fore or rear, depending on massflow") "Choices for Initialization of state h of undirected ConductionElement"
-annotation (Icon(coordinateSystem(preserveAspectRatio=false)),
-  Diagram(coordinateSystem(preserveAspectRatio=false)),
-  Documentation(info="<html>
-        <p><span style=\"font-family: Courier New;\">Choices for Initailtaion of a state h.</span></p>
-        </html>"));
+    port "regularized input state from fore or rear, depending on massflow") "Choices for initialization of state h of undirected ConductionElement"
+  annotation (
+    Icon(coordinateSystem(preserveAspectRatio=false)),
+    Diagram(coordinateSystem(preserveAspectRatio=false)),
+    Documentation(info="<html>
+<p>
+Choices for initialization of a state h.
+</p>
+</html>"));

--- a/ThermofluidStream/Undirected/Processes/Internal/PartialConductionElement.mo
+++ b/ThermofluidStream/Undirected/Processes/Internal/PartialConductionElement.mo
@@ -128,17 +128,72 @@ equation
          color={238,46,47})}),
     Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>Undirected implementation of the Conduction Element.</p>
-<p>This model is an element with a fixed volume (fig. 1). The mass in the volume is assumed quasi-stationary (statically computed with volume and density), and the fore massflow is coupled to the rear massflow. <span style=\"color: #f47d23;\">Because of this the ConductionElement cannot be used as a loop breaker</span><span style=\"color: #b83d00;\">. </span>The advantage is that multiple ConductionElements can be put behind each other without worrying about oscillations or fast eigenvalues between their masses. The ConductionElement implements equations for conservation of mass and energy for the fluid mass contained within it.</p>
-<p>Different to the unidirectional ConductionElement, the model for forward massflow (see fig. 1) is valid for both flow directions.</p>
-<p>Additionally the undirected Conduction Element offers more initialization methods for h. Additionally to initialize T or h by a parameter, one can choose to initialize with the incoming enthalpy from either one of the two ports, or use the correct one, depending on the massflow (option &apos;port&apos;). The last option can lead to large nonlinear initialization problems, we advice to choose the port to initialize h from if known in advance (options &apos;rear&apos; or &apos;fore&apos;). </p>
-<p>The ConductionElement makes different assumptions:</p>
+<p>
+Undirected implementation of the Conduction Element.
+</p>
+<p>
+This model is an element with a fixed volume (fig. 1). The mass in the volume is 
+assumed quasi-stationary (statically computed with volume and density), and the 
+fore massflow is coupled to the rear massflow. <strong>Because of this the 
+ConductionElement cannot be used as a loop breaker</strong>.
+The advantage is that multiple ConductionElements can be put behind each other 
+without worrying about oscillations or fast eigenvalues between their masses. 
+The ConductionElement implements equations for conservation of mass and energy 
+for the fluid mass contained within it.
+</p>
+<p>
+Different to the unidirectional ConductionElement, the model for forward massflow
+(see fig. 1) is valid for both flow directions.
+</p>
+<p>
+Additionally the undirected Conduction Element offers more initialization methods 
+for h. Additionally to initialize T or h by a parameter, one can choose to 
+initialize with the incoming enthalpy from either one of the two ports, or use the 
+correct one, depending on the massflow (option &apos;port&apos;). The last option 
+can lead to large nonlinear initialization problems, we advice to choose the port 
+to initialize h from if known in advance (options &apos;rear&apos; or &apos;fore&apos;).
+</p>
+<p>
+The ConductionElement makes different assumptions:
+</p>
 <ul>
-<li>Quasistationary Mass:<br>m_flow_rear = - m_flow_fore &amp; M = rho * V (this assumption violates the conservation of mass for changing densities, since the mass in the element can change although inflow and outflow are the same)<br>der(H) = der(M*h) = M*der(h) (This assumption violates the conservation of energy for changing densities, since then the mass M of fluid in the element is no longer constant)</li>
-<li>Neglection of der(p) in the energy equation<br>V*der(p) = 0 (this assumption violates the conservation of energy for changing pressures. For a noticable difference in the testcase the der(p) must be in the order of 1e5 Pa/s). <br>This assumption can be turned off by setting neglectPressureChanges=false (true by default) in the Advanced tab. <span style=\"color: #f47d23;\">This option requires the fore and rear input pressures to be smooth.</span><br></li>
+  <li>
+    Quasistationary Mass:
+    <br>
+    m_flow_rear = - m_flow_fore &amp; M = rho * V
+    (this assumption violates the conservation of mass for changing densities,
+    since the mass in the element can change although inflow and outflow are the
+    same)
+    <br>
+    der(H) = der(M*h) = M*der(h)
+    (This assumption violates the conservation of energy for changing densities,
+    since then the mass M of fluid in the element is no longer constant)
+  </li>
+  <li>
+    Neglection of der(p) in the energy equation
+    <br>
+    V*der(p) = 0
+    (this assumption violates the conservation of energy for changing pressures.
+    For a noticable difference in the testcase the der(p) must be in the
+    order of 1e5 Pa/s).
+    <br>
+    This assumption can be turned off by setting neglectPressureChanges=false
+    (true by default) in the Advanced tab. <strong>This option requires the 
+    fore and rear input pressures to be smooth.</strong>
+  </li>
 </ul>
-<p>Due to these assumptions minor violations in the global energy conservation can occur. With the flag enforce_global_energy_conservation in the &quot;Advanced&quot; tab is set true (Default: false), long-term energy storage in the ConductionElement is sacrificed to hold global energy conservation.</p>
-<p><img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.ConductionElement_positive.png\"/></p>
-<p>fig. 1: positive massflow model</p>
+<p>
+Due to these assumptions minor violations in the global energy conservation can 
+occur.
+With the flag enforce_global_energy_conservation in the &quot;Advanced&quot; tab 
+is set true (Default: false), long-term energy storage in the ConductionElement 
+is sacrificed to hold global energy conservation.
+</p>
+<div>
+<img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.ConductionElement_positive.png\"/>
+</div>
+<p>
+fig. 1: positive massflow model
+</p>
 </html>"));
 end PartialConductionElement;

--- a/ThermofluidStream/Undirected/Processes/Tests/ConductionElement.mo
+++ b/ThermofluidStream/Undirected/Processes/Tests/ConductionElement.mo
@@ -6,7 +6,10 @@ model ConductionElement "Test for ConductionElement"
     constrainedby Media.myMedia.Interfaces.PartialMedium
     "Medium Model"
     annotation(choicesAllMatching=true, Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Medium Model for the test. Be aware that the Component is mainly ment for liquids with low compressablility.</span></p>
+<p>
+Medium Model for the test. Be aware that the Component is mainly
+ment for liquids with low compressablility.
+</p>
 </html>"));
 
   ThermofluidStream.Undirected.Processes.ConductionElement conductionElement(

--- a/ThermofluidStream/Undirected/Processes/Tests/TransportDelay.mo
+++ b/ThermofluidStream/Undirected/Processes/Tests/TransportDelay.mo
@@ -5,7 +5,9 @@ model TransportDelay "Test for transport delay"
   replaceable package Medium = Media.myMedia.Air.DryAirNasa
     constrainedby Media.myMedia.Interfaces.PartialMedium "Medium Model"
     annotation (Documentation(info="<html>
-<p><span style=\"font-size: 12pt;\">Medium model for the test. Can be anything. </span></p>
+<p>
+Medium model for the test. Can be anything.
+</p>
 </html>"));
 
   ThermofluidStream.Processes.TransportDelay transportDelay(
@@ -19,8 +21,8 @@ model TransportDelay "Test for transport delay"
     r=100,
     l(displayUnit="mm") = 0.008,
     redeclare function pLoss =
-        ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss
-        (k=1e4))
+        ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+      k=1e4))
     annotation (Placement(transformation(extent={{-10,30},{10,50}})));
 
   ThermofluidStream.Boundaries.Sink sink(redeclare package Medium = Medium,
@@ -61,8 +63,8 @@ model TransportDelay "Test for transport delay"
     r=100,
     l(displayUnit="mm") = 0.008,
     redeclare function pLoss =
-        ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss
-        (k=1e4))
+        ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+      k=1e4))
     annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
   Boundaries.BoundaryFore boundary_fore(redeclare package Medium = Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{70,-50},{90,-30}})));
@@ -70,8 +72,7 @@ model TransportDelay "Test for transport delay"
     redeclare package Medium = Medium,
     temperatureFromInput=true,
     pressureFromInput=true) annotation (Placement(transformation(extent={{-48,-50},{-28,-30}})));
-  Modelica.Blocks.Sources.Trapezoid
-                               trapezoid1(
+  Modelica.Blocks.Sources.Trapezoid trapezoid1(
     amplitude=-6e3,
     rising=0.2,
     width=0.2,

--- a/ThermofluidStream/Undirected/Topology/JunctionRFF.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRFF.mo
@@ -77,6 +77,8 @@ equation
           textString="B")}), Diagram(coordinateSystem(preserveAspectRatio=
             false)),
     Documentation(info="<html>
-<p><span style=\"font-family: MS Shell Dlg 2;\">Junction with a rear and two fores in a lying T shape.</span></p>
+<p>
+Junction with a rear and two fores in a lying T shape.
+</p>
 </html>"));
 end JunctionRFF;

--- a/ThermofluidStream/UserGuide/License/package.mo
+++ b/ThermofluidStream/UserGuide/License/package.mo
@@ -30,7 +30,7 @@ If you have used this library for your publication, please cite the following tw
     Zimmer, Dirk (2020).
     &quot;Robust object-oriented formulation of directed thermofluid stream networks&quot;.
     In: Mathematical and Computer Modelling of Dynamical Systems 26.3, pp. 204&ndash; 233.
-    <span style=\"font-size: 8pt;\">DOI</span>: 10.1080/13873954.2020.1757726.
+    DOI: 10.1080/13873954.2020.1757726.
   </li>
   <li>
     Zimmer, Dirk, Michael Mei&szlig;ner, Niels Weber (in review 2021).

--- a/ThermofluidStream/Utilities/Types.mo
+++ b/ThermofluidStream/Utilities/Types.mo
@@ -7,17 +7,26 @@ package Types "Types that are not units needed."
       steadyState,
       none)
     "Choices for Initialization of a state."
-    annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
-          coordinateSystem(preserveAspectRatio=false)),
+    annotation (
+      Icon(coordinateSystem(preserveAspectRatio=false)),
+      Diagram(
+        coordinateSystem(preserveAspectRatio=false)),
       Documentation(info="<html>
-<p><span style=\"font-family: Courier New;\">Choices for Initialization of a state.</span></p>
-<p><br><span style=\"font-family: Courier New;\">These are:</span></p>
-<p><span style=\"font-family: Courier New;\">&quot;state&quot;: initialize a state with a value</span></p>
-<p><span style=\"font-family: Courier New;\">&quot;derivative&quot;: initialize the derivative of a state with a value</span></p>
-<p><span style=\"font-family: Courier New;\">&quot;none&quot;: no initialization for this state</span></p>
-<p><span style=\"font-family: Courier New;\">&quot;steadyState&quot;: zero derivative</span></p>
+<p>
+Choices for Initialization of a state. These are:
+</p>
+<ul>
+  <li><code>state</code>: initialize a state with a value</li>
+  <li><code>derivative</code>: initialize the derivative of a state with a value</li>
+  <li><code>none</code>: no initialization for this state</li>
+  <li><code>steadyState</code>: zero derivative</li>
+</ul>
 </html>"));
+
   annotation (Documentation(info="<html>
-<p>Types that are not units needed for Thermofluid simulation. Unit types should be defined not here but in Utilities.Units.</p>
+<p>
+Types that are not units needed for Thermofluid simulation.
+Unit types should be defined not here but in Utilities.Units.
+</p>
 </html>"));
 end Types;


### PR DESCRIPTION
Mostly replaced by 'strong' or 'code' - depending on model documentation's text.