### PR TITLE
Soften automatic labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,49 +7,49 @@ CI:
 - any: ['.github/**/*']
 
 p::Boundaries:
-- all: ['ThermofluidStream/Boundaries/**/*.mo']
-- all: ['ThermofluidStream/Undirected/Boundaries/**/*.mo']
+- any: ['ThermofluidStream/Boundaries/**/*.mo']
+- any: ['ThermofluidStream/Undirected/Boundaries/**/*.mo']
 
 p::Examples:
 - all: ['ThermofluidStream/Examples/**/*.mo']
 
 p::FlowControl:
-- all: ['ThermofluidStream/FlowControl/**/*.mo']
-- all: ['ThermofluidStream/Undirected/FlowControl/**/*.mo']
+- any: ['ThermofluidStream/FlowControl/**/*.mo']
+- any: ['ThermofluidStream/Undirected/FlowControl/**/*.mo']
 
 p::HeatExchangers:
-- all: ['ThermofluidStream/HeatExchangers/**/*.mo']
-- all: ['ThermofluidStream/Undirected/HeatExchangers/**/*.mo']
+- any: ['ThermofluidStream/HeatExchangers/**/*.mo']
+- any: ['ThermofluidStream/Undirected/HeatExchangers/**/*.mo']
 
 p::Interfaces:
-- all: ['ThermofluidStream/Interfaces/**/*.mo']
-- all: ['ThermofluidStream/Undirected/Interfaces/**/*.mo']
+- any: ['ThermofluidStream/Interfaces/**/*.mo']
+- any: ['ThermofluidStream/Undirected/Interfaces/**/*.mo']
 
 p::Internal:
-- all: ['ThermofluidStream/Undirected/Internal/**/*.mo']
+- any: ['ThermofluidStream/Undirected/Internal/**/*.mo']
 
 p::Media:
-- all: ['ThermofluidStream/Media/**/*.mo']
+- any: ['ThermofluidStream/Media/**/*.mo']
 
 p::Processes:
-- all: ['ThermofluidStream/Processes/**/*.mo']
-- all: ['ThermofluidStream/Undirected/Processes/**/*.mo']
+- any: ['ThermofluidStream/Processes/**/*.mo']
+- any: ['ThermofluidStream/Undirected/Processes/**/*.mo']
 
 d::Resources:
 - all: ['ThermofluidStream/Resources/**/*']
 
 p::Sensors:
-- all: ['ThermofluidStream/Sensors/**/*.mo']
-- all: ['ThermofluidStream/Undirected/Sensors/**/*.mo']
+- any: ['ThermofluidStream/Sensors/**/*.mo']
+- any: ['ThermofluidStream/Undirected/Sensors/**/*.mo']
 
 p::Topology:
-- all: ['ThermofluidStream/Topology/**/*.mo']
-- all: ['ThermofluidStream/Undirected/Topology/**/*.mo']
+- any: ['ThermofluidStream/Topology/**/*.mo']
+- any: ['ThermofluidStream/Undirected/Topology/**/*.mo']
 
 p::UsersGuide:
 - all: ['ThermofluidStream/UsersGuide/**/*.mo']
 
 p::Utilities:
-- all: ['ThermofluidStream/Utilities/**/*.mo']
+- any: ['ThermofluidStream/Utilities/**/*.mo']
 
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true
+          sync-labels: false


### PR DESCRIPTION
Labels are set when ANY matching file of corresponding package is changed, except for Examples, Resources and UsersGuide where ALL files must still match.
