### PR TITLE
Omit potentially problematic link to tandfonline.com setting a direct DOI link

### DIFF
--- a/ThermofluidStream/UsersGuide/References.mo
+++ b/ThermofluidStream/UsersGuide/References.mo
@@ -25,8 +25,8 @@ class References "References"
     Zimmer, Dirk (2020).
     &quot;Robust object-oriented formulation of directed thermofluid stream networks&quot;.
     In: Mathematical and Computer Modelling of Dynamical Systems 26.3, pp. 204&ndash; 233.
-    DOI: 10.1080/13873954.2020.1757726. <br>
-    <a href=\"https://www.tandfonline.com/doi/full/10.1080/13873954.2020.1757726\">https://www.tandfonline.com/doi/full/10.1080/13873954.2020.1757726</a>
+    DOI: 
+    <a href=\"https://doi.org/10.1080/13873954.2020.1757726\">10.1080/13873954.2020.1757726</a>.
   </li>
   <li>
     Zimmer, Dirk, Michael Mei&szlig;ner, Niels Weber (2021).


### PR DESCRIPTION
Former git action message:
> Run python ./.CI/check_html.py checkLinks ./
  File "./ThermofluidStream/UsersGuide/References.mo": Error 403 for URL "    https://www.tandfonline.com/doi/full/10.1080/13873954.2020.1757726"
  Error: Process completed with exit code 1.