### PR TITLE
Source sink flow asserts

### DIFF
--- a/ThermofluidStream/Boundaries/Sink.mo
+++ b/ThermofluidStream/Boundaries/Sink.mo
@@ -13,6 +13,8 @@ the outlet the sink is connected to.
     annotation(Dialog(enable = not pressureFromInput));
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance of pressure"
     annotation (Dialog(tab="Advanced"));
+  parameter SI.MassFlowRate m_flow_assert(max=0) = -dropOfCommons.m_flow_reg "Assertion threshold for negative massflows"
+    annotation(Dialog(tab="Advanced"));
 
   Interfaces.Inlet inlet(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
@@ -36,6 +38,8 @@ protected
   SI.Pressure p = Medium.pressure(inlet.state);
 
 equation
+  assert(inlet.m_flow > m_flow_assert, "Negative massflow at Sink inlet", dropOfCommons.assertionLevel);
+  
   if not pressureFromInput then
     p0 = p0_par;
   end if;

--- a/ThermofluidStream/Boundaries/Sink.mo
+++ b/ThermofluidStream/Boundaries/Sink.mo
@@ -38,7 +38,7 @@ protected
   SI.Pressure p = Medium.pressure(inlet.state);
 
 equation
-  assert(inlet.m_flow > m_flow_assert, "Negative massflow at Sink inlet", dropOfCommons.assertionLevel);
+  assert(inlet.m_flow > m_flow_assert, "Negative mass flow at sink inlet", dropOfCommons.assertionLevel);
   
   connect(p0_var, p0);
   if not pressureFromInput then

--- a/ThermofluidStream/Boundaries/Sink.mo
+++ b/ThermofluidStream/Boundaries/Sink.mo
@@ -13,7 +13,7 @@ the outlet the sink is connected to.
     annotation(Dialog(enable = not pressureFromInput));
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance of pressure"
     annotation (Dialog(tab="Advanced"));
-  parameter SI.MassFlowRate m_flow_assert(max=0) = -dropOfCommons.m_flow_reg "Assertion threshold for negative massflows"
+  parameter SI.MassFlowRate m_flow_assert(max=0) = -dropOfCommons.m_flow_reg "Assertion threshold for negative mass flows"
     annotation(Dialog(tab="Advanced"));
 
   Interfaces.Inlet inlet(redeclare package Medium = Medium)

--- a/ThermofluidStream/Boundaries/Sink.mo
+++ b/ThermofluidStream/Boundaries/Sink.mo
@@ -13,7 +13,7 @@ the outlet the sink is connected to.
     annotation(Dialog(enable = not pressureFromInput));
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance of pressure"
     annotation (Dialog(tab="Advanced"));
-  parameter SI.MassFlowRate m_flow_assert(max=0) = -dropOfCommons.m_flow_reg "Assertion threshold for negative mass flows"
+  parameter SI.MassFlowRate m_flow_assert(max=0) = -dropOfCommons.m_flow_reg "Assertion threshold for negative mass flow"
     annotation(Dialog(tab="Advanced"));
 
   Interfaces.Inlet inlet(redeclare package Medium = Medium)

--- a/ThermofluidStream/Boundaries/Source.mo
+++ b/ThermofluidStream/Boundaries/Source.mo
@@ -27,6 +27,8 @@ the inlet the source is connected to.
     annotation(Dialog(enable = not xiFromInput));
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance"
     annotation (Dialog(tab="Advanced"));
+  parameter SI.MassFlowRate m_flow_assert(max=0) = -dropOfCommons.m_flow_reg "Assertion threshold for negative massflows"
+    annotation(Dialog(tab="Advanced"));
 
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa")= p0 if pressureFromInput "Pressure input connector [Pa]"
     annotation (Placement(transformation(extent={{-40,40},{0,80}}), iconTransformation(extent={{-40,40},{0,80}})));
@@ -48,6 +50,7 @@ protected
   Medium.MassFraction Xi0[Medium.nXi];
 
 equation
+   assert(-outlet.m_flow > m_flow_assert, "Positive massflow at Source outlet", dropOfCommons.assertionLevel);
 
    if not temperatureFromInput then
      T0 = T0_par;

--- a/ThermofluidStream/Boundaries/Source.mo
+++ b/ThermofluidStream/Boundaries/Source.mo
@@ -50,7 +50,7 @@ protected
   Modelica.Blocks.Interfaces.RealInput Xi0[Medium.nXi](each unit = "kg/kg") "Internal mass fraction connector";
 
 equation
-   assert(-outlet.m_flow > m_flow_assert, "Positive massflow at Source outlet", dropOfCommons.assertionLevel);
+   assert(-outlet.m_flow > m_flow_assert, "Positive mass flow at source outlet", dropOfCommons.assertionLevel);
 
    connect(T0_var, T0);
    if not temperatureFromInput or setEnthalpy then

--- a/ThermofluidStream/Boundaries/Source.mo
+++ b/ThermofluidStream/Boundaries/Source.mo
@@ -27,7 +27,7 @@ the inlet the source is connected to.
     annotation(Dialog(enable = not xiFromInput));
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance"
     annotation (Dialog(tab="Advanced"));
-  parameter SI.MassFlowRate m_flow_assert(max=0) = -dropOfCommons.m_flow_reg "Assertion threshold for negative massflows"
+  parameter SI.MassFlowRate m_flow_assert(max=0) = -dropOfCommons.m_flow_reg "Assertion threshold for negative mass flow"
     annotation(Dialog(tab="Advanced"));
 
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"

--- a/ThermofluidStream/Examples/EspressoMachine.mo
+++ b/ThermofluidStream/Examples/EspressoMachine.mo
@@ -88,7 +88,8 @@ Medium model for water.
   Boundaries.Source source1(
     redeclare package Medium = Water,
     T0_par=298.15,
-    p0_par=100000)
+    p0_par=100000,
+    m_flow_assert=-3*dropOfCommons.m_flow_reg)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=0,
         origin={-140,-120})));


### PR DESCRIPTION
This adds to the Source and Sink components an assert on m_flow direction
similar to what is already in the PartialVolume components.

Some models in Examples such as SimpleStream and WaterHammer do
not have volumes so without this commit there is no check for invalid
mass flow direction when users modify the models. This also catches a
mass flow reversal in the EspressoMachine example that is larger than
the default threshold, so the threshold for that example has been
increased so there is no assert.

With this commit, some topologies may still have invalid flow direction
without an assert. To make a complete check, the SISOFlow or Inlet
and Outlet connectors need an assert, but that will lead to many more
assert messages. This commit is a compromise to catch most errors
with fewer messages.