### PR TITLE
Fix some words to be of American English

### DIFF
--- a/ThermofluidStream/Boundaries/Tests/Volumes.mo
+++ b/ThermofluidStream/Boundaries/Tests/Volumes.mo
@@ -427,7 +427,7 @@ equation
                                                                  Diagram(
         coordinateSystem(preserveAspectRatio=false, extent={{-100,-200},{100,200}})),
         Documentation(info="<html>
-<p>This test purposely violates the asserts for reversed mass-flows to test the behaviour of volumes for prolonged reversed massflow for some of the volumes. The assert is set to warning.</p>
+<p>This test purposely violates the asserts for reversed mass-flows to test the behavior of volumes for prolonged reversed massflow for some of the volumes. The assert is set to warning.</p>
 <p><br>Owner: <a href=\"mailto:michael.meissner@dlr.de\">Michael Mei&szlig;ner</a></p>
 </html>"));
 end Volumes;

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -96,7 +96,7 @@ equation
           origin={0,-20},
           rotation=180)}), Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
-<p>This valve models the behaviour of specific valve types.</p>
+<p>This valve models the behavior of specific valve types.</p>
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>

--- a/ThermofluidStream/HeatExchangers/Internal/PartialNTU.mo
+++ b/ThermofluidStream/HeatExchangers/Internal/PartialNTU.mo
@@ -24,7 +24,7 @@ partial model PartialNTU "Base heat exchanger using the epsilon-NTU method"
   parameter Modelica.Units.SI.Area A "Conductive Surface";
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance of the flow" annotation (Dialog(tab="Advanced"));
   parameter Modelica.Units.SI.CoefficientOfHeatTransfer k_NTU=50 "Overall heat transfer coefficient";
-  parameter Modelica.Units.SI.MassFlowRate m_flow_reg=dropOfCommons.m_flow_reg "Nominal mass flow for regularisation" annotation (Dialog(tab="Advanced", group="Regularisation parameters"));
+  parameter Modelica.Units.SI.MassFlowRate m_flow_reg=dropOfCommons.m_flow_reg "Nominal mass flow for regularization" annotation (Dialog(tab="Advanced", group="Regularization parameters"));
   parameter Modelica.Units.SI.Time TC=0.01 "Time constant for dh" annotation (Dialog(tab="Advanced"));
 
   Modelica.Units.SI.TemperatureDifference Delta_T_max "Maximum Temperature Difference";
@@ -134,7 +134,7 @@ equation
 
   if noEvent(C_A < C_B) then
 
-    //if both mass flows are smaller than regularisation mass flow, no heat is transferred
+    //if both mass flows are smaller than regularization mass flow, no heat is transferred
     if noEvent(inletA.m_flow < m_flow_reg) and noEvent(inletB.m_flow < m_flow_reg) then
       dh_A = 0;
     else
@@ -144,7 +144,7 @@ equation
     q_flowA = m_flow_A*dh_A;
     q_flowB = -q_flowA;
 
-    //Based on regularisation for mass flow
+    //Based on regularization for mass flow
     dh_B = (m_flow_B*q_flowB)/(m_flow_B^2 + (m_flow_reg/10)^2);
 
     der(h_out_A)*TC = h_in_A - dh_A - h_out_A;
@@ -152,7 +152,7 @@ equation
 
   else
 
-    //if both mass flows are smaller than regularisation mass flow, no heat is transferred
+    //if both mass flows are smaller than regularization mass flow, no heat is transferred
     if noEvent(inletA.m_flow < m_flow_reg) and noEvent(inletB.m_flow < m_flow_reg) then
       dh_B = 0;
     else
@@ -162,7 +162,7 @@ equation
     q_flowB = m_flow_B*dh_B;
     q_flowA = -q_flowB;
 
-    //Based on regularisation for mass flow
+    //Based on regularization for mass flow
     dh_A = (m_flow_A*q_flowA)/(m_flow_A^2 + (m_flow_reg/10)^2);
 
     der(h_out_A)*TC = h_in_A - dh_A - h_out_A;

--- a/ThermofluidStream/Processes/TransportDelay.mo
+++ b/ThermofluidStream/Processes/TransportDelay.mo
@@ -58,7 +58,7 @@ equation
   h_out = u_out + p_out * v_out;
   Xi_out = Xi_in;
   annotation (Documentation(info="<html>
-<p>Delays the temperature and massFraction, not pressure, since pressure differences propagate with speed of sound, and since delaying only steady state pressure p not inertial pressure r might lead to undesirable behaviour.</p>
+<p>Delays the temperature and massFraction, not pressure, since pressure differences propagate with speed of sound, and since delaying only steady state pressure p not inertial pressure r might lead to undesirable behavior.</p>
 <p>Note that this component uses the spatialDistribution operator, that has some artefacts (see Fig. 1) for high and low non-dimensional speeds v (possibly due to inerpolation or extrapolation of the function). Therefore minimum and maximum speed in the non-dimensional coordinate x (inlet @ x=0, outlet @ x=1) is limited. The default limits are [0.01, 50], so the delay is limited by default to [0.02s, 100s]. This limit can be adjusted in the advanced parameters tab.</p>
 <p><img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.Tests.TransportDelay_artefacts2.PNG\"/> <img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.Tests.TransportDelay_artefacts.PNG\"/> </p>
 <p style=\"margin-left: 250px;\">Fig. 1: artefacts of the TransportDelay</p>

--- a/ThermofluidStream/Topology/Internal.mo
+++ b/ThermofluidStream/Topology/Internal.mo
@@ -162,5 +162,5 @@ package Internal
       B "Port B",
       OneMinusS "1-s",
       pressureDrop "Pressure Drop")
-      "Choices for the pressure drop behaviour of SplitterRatio";
+      "Choices for the pressure drop behavior of SplitterRatio";
 end Internal;

--- a/ThermofluidStream/Topology/NonPhysical.mo
+++ b/ThermofluidStream/Topology/NonPhysical.mo
@@ -171,7 +171,7 @@ package NonPhysical "Junctions and splitters with non-physical constraints"
 
   annotation (Documentation(info="<html>
 <p>This package contains topology elements that have non-physical assumptions or constraints like mass-flow splits. </p>
-<p>Although they are non-physical they can be used to model certain behaviour like a leakage or mass-flow-split controlled junction-valve combinations and simplify the model by not explicitly modeling the phenomena like a controlled valve.</p>
+<p>Although they are non-physical they can be used to model certain behavior like a leakage or mass-flow-split controlled junction-valve combinations and simplify the model by not explicitly modeling the phenomena like a controlled valve.</p>
 <p>For SplitterRatio and JunctionRatio make to only prescribe mass-flow-split in Splitter <u><strong>or</strong></u> Junction.</p>
 </html>"));
 end NonPhysical;

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -99,7 +99,7 @@ equation
           rotation=180)}), Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
 <p>Undirected implementation of the specific valve type.</p>
-<p>This valve models the behaviour of specific valve types.</p>
+<p>This valve models the behavior of specific valve types.</p>
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>

--- a/ThermofluidStream/Undirected/Processes/TransportDelay.mo
+++ b/ThermofluidStream/Undirected/Processes/TransportDelay.mo
@@ -71,7 +71,7 @@ equation
   Xi_rear_out = Xi_fore_in;
   annotation (Documentation(info="<html>
 <p>Undirected implementation of the transport delay.</p>
-<p>Delays the temperature and massFraction, not pressure, since pressure differences propagate with speed of sound, and since delaying only steady state pressure p not inertial pressure r might lead to undesirable behaviour.</p>
+<p>Delays the temperature and massFraction, not pressure, since pressure differences propagate with speed of sound, and since delaying only steady state pressure p not inertial pressure r might lead to undesirable behavior.</p>
 <p>Note that this component uses the spatialDistribution operator, that has some artefacts (see Fig. 1) for high and low non-dimensional speeds v (possibly due to inerpolation or extrapolation of the function). Therefore minimum and maximum speed in the non-dimensional coordinate x (inlet @ x=0, outlet @ x=1) is limited. The default limits are [0.01, 50], so the delay is limited by default to [0.02s, 100s]. This limit can be adjusted in the advanced parameters tab.</p>
 <p><img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.Tests.TransportDelay_artefacts2.PNG\"/> <img src=\"modelica://ThermofluidStream/Resources/Doku/ThermofluidStream.Processes.Tests.TransportDelay_artefacts.PNG\"/> </p>
 <p style=\"margin-left: 250px;\">Fig. 1: artefacts of the TransportDelay</p>

--- a/ThermofluidStream/package.mo
+++ b/ThermofluidStream/package.mo
@@ -1,5 +1,5 @@
 within ;
-package ThermofluidStream "Library for the Modelling of Thermofluid Streams"
+package ThermofluidStream "Library for the modeling of thermofluid streams"
   extends Modelica.Icons.Package;
 
   import Modelica.Units.SI;


### PR DESCRIPTION
The concerned words are used throughout the library but with different spelling (BE/AE). I tried use AE consistently now.