### PR TITLE
Remove input binding for conditional connectors

### DIFF
--- a/ThermofluidStream/Boundaries/CreateState.mo
+++ b/ThermofluidStream/Boundaries/CreateState.mo
@@ -25,35 +25,42 @@ model CreateState "Create state signal as output"
   Interfaces.StateOutput y(redeclare package Medium = Medium) annotation (
       Placement(transformation(extent={{80,-20},{120,20}}), iconTransformation(
           extent={{80,-20},{120,20}})));
-  Modelica.Blocks.Interfaces.RealInput p_inp(unit="Pa") = p if PFromInput "Input for pressure [Pa]"
+  Modelica.Blocks.Interfaces.RealInput p_inp(unit="Pa") if PFromInput "Input for pressure [Pa]"
     annotation (Placement(transformation(extent={{-120,80},{-80,120}}),
         iconTransformation(extent={{-120,80},{-80,120}})));
-  Modelica.Blocks.Interfaces.RealInput T_inp(unit="K") = T if TFromInput "Input for Temperature [K]"
+  Modelica.Blocks.Interfaces.RealInput T_inp(unit="K") if TFromInput "Input for Temperature [K]"
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
-  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg")= h if hFromInput "Enthalpy input connector [J/kg]"
+  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if hFromInput "Enthalpy input connector [J/kg]"
     annotation (Placement(transformation(extent={{-40,-40},{0,0}}), iconTransformation(extent={{-40,-20},{0,20}})));
-  Modelica.Blocks.Interfaces.RealInput Xi_inp[Medium.nXi](each unit="kg/kg") = Xi if XiFromInput "Vector input for Mass fraction [kg/kg]"
+  Modelica.Blocks.Interfaces.RealInput Xi_inp[Medium.nXi](each unit="kg/kg") if XiFromInput "Vector input for Mass fraction [kg/kg]"
     annotation (Placement(transformation(extent={{-120,-120},{-80,-80}}),
         iconTransformation(extent={{-120,-120},{-80,-80}})));
 
 protected
-  SI.Pressure p;
-  SI.Temperature T;
-  SI.SpecificEnthalpy h;
-  Medium.MassFraction Xi[Medium.nXi];
+  Modelica.Blocks.Interfaces.RealInput p(unit="Pa") "Internal pressure connector";
+  Modelica.Blocks.Interfaces.RealInput T(unit="K") "Internal temperature connector";
+  Modelica.Blocks.Interfaces.RealInput h(unit = "J/kg") "Internal enthalpy connector";
+  Modelica.Blocks.Interfaces.RealInput Xi[Medium.nXi](each unit="kg/kg") "Internal mass fraction connector";
 
 equation
   y.state = if not setEnthalpy then Medium.setState_pTX(p,T,Xi) else Medium.setState_phX(p, h, Xi);
 
+  connect(p_inp, p);
   if not PFromInput then
     p = p_par;
   end if;
+
+  connect(T_inp, T);
   if not TFromInput then
     T = T_par;
   end if;
+
+  connect(h0_var, h);
   if not hFromInput then
     h = h0_par;
   end if;
+
+  connect(Xi_inp, Xi);
   if not XiFromInput then
     Xi = Xi_par;
   end if;

--- a/ThermofluidStream/Boundaries/CreateState.mo
+++ b/ThermofluidStream/Boundaries/CreateState.mo
@@ -28,9 +28,9 @@ model CreateState "Create state signal as output"
   Modelica.Blocks.Interfaces.RealInput p_inp(unit="Pa") if PFromInput "Input for pressure [Pa]"
     annotation (Placement(transformation(extent={{-120,80},{-80,120}}),
         iconTransformation(extent={{-120,80},{-80,120}})));
-  Modelica.Blocks.Interfaces.RealInput T_inp(unit="K") if TFromInput "Input for Temperature [K]"
+  Modelica.Blocks.Interfaces.RealInput T_inp(unit="K") if not setEnthalpy and TFromInput "Input for Temperature [K]"
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
-  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if hFromInput "Enthalpy input connector [J/kg]"
+  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if setEnthalpy and hFromInput "Enthalpy input connector [J/kg]"
     annotation (Placement(transformation(extent={{-40,-40},{0,0}}), iconTransformation(extent={{-40,-20},{0,20}})));
   Modelica.Blocks.Interfaces.RealInput Xi_inp[Medium.nXi](each unit="kg/kg") if XiFromInput "Vector input for Mass fraction [kg/kg]"
     annotation (Placement(transformation(extent={{-120,-120},{-80,-80}}),
@@ -51,12 +51,12 @@ equation
   end if;
 
   connect(T_inp, T);
-  if not TFromInput then
+  if not TFromInput or setEnthalpy then
     T = T_par;
   end if;
 
   connect(h0_var, h);
-  if not hFromInput then
+  if not hFromInput or not setEnthalpy then
     h = h0_par;
   end if;
 

--- a/ThermofluidStream/Boundaries/DynamicPressureInflow.mo
+++ b/ThermofluidStream/Boundaries/DynamicPressureInflow.mo
@@ -16,13 +16,13 @@ model DynamicPressureInflow
   parameter SI.MassFlowRate m_flow_reg = dropOfCommons.m_flow_reg "Regularization threshold of mass flow rate"
     annotation(Dialog(tab="Advanced", group="Regularization", enable = not extrapolateQuadratic));
 
-  Modelica.Blocks.Interfaces.RealInput A_var(unit = "m2") = A if areaFromInput "Area input connector [m2]" annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealInput A_var(unit = "m2") if areaFromInput "Area input connector [m2]" annotation (Placement(transformation(
           extent={{-20,-20},{20,20}},
         rotation=270,
         origin={60,100}), iconTransformation(extent={{-20,-20},{20,20}},
         rotation=270,
         origin={60,100})));
-  Modelica.Blocks.Interfaces.RealInput v_in_var(unit="m/s")=v_in if velocityFromInput "Velocity input connector [m/s]" annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealInput v_in_var(unit="m/s") if velocityFromInput "Velocity input connector [m/s]" annotation (Placement(transformation(
           extent={{-20,-20},{20,20}},
         rotation=270,
         origin={0,100}), iconTransformation(extent={{-20,-20},{20,20}},
@@ -30,9 +30,9 @@ model DynamicPressureInflow
         origin={0,100})));
 
 protected
-  SI.Area A "Cross-section area of inlet boundary";
+  Modelica.Blocks.Interfaces.RealInput A(unit = "m2") "Internal connector for cross-section area of inlet boundary";
 
-  SI.Velocity v_in "Reference velocity for p0. Positive velocity points from outside the boundary to inside";
+  Modelica.Blocks.Interfaces.RealInput v_in(unit="m/s") "Internal connector for reference velocity";
   SI.Velocity v_out;
 
   SI.Density rho_in =  Medium.density(inlet.state) "density of medium entering";
@@ -42,10 +42,13 @@ protected
   SI.Velocity delta_v;
 
 equation
+
+   connect(A_var, A);
    if not areaFromInput then
      A = A_par;
    end if;
 
+   connect(v_in_var, v_in);
    if not velocityFromInput then
      v_in = v_in_par;
    end if;

--- a/ThermofluidStream/Boundaries/DynamicPressureOutflow.mo
+++ b/ThermofluidStream/Boundaries/DynamicPressureOutflow.mo
@@ -16,13 +16,13 @@ model DynamicPressureOutflow
   parameter SI.MassFlowRate m_flow_reg = dropOfCommons.m_flow_reg "Regularization threshold of mass flow rate"
     annotation(Dialog(tab="Advanced", group="Regularization", enable = not extrapolateQuadratic));
 
-  Modelica.Blocks.Interfaces.RealInput A_var(unit = "m2") = A if areaFromInput "Area input connector [m2]" annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealInput A_var(unit = "m2") if areaFromInput "Area input connector [m2]" annotation (Placement(transformation(
           extent={{-20,-20},{20,20}},
         rotation=270,
         origin={0,100}), iconTransformation(extent={{-20,-20},{20,20}},
         rotation=270,
         origin={0,100})));
-  Modelica.Blocks.Interfaces.RealInput v_out_var(unit="m/s")=v_out if velocityFromInput "Velocity input connector [m/s]" annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealInput v_out_var(unit="m/s") if velocityFromInput "Velocity input connector [m/s]" annotation (Placement(transformation(
           extent={{-20,-20},{20,20}},
         rotation=270,
         origin={-60,100}), iconTransformation(extent={{-20,-20},{20,20}},
@@ -30,10 +30,10 @@ model DynamicPressureOutflow
         origin={-60,100})));
 
 protected
-  SI.Area A "Cross-section area of outlet boundary";
+  Modelica.Blocks.Interfaces.RealInput A(unit = "m2") "Internal connector for cross-section area of inlet boundary";
 
   SI.Velocity v_in;
-  SI.Velocity v_out "Reference velocity for p0. Positive velocity points from inside the boundary to outside";
+  Modelica.Blocks.Interfaces.RealInput v_out(unit="m/s") "Internal connector for reference velocity";
 
   SI.Density rho_in =  Medium.density(inlet.state) "density of medium entering";
   SI.Density rho_out "density of medium exiting";
@@ -42,10 +42,12 @@ protected
   SI.Velocity delta_v;
 
 equation
+   connect(A_var, A);
    if not areaFromInput then
      A = A_par;
    end if;
 
+   connect(v_out_var, v_out);
    if not velocityFromInput then
      v_out = v_out_par;
    end if;
@@ -75,7 +77,7 @@ equation
   Xi_out = Xi_in;
 
   annotation (
-  	Icon(graphics={
+   Icon(graphics={
         Rectangle(
           extent={{-58,76},{6,-84}},
           lineColor={28,108,200},

--- a/ThermofluidStream/Boundaries/Sink.mo
+++ b/ThermofluidStream/Boundaries/Sink.mo
@@ -31,7 +31,6 @@ protected
   outer DropOfCommons dropOfCommons;
 
   Modelica.Blocks.Interfaces.RealInput p0(unit="Pa") "Internal pressure connector";
-  //SI.Pressure p0;
   SI.Pressure r;
 
   SI.Pressure p = Medium.pressure(inlet.state);

--- a/ThermofluidStream/Boundaries/Sink.mo
+++ b/ThermofluidStream/Boundaries/Sink.mo
@@ -17,7 +17,7 @@ the outlet the sink is connected to.
   Interfaces.Inlet inlet(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
 
-  Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa")=p0 if pressureFromInput "Pressure setpoint [Pa]"
+  Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure setpoint [Pa]"
     annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},
@@ -30,12 +30,15 @@ the outlet the sink is connected to.
 protected
   outer DropOfCommons dropOfCommons;
 
-  SI.Pressure p0;
+  Modelica.Blocks.Interfaces.RealInput p0(unit="Pa") "Internal pressure connector";
+  //SI.Pressure p0;
   SI.Pressure r;
 
   SI.Pressure p = Medium.pressure(inlet.state);
 
 equation
+
+  connect(p0_var, p0);
   if not pressureFromInput then
     p0 = p0_par;
   end if;

--- a/ThermofluidStream/Boundaries/Source.mo
+++ b/ThermofluidStream/Boundaries/Source.mo
@@ -30,9 +30,9 @@ the inlet the source is connected to.
 
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
     annotation (Placement(transformation(extent={{-40,40},{0,80}}), iconTransformation(extent={{-40,40},{0,80}})));
-  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if temperatureFromInput "Temperature input connector [K]"
+  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if not setEnthalpy and temperatureFromInput "Temperature input connector [K]"
     annotation (Placement(transformation(extent={{-40,0},{0,40}}), iconTransformation(extent={{-40,-20},{0,20}})));
-  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if enthalpyFromInput "Enthalpy input connector [J/kg]"
+  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if setEnthalpy and enthalpyFromInput "Enthalpy input connector [J/kg]"
     annotation (Placement(transformation(extent={{-40,-40},{0,0}}), iconTransformation(extent={{-40,-20},{0,20}})));
   Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fraction connector [kg/kg]"
     annotation (Placement(transformation(extent={{-40,-80},{0,-40}}), iconTransformation(extent={{-40,-80},{0,-40}})));
@@ -50,7 +50,7 @@ protected
 equation
 
    connect(T0_var, T0);
-   if not temperatureFromInput then
+   if not temperatureFromInput or setEnthalpy then
      T0 = T0_par;
    end if;
 
@@ -65,7 +65,7 @@ equation
    end if;
 
    connect(h0_var, h0);
-   if not enthalpyFromInput then
+   if not enthalpyFromInput or not setEnthalpy then
      h0 = h0_par;
    end if;
 

--- a/ThermofluidStream/Boundaries/Source.mo
+++ b/ThermofluidStream/Boundaries/Source.mo
@@ -28,13 +28,13 @@ the inlet the source is connected to.
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance"
     annotation (Dialog(tab="Advanced"));
 
-  Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa")= p0 if pressureFromInput "Pressure input connector [Pa]"
+  Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
     annotation (Placement(transformation(extent={{-40,40},{0,80}}), iconTransformation(extent={{-40,40},{0,80}})));
-  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") = T0 if temperatureFromInput "Temperature input connector [K]"
+  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if temperatureFromInput "Temperature input connector [K]"
     annotation (Placement(transformation(extent={{-40,0},{0,40}}), iconTransformation(extent={{-40,-20},{0,20}})));
-  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg")= h0 if enthalpyFromInput "Enthalpy input connector [J/kg]"
+  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if enthalpyFromInput "Enthalpy input connector [J/kg]"
     annotation (Placement(transformation(extent={{-40,-40},{0,0}}), iconTransformation(extent={{-40,-20},{0,20}})));
-  Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg")= Xi0 if xiFromInput "Mass fraction connector [kg/kg]"
+  Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fraction connector [kg/kg]"
     annotation (Placement(transformation(extent={{-40,-80},{0,-40}}), iconTransformation(extent={{-40,-80},{0,-40}})));
   Interfaces.Outlet outlet(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{80,-20},{120,20}})));
@@ -42,25 +42,34 @@ the inlet the source is connected to.
 protected
   outer DropOfCommons dropOfCommons;
 
-  SI.Temperature T0;
-  SI.Pressure p0;
-  SI.SpecificEnthalpy h0;
-  Medium.MassFraction Xi0[Medium.nXi];
+  Modelica.Blocks.Interfaces.RealInput p0(unit="Pa") "Internal pressure connector";
+  Modelica.Blocks.Interfaces.RealInput T0(unit = "K") "Internal temperature connector";
+  Modelica.Blocks.Interfaces.RealInput h0(unit = "J/kg") "Internal enthalpy connector";
+  Modelica.Blocks.Interfaces.RealInput Xi0[Medium.nXi](each unit = "kg/kg") "Internal mass fraction connector";
+
+  //SI.Temperature T0;
+  //SI.Pressure p0;
+  //SI.SpecificEnthalpy h0;
+  //Medium.MassFraction Xi0[Medium.nXi];
 
 equation
 
+   connect(T0_var, T0);
    if not temperatureFromInput then
      T0 = T0_par;
    end if;
 
+   connect(p0_var, p0);
    if not pressureFromInput then
      p0 = p0_par;
    end if;
 
+   connect(xi_var, Xi0);
    if not xiFromInput then
      Xi0 = Xi0_par;
    end if;
 
+   connect(h0_var, h0);
    if not enthalpyFromInput then
      h0 = h0_par;
    end if;

--- a/ThermofluidStream/Boundaries/Source.mo
+++ b/ThermofluidStream/Boundaries/Source.mo
@@ -47,11 +47,6 @@ protected
   Modelica.Blocks.Interfaces.RealInput h0(unit = "J/kg") "Internal enthalpy connector";
   Modelica.Blocks.Interfaces.RealInput Xi0[Medium.nXi](each unit = "kg/kg") "Internal mass fraction connector";
 
-  //SI.Temperature T0;
-  //SI.Pressure p0;
-  //SI.SpecificEnthalpy h0;
-  //Medium.MassFraction Xi0[Medium.nXi];
-
 equation
 
    connect(T0_var, T0);

--- a/ThermofluidStream/FlowControl/MCV.mo
+++ b/ThermofluidStream/FlowControl/MCV.mo
@@ -5,7 +5,7 @@ model MCV "Massflow and volume control valve"
 
   import Mode = ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode;
 
-  Modelica.Blocks.Interfaces.RealInput setpoint_var = setpoint if setpointFromInput "Desired mass-flow [kg/s or m3/s]"
+  Modelica.Blocks.Interfaces.RealInput setpoint_var if setpointFromInput "Desired mass-flow [kg/s or m3/s]"
     annotation (Placement(
         transformation(extent={{-20,-20},{20,20}},
         rotation=270,
@@ -49,7 +49,7 @@ protected
 
   SI.MassFlowRate m_flow_set;
   SI.VolumeFlowRate V_flow_set;
-  Real setpoint;
+  Modelica.Blocks.Interfaces.RealInput setpoint "Internal setpoint connector";
 
   SI.Pressure dr = outlet.r - inlet.r;
   SI.Pressure dr_set;
@@ -62,6 +62,7 @@ initial equation
   dp_int = 0;
 
 equation
+  connect(setpoint_var, setpoint);
   if setpointFromInput then
     m_flow_set = setpoint;
     V_flow_set = setpoint;

--- a/ThermofluidStream/FlowControl/PCV.mo
+++ b/ThermofluidStream/FlowControl/PCV.mo
@@ -4,7 +4,7 @@ model PCV "Pressure and pressure-drop control valve"
 
   import Mode = ThermofluidStream.FlowControl.Internal.Types.PressureControlValveMode;
 
-  Modelica.Blocks.Interfaces.RealInput pressure_set_var(unit="Pa") = pressure_set if pressureFromInput "Output pressure [Pa]"
+  Modelica.Blocks.Interfaces.RealInput pressure_set_var(unit="Pa") if pressureFromInput "Output pressure [Pa]"
     annotation (Placement(
         transformation(extent={{-20,-20},{20,20}},
         rotation=270,
@@ -21,10 +21,11 @@ model PCV "Pressure and pressure-drop control valve"
     annotation(Dialog(tab="Advanced"));
 
 protected
-  SI.AbsolutePressure pressure_set;
+  Modelica.Blocks.Interfaces.RealInput pressure_set(unit="Pa") "Internal pressure connector";
   SI.Pressure dp_raw "Not normalized desired dp";
 
 equation
+  connect(pressure_set_var, pressure_set);
   if not pressureFromInput then
     pressure_set = pressure_set_par;
   end if;

--- a/ThermofluidStream/Undirected/Boundaries/BoundaryFore.mo
+++ b/ThermofluidStream/Undirected/Boundaries/BoundaryFore.mo
@@ -25,10 +25,10 @@ model BoundaryFore "Generic Boundary model (may act as source or sink)"
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,60}),
       iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,60})));
-  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if temperatureFromInput "Temperature input connector [K]"
+  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if not setEnthalpy and temperatureFromInput "Temperature input connector [K]"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,20}),
       iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,0})));
-  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if enthalpyFromInput "Enthalpy input connector"
+  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if setEnthalpy and enthalpyFromInput "Enthalpy input connector"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-20}),
       iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,0})));
   Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fraction connector [kg/kg]"
@@ -53,7 +53,7 @@ protected
 equation
 
   connect(T0_var, T0);
-  if not temperatureFromInput then
+  if not temperatureFromInput or setEnthalpy then
     T0 = T0_par;
   end if;
 
@@ -63,7 +63,7 @@ equation
   end if;
 
   connect(h0_var, h0);
-  if not enthalpyFromInput then
+  if not enthalpyFromInput or not setEnthalpy then
      h0 = h0_par;
   end if;
 

--- a/ThermofluidStream/Undirected/Boundaries/BoundaryFore.mo
+++ b/ThermofluidStream/Undirected/Boundaries/BoundaryFore.mo
@@ -22,16 +22,16 @@ model BoundaryFore "Generic Boundary model (may act as source or sink)"
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance of the boundary"
     annotation (Dialog(tab="Advanced"));
 
-  Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa")= p0 if pressureFromInput "Pressure input connector [Pa]"
+  Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,60}),
       iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,60})));
-  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") = T0 if temperatureFromInput "Temperature input connector [K]"
+  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if temperatureFromInput "Temperature input connector [K]"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,20}),
       iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,0})));
-  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg")= h0 if enthalpyFromInput "Enthalpy input connector"
+  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if enthalpyFromInput "Enthalpy input connector"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-20}),
       iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,0})));
-  Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg")= Xi0 if xiFromInput "Mass fraction connector [kg/kg]"
+  Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fraction connector [kg/kg]"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-60}),
       iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-60})));
   Interfaces.Rear rear(redeclare package Medium = Medium)
@@ -43,28 +43,33 @@ protected
 
   SI.Pressure p_forwards = Medium.pressure(rear.state_forwards);
 
-  SI.Temperature T0;
-  SI.Pressure p0;
-  SI.SpecificEnthalpy h0;
-  Medium.MassFraction Xi0[Medium.nXi];
+  Modelica.Blocks.Interfaces.RealInput p0(unit="Pa") "Internal pressure connector";
+  Modelica.Blocks.Interfaces.RealInput T0(unit = "K") "Internal temperature connector";
+  Modelica.Blocks.Interfaces.RealInput h0(unit = "J/kg") "Internal enthalpy connector";
+  Modelica.Blocks.Interfaces.RealInput Xi0[Medium.nXi](each unit = "kg/kg") "Internal mass fraction connector";
+
   SI.Pressure r;
 
 equation
 
+  connect(T0_var, T0);
   if not temperatureFromInput then
     T0 = T0_par;
   end if;
 
+  connect(p0_var, p0);
   if not pressureFromInput then
     p0 = p0_par;
   end if;
 
-  if not xiFromInput then
-    Xi0 = Xi0_par;
-  end if;
-
+  connect(h0_var, h0);
   if not enthalpyFromInput then
      h0 = h0_par;
+  end if;
+
+  connect(xi_var, Xi0);
+  if not xiFromInput then
+    Xi0 = Xi0_par;
   end if;
 
   der(rear.m_flow)*L = rear.r-r;

--- a/ThermofluidStream/Undirected/Boundaries/BoundaryRear.mo
+++ b/ThermofluidStream/Undirected/Boundaries/BoundaryRear.mo
@@ -22,13 +22,13 @@ model BoundaryRear "Generic Boundary model (may act as source or sink)"
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance of the boundary"
     annotation (Dialog(tab="Advanced"));
 
-  Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa")= p0 if pressureFromInput "Pressure input connector [Pa]"
+  Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
     annotation (Placement(transformation(extent={{-40,40},{0,80}}), iconTransformation(extent={{-40,40},{0,80}})));
-  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") = T0 if temperatureFromInput "Temperature input connector [K]"
+  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if temperatureFromInput "Temperature input connector [K]"
     annotation (Placement(transformation(extent={{-40,0},{0,40}}), iconTransformation(extent={{-40,-20},{0,20}})));
-  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg")= h0 if enthalpyFromInput "Enthalpy input connector"
+  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if enthalpyFromInput "Enthalpy input connector"
     annotation (Placement(transformation(extent={{-40,-40},{0,0}}), iconTransformation(extent={{-40,-20},{0,20}})));
-  Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg")= Xi0 if xiFromInput "Mass fraction connector [kg/kg]"
+  Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fraction connector [kg/kg]"
     annotation (Placement(transformation(extent={{-40,-80},{0,-40}}), iconTransformation(extent={{-40,-80},{0,-40}})));
   Interfaces.Fore fore(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{80,-20},{120,20}}),
@@ -39,26 +39,31 @@ protected
 
   SI.Pressure p_rearwards = Medium.pressure(fore.state_rearwards);
 
-  SI.Temperature T0;
-  SI.Pressure p0;
-  SI.SpecificEnthalpy h0;
-  Medium.MassFraction Xi0[Medium.nXi];
+  Modelica.Blocks.Interfaces.RealInput p0(unit="Pa") "Internal pressure connector";
+  Modelica.Blocks.Interfaces.RealInput T0(unit = "K") "Internal temperature connector";
+  Modelica.Blocks.Interfaces.RealInput h0(unit = "J/kg") "Internal enthalpy connector";
+  Modelica.Blocks.Interfaces.RealInput Xi0[Medium.nXi](each unit = "kg/kg") "Internal mass fraction connector";
+
   SI.Pressure r;
 
 equation
 
+  connect(T0_var, T0);
   if not temperatureFromInput then
     T0 = T0_par;
   end if;
 
+  connect(p0_var, p0);
   if not pressureFromInput then
     p0 = p0_par;
   end if;
 
+  connect(h0_var, h0);
   if not enthalpyFromInput then
      h0 = h0_par;
   end if;
 
+  connect(xi_var, Xi0);
   if not xiFromInput then
     Xi0 = Xi0_par;
   end if;

--- a/ThermofluidStream/Undirected/Boundaries/BoundaryRear.mo
+++ b/ThermofluidStream/Undirected/Boundaries/BoundaryRear.mo
@@ -24,9 +24,9 @@ model BoundaryRear "Generic Boundary model (may act as source or sink)"
 
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
     annotation (Placement(transformation(extent={{-40,40},{0,80}}), iconTransformation(extent={{-40,40},{0,80}})));
-  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if temperatureFromInput "Temperature input connector [K]"
+  Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if not setEnthalpy and temperatureFromInput "Temperature input connector [K]"
     annotation (Placement(transformation(extent={{-40,0},{0,40}}), iconTransformation(extent={{-40,-20},{0,20}})));
-  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if enthalpyFromInput "Enthalpy input connector"
+  Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if setEnthalpy and enthalpyFromInput "Enthalpy input connector"
     annotation (Placement(transformation(extent={{-40,-40},{0,0}}), iconTransformation(extent={{-40,-20},{0,20}})));
   Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fraction connector [kg/kg]"
     annotation (Placement(transformation(extent={{-40,-80},{0,-40}}), iconTransformation(extent={{-40,-80},{0,-40}})));
@@ -49,7 +49,7 @@ protected
 equation
 
   connect(T0_var, T0);
-  if not temperatureFromInput then
+  if not temperatureFromInput or setEnthalpy then
     T0 = T0_par;
   end if;
 
@@ -59,7 +59,7 @@ equation
   end if;
 
   connect(h0_var, h0);
-  if not enthalpyFromInput then
+  if not enthalpyFromInput or not setEnthalpy then
      h0 = h0_par;
   end if;
 

--- a/ThermofluidStream/Undirected/FlowControl/MCV.mo
+++ b/ThermofluidStream/Undirected/FlowControl/MCV.mo
@@ -4,7 +4,7 @@ model MCV "Massflow control valve"
 
   import Mode = ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode;
 
-  Modelica.Blocks.Interfaces.RealInput setpoint_var = setpoint if setpointFromInput "Desired mass-flow [kg/s or m3/s]"
+  Modelica.Blocks.Interfaces.RealInput setpoint_var if setpointFromInput "Desired mass-flow [kg/s or m3/s]"
     annotation (Placement(
         transformation(extent={{-20,-20},{20,20}},
         rotation=270,
@@ -54,7 +54,7 @@ protected
 
   SI.MassFlowRate m_flow_set;
   SI.VolumeFlowRate V_flow_set;
-  Real setpoint;
+  Modelica.Blocks.Interfaces.RealInput setpoint "Internal setpoint connector";
 
   SI.Pressure dr = fore.r - rear.r;
   SI.Pressure dr_set;
@@ -68,6 +68,7 @@ initial equation
   dp_int = 0;
 
 equation
+  connect(setpoint_var, setpoint);
   if setpointFromInput then
     m_flow_set = setpoint;
     V_flow_set = setpoint;

--- a/ThermofluidStream/UsersGuide/ReleaseNotes.mo
+++ b/ThermofluidStream/UsersGuide/ReleaseNotes.mo
@@ -71,6 +71,40 @@ This section summarizes the changes that have been performed on the library.
     <a href=\"modelica://ThermofluidStream.Boundaries.Internal.PartialVolumeM\">PartialVolumeM</a> and <a href=\"modelica://ThermofluidStream.Boundaries.Internal.PartialVolumeN\">PartialVolumeN</a>:
     <code>noEvent</code> operator now works on mass flow related if-statements.
   </li>
+  <li>
+    Fix wrong handling of conditional connectors:
+    <ul>
+      <li>
+        remove input binding for conditional connectors and
+      </li>
+      <li>
+        enable/disable conditional connectors which depend on <code>setEnthalpy</code>
+        parameter.
+      </li>
+    </ul>
+    This concerns:
+    <ul>
+      <li>
+        Boundaries: 
+        <a href=\"modelica://ThermofluidStream.Boundaries.CreateState\">CreateState</a>,
+        <a href=\"modelica://ThermofluidStream.Boundaries.DynamicPressureInflow\">DynamicPressureInflow</a>,
+        <a href=\"modelica://ThermofluidStream.Boundaries.DynamicPressureOutflow\">DynamicPressureOutflow</a>,
+        <a href=\"modelica://ThermofluidStream.Boundaries.Sink\">Sink</a>,
+        <a href=\"modelica://ThermofluidStream.Boundaries.Source\">Source</a>.
+      </li>
+      <li>
+        FlowControl: 
+        <a href=\"modelica://ThermofluidStream.FlowControl.MCV\">MCV</a>,
+        <a href=\"modelica://ThermofluidStream.FlowControl.PCV\">PCV</a>.
+      </li>
+      <li>
+        Undirected:
+        <a href=\"modelica://ThermofluidStream.Undirected.Boundaries.BoundaryFore\">BoundaryFore</a>,
+        <a href=\"modelica://ThermofluidStream.Undirected.Boundaries.BoundaryRear\">BoundaryRear</a>,
+        <a href=\"modelica://ThermofluidStream.Undirected.FlowControl.MCV\">MCV</a>.
+      </li>
+    </ul>
+  </li>
 </ul>
 
 <h4>Version 1.0.0 (2022-12-02)</h4>


### PR DESCRIPTION
All components that provide conditional `RealInput` connectors are updated. 
The input binding was removed and internal connectors are introduced to avoid underdetermined equation systems.

closes #105