### PR TITLE
Make redeclared element replaceable

### DIFF
--- a/ThermofluidStream/HeatExchangers/Internal/ConductionElementHEX_twoPhase.mo
+++ b/ThermofluidStream/HeatExchangers/Internal/ConductionElementHEX_twoPhase.mo
@@ -1,6 +1,6 @@
 within ThermofluidStream.HeatExchangers.Internal;
 model ConductionElementHEX_twoPhase "ConductionElement for two-phase fluids"
-  extends PartialConductionElementHEX(redeclare package Medium =
+  extends PartialConductionElementHEX(redeclare replaceable package Medium =
         Media.myMedia.Interfaces.PartialTwoPhaseMedium);
 
   import Modelica.Math;


### PR DESCRIPTION
In `ThermofluidStream.HeatExchangers.Internal.ConductionElementHEX_twoPhase` the package `Medium` was redeclared but not replaceable which triggered errors in Wolfram System Modeler.

To fix this, the `replaceable` statement was added to the component.

closes #54 