### PR TITLE
Fix pressure loss functions

### DIFF
--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLoss.mo
@@ -11,7 +11,7 @@ function laminarTurbulentPressureLoss
     annotation (Dialog(enable=true));
 
 protected
-  constant Real R_laminar_DarcyWeisbach_min(unit="1") = 500 "Minimal Reynolds number to use the general equation. Laminar flow before";
+  constant SI.ReynoldsNumber R_laminar_DarcyWeisbach_min = 500 "Minimal Reynolds number to use the general equation. Laminar flow before";
   SI.Length ks "pipe roughness";
 
   Real a(unit="1") "Laminar flow factor for the DarcyWeisbach equation (1=laminar flow; 0=turbulent flow)";
@@ -19,7 +19,7 @@ protected
   Real lambda_aux(unit="1") "Darcy friction factor for Darcy-Weisbach equation";
 
   SI.Velocity u "Median flow velocity";
-  Real Re(unit="1") "Reynolds number for flow through the pipe";
+  SI.ReynoldsNumber Re "Reynolds number for flow through the pipe";
   constant Real eps(unit="1") = 0.001;
 algorithm
   if material == ThermofluidStream.Processes.Internal.Material.concrete then

--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
@@ -38,7 +38,7 @@ protected
   SI.Pressure pressureLossLaminar "Laminar pressure loss";
   SI.Pressure pressureLossTurbulent "Turbulent pressure loss";
 
-  constant SI.ReynoldsNumber eps=1e-5 "Lower bound of turbulent Re to avoid division by zero";
+  constant SI.ReynoldsNumber Re_small=1e-5 "Lower bound of turbulent Reynolds number to avoid division by zero";
 
 algorithm
   if material == ThermofluidStream.Processes.Internal.Material.concrete then
@@ -61,7 +61,7 @@ algorithm
 
   //absolute Reynolds number
   Re_abs := abs(m_flow)*diameter/(area*mu);
-  Re_abs_limited := max(eps, min(1, Re_abs));
+  Re_abs_limited := max(Re_small, min(1, Re_abs));
 
   friction_factor :=
     (-1.8/n*log10((6.9/Re_abs_limited)^n + (relative_roughness/3.75)^(1.11*n)))^(-2);

--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
@@ -29,7 +29,7 @@ protected
 
   SI.Length diameter=r*2 "Diameter of pipe";
   SI.Area area=pi*r^2 "Area of pipe";
-  Real relative_roughness=ks/diameter "Relative roughness of pipe";
+  Real relative_roughness "Relative roughness of pipe";
 
   Real Re_abs "Absolute value of Reynolds number";
   Real Re_abs_limited "Limited absolute value of Reynolds number";
@@ -57,6 +57,7 @@ algorithm
     ks := ks_input;
   end if;
 
+  relative_roughness :=ks/diameter;
 
   //absolute Reynolds number
   Re_abs := abs(m_flow)*diameter/(area*mu);

--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
@@ -5,16 +5,16 @@ function laminarTurbulentPressureLossHaaland "Laminar and turbulent flow regimes
   import Modelica.Constants.pi;
 
   // Inputs
-  input Real Re_laminar(unit "1") = 2000
+  input SI.ReynoldsNumber Re_laminar = 2000
     "Upper Reynolds number boundary for laminar flow in pipe"
     annotation(Dialog(enable=true));
-  input Real Re_turbulent(unit "1") = 4000
+  input SI.ReynoldsNumber Re_turbulent = 4000
     "Lower Reynolds number boundary for turbulent flow in pipe"
     annotation(Dialog(enable=true));
-  input Real shape_factor(unit "1") = 64
+  input Real shape_factor(unit="1") = 64
     "Laminar pressure loss factor based on Hagen-Poiseuille loss"
     annotation(Dialog(enable=true));
-  input Real n(unit "1") = 1 "Transition coefficient (see documentation)"
+  input Real n(unit="1") = 1 "Transition coefficient (see documentation)"
     annotation(Dialog(enable=true));
 
   input SI.Length ks_input(min=1e-7) = 1e-7 "Pipe roughness" annotation (Dialog(
@@ -31,14 +31,14 @@ protected
   SI.Area area=pi*r^2 "Area of pipe";
   Real relative_roughness "Relative roughness of pipe";
 
-  Real Re_abs "Absolute value of Reynolds number";
-  Real Re_abs_limited "Limited absolute value of Reynolds number";
+  SI.ReynoldsNumber Re_abs "Absolute value of Reynolds number";
+  SI.ReynoldsNumber Re_abs_limited "Limited absolute value of Reynolds number";
 
-  Real friction_factor;
+  Real friction_factor(unit="1");
   SI.Pressure pressureLossLaminar "Laminar pressure loss";
   SI.Pressure pressureLossTurbulent "Turbulent pressure loss";
 
-  constant Real eps=1e-5 "Lower bound of turbulent Re to avoid division by zero";
+  constant SI.ReynoldsNumber eps=1e-5 "Lower bound of turbulent Re to avoid division by zero";
 
 algorithm
   if material == ThermofluidStream.Processes.Internal.Material.concrete then


### PR DESCRIPTION
In `Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland`, the `relative_roughness` was calculated before the pipe roughness `ks` was defined. This caused an error in OpenModelica and hence it was moved to the algorithm section.

Furthermore, all units for Reynolds numbers were updated with `Units.SI.ReynoldsNumber` and variables without unit were given a unit.