### PR TITLE
Improve incompressible media assert

### DIFF
--- a/ThermofluidStream/Boundaries/Volume.mo
+++ b/ThermofluidStream/Boundaries/Volume.mo
@@ -9,7 +9,7 @@ model Volume "Model of a vessel with fixed volume"
     annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
 
 equation
-  assert(abs(Medium.density_derp_h(medium.state)) > 1e-12, "The simple Volume model should not be used with incompressible or nearly incompressible media. Consider using the FlexVolume instead.");
+  assert(abs(density_derp_h) > 1e-12, "The simple Volume model should not be used with incompressible or nearly incompressible media. Consider using the FlexVolume instead.", dropOfCommons.assertionLevel);
 
   if density_derp_h_from_media then
     density_derp_h = Medium.density_derp_h(medium.state);

--- a/ThermofluidStream/Boundaries/VolumeMix.mo
+++ b/ThermofluidStream/Boundaries/VolumeMix.mo
@@ -9,7 +9,7 @@ model VolumeMix "Volume with N inlets that allows mixing"
     annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
 
 equation
-  assert(abs(Medium.density_derp_h(medium.state)) > 1e-12, "The simple Volume model should not be used with incompressible or nearly incompressible media. Consider using the FlexVolume instead.");
+  assert(abs(density_derp_h) > 1e-12, "The simple Volume model should not be used with incompressible or nearly incompressible media. Consider using the FlexVolume instead.", dropOfCommons.assertionLevel);
 
   if density_derp_h_from_media then
     density_derp_h = Medium.density_derp_h(medium.state);

--- a/ThermofluidStream/Undirected/Boundaries/Volume.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Volume.mo
@@ -9,7 +9,7 @@ model Volume "Model of a vessel with fixed volume"
     annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
 
 equation
-  assert(abs(Medium.density_derp_h(medium.state)) > 1e-12, "The simple Volume model should not be used with incompressible or nearly incompressible media. Consider using the FlexVolume instead.");
+  assert(abs(density_derp_h) > 1e-12, "The simple Volume model should not be used with incompressible or nearly incompressible media. Consider using the FlexVolume instead.", dropOfCommons.assertionLevel);
 
   if density_derp_h_from_media then
     density_derp_h = Medium.density_derp_h(medium.state);

--- a/ThermofluidStream/Undirected/Boundaries/VolumeMix.mo
+++ b/ThermofluidStream/Undirected/Boundaries/VolumeMix.mo
@@ -9,7 +9,7 @@ model VolumeMix "Volume with N_fore fores and N_rear rears that allows mixing"
     annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
 
 equation
-  assert(abs(Medium.density_derp_h(medium.state)) > 1e-12, "The simple Volume model should not be used with incompressible or nearly incompressible media. Consider using the FlexVolume instead.");
+  assert(abs(density_derp_h) > 1e-12, "The simple Volume model should not be used with incompressible or nearly incompressible media. Consider using the FlexVolume instead.", dropOfCommons.assertionLevel);
 
   if density_derp_h_from_media then
     density_derp_h = Medium.density_derp_h(medium.state);


### PR DESCRIPTION
The assert condition was fixed to also take the choice of the Boolean `density_derp_h_from_media` into account.

Furthermore the `assertionLevel` from the `DropOfCommons` model was included.

Closes #149 