### PR TITLE
Realize connection loops in diagram instead of text block

### DIFF
--- a/ThermofluidStream/HeatExchangers/DiscretizedCrossFlowHEX.mo
+++ b/ThermofluidStream/HeatExchangers/DiscretizedCrossFlowHEX.mo
@@ -24,6 +24,11 @@ model DiscretizedCrossFlowHEX "Discretized heat exchanger for single- or two-pha
         rotation=180,
         origin={50,-80})));
 
+  Topology.JunctionN loopThermalElementB[nCells - 1](
+    redeclare package Medium = MediumB, each N=1) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=180,
+        origin={20,60})));
 initial equation
 
   if initializeMassFlow then
@@ -39,9 +44,12 @@ equation
   //Connecting equations (to interconnect pipes)
   //Fluid Side B
   connect(inletB, thermalElementB[1].inlet) annotation (Line(points={{-100,80},{-10,80}}, color={28,108,200}));
-  for i in 1:nCells - 1 loop
-    connect(thermalElementB[i].outlet, thermalElementB[i + 1].inlet);
-  end for;
+  connect(thermalElementB[1:nCells-1].outlet, loopThermalElementB[1:nCells-1].inlets[1]) annotation (Line(
+        points={{10,80},{10,78},{40,78},{40,60},{30,60}},
+        color={28,108,200}));
+  connect(thermalElementB[2:nCells].inlet, loopThermalElementB[1:nCells-1].outlet) annotation (Line(
+        points={{-10,80},{-10,78},{-20,78},{-20,60},{10,60}},
+        color={28,108,200}));
   connect(thermalElementB[nCells].outlet, outletB) annotation (Line(points={{10,80},{100,80}}, color={28,108,200}));
   connect(thermalElementB.heatPort, thermalConductor.port_b) annotation (Line(points={{0,70.2},{0,14},{-1.77636e-15,14},{-1.77636e-15,10},{0,10}}, color={191,0,0}));
   connect(thermalElementA.heatPort, thermalConductor.port_a) annotation (Line(points={{0,-70.2},{0,-42},{0,-42},{0,-10},{0,-10}}, color={191,0,0}));


### PR DESCRIPTION
In several models, vectorized connections are realized in the equation section by for-loops like:
```
  for i in 1:n loop
    connect(...);
  end for;
```
For models implemented graphically, such connections can't be recognized - they are only visible in source code. But generally, mixing of graphical and textual implementation shall be omited.

This PR shows a possible solution to work only in the diagram layer. In `DiscretizedCrossFlowHEX`, the `JunctionN` element is added to realize such inner loops.