### PR TITLE
PartialConductionElementHEX Initialization

### DIFF
--- a/ThermofluidStream/HeatExchangers/Internal/PartialConductionElementHEX.mo
+++ b/ThermofluidStream/HeatExchangers/Internal/PartialConductionElementHEX.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.HeatExchangers.Internal;
 partial model PartialConductionElementHEX "Parent for CEs for discretizedHEX"
   extends Processes.Internal.PartialConductionElement(
-    final init= Processes.Internal.InitializationMethodsCondElement.inlet,
+    init= Processes.Internal.InitializationMethodsCondElement.inlet,
     final neglectPressureChanges=true);
 
     parameter SI.Area A = 1 "Heat transfer area";


### PR DESCRIPTION
Currently the fluid inside discretized heat exchangers (e.g. `ThermofluidStream.HeatExchangers.DiscretizedCounterFlowHEX`) is initialized using `final init = *.inlet` (i.e. initialized with inlet state), but sometimes it might be more realistic to use a given temperature (for 1 phase) or specific enthalpy (for 2 phase) instead.

Therefor i suggest to remove the `final`.