### PR TITLE
PartialNTU Time Constant

### DIFF
--- a/ThermofluidStream/HeatExchangers/CounterFlowNTU.mo
+++ b/ThermofluidStream/HeatExchangers/CounterFlowNTU.mo
@@ -123,5 +123,12 @@ equation
 <p>The equations are derived from the generic effectiveness-NTU relations which can be found in the &quot;VDI W&auml;rmeatlas&quot; and noumerous standard literature.</p>
 <p>For stream dominated applications the following assumptions are made for mass flow regularization close to zero:</p>
 <p>- if the mass flow on both sides of the heat exchanger is zero, no heat is transferred</p>
+<p>
+The heat exchanger time constant <code>TC<\\code> is necessary to ensure robust simulation. It can approximate the transient behavior using a first order ODE. 
+The time constant is related to the ratio of thermal inertia (wall + fluid) <code>dU/dT<\\code> to enthalpy flow rate 'inertia' <code>dH_flow/dT</code>:
+<\\p>
+<p>
+ <code>TC ~ (m_Wall*c_Wall + m_Fluid*c_Fluid)/(m_flow*c_Fluid)</code>.
+<\\p>
 </html>"));
 end CounterFlowNTU;

--- a/ThermofluidStream/HeatExchangers/CrossFlowNTU.mo
+++ b/ThermofluidStream/HeatExchangers/CrossFlowNTU.mo
@@ -173,5 +173,12 @@ equation
 <p>The equations are derived from the generic effectiveness-NTU relations which can be found in the &quot;VDI W&auml;rmeatlas&quot; and noumerous standard literature.</p>
 <p>For stream dominated applications the following assumptions are made for mass flow regularization close to zero:</p>
 <p>- if the mass flow on both sides of the heat exchanger is zero, no heat is transferred</p>
+<p>
+The heat exchanger time constant <code>TC<\\code> is necessary to ensure robust simulation. It can approximate the transient behavior using a first order ODE. 
+The time constant is related to the ratio of thermal inertia (wall + fluid) <code>dU/dT<\\code> to enthalpy flow rate 'inertia' <code>dH_flow/dT</code>:
+<\\p>
+<p>
+ <code>TC ~ (m_Wall*c_Wall + m_Fluid*c_Fluid)/(m_flow*c_Fluid)</code>.
+<\\p>
 </html>"));
 end CrossFlowNTU;

--- a/ThermofluidStream/HeatExchangers/Internal/PartialNTU.mo
+++ b/ThermofluidStream/HeatExchangers/Internal/PartialNTU.mo
@@ -14,7 +14,7 @@ partial model PartialNTU "Partial heat exchanger model using the epsilon-NTU met
     annotation (Dialog(tab="Advanced"));
   parameter Modelica.Units.SI.MassFlowRate m_flow_reg=dropOfCommons.m_flow_reg "Nominal mass flow rate for regularization"
     annotation (Dialog(tab="Advanced", group="Regularization parameters"));
-  parameter Modelica.Units.SI.Time TC=0.01 "Time constant for specific enthalpy difference dh"
+  parameter Modelica.Units.SI.Time TC=0.01 "Heat exchanger time constant"
     annotation (Dialog(tab="Advanced"));
 
   // ------ Parameter Display Configuration  ------------------------
@@ -231,5 +231,13 @@ flow regularization close to zero:
     is transferred
   </li>
 </ul>
+</p>
+<p>
+The heat exchanger time constant <code>TC<\\code> is necessary to ensure robust simulation. It can approximate the transient behavior using a first order ODE. 
+The time constant is related to the ratio of thermal inertia (wall + fluid) <code>dU/dT<\\code> to enthalpy flow rate 'inertia' <code>dH_flow/dT</code>:
+<\\p>
+<p>
+ <code>TC ~ (m_Wall*c_Wall + m_Fluid*c_Fluid)/(m_flow*c_Fluid)</code>.
+<\\p>
 </html>"));
 end PartialNTU;


### PR DESCRIPTION
Currently `ThermofluidStream.HeatExchangers.Internal.PartialNTU` uses a time constant 
`parameter Modelica.Units.SI.Time TC=0.01 "Heat exchanger time constant" annotation (Dialog(tab="Advanced"));`

to filter the outlet enthalpy to ensure a robust simulation. On the other hand, the time constant can be a good first guess to consider the transient behavior without the need of a high spatial resolution, e.g. like `ThermofluidStream.HeatExchangers.DiscretizedCounterFlowHEX`.  (Note that DiscretizedCounterFlowHEX does not consider the thermal inertia of the heat exchanger wall material, which might be relevant (e.g. for m_Wall c_Wall > m_flow_Fluid c_Fluid, i.e. for gas where rho_Wall >> rho_Fluid. We might reconsider that)


1. Hence i added a short description for the time constant.

2. I would suggest to move the time constant from `Advanced` tab, since it matters.
3. I would suggest to change the default value of the heat exchanger time constant, because the heat exchanger time constant default value is currently less than the default value of the fluid flow time constant, which is not physical and leads to unphysical results, see figure below, where the heat exchanger is faster than the mass flow rate:   Dimensional analysis  (https://en.wikipedia.org/wiki/Dimensional_analysis) yields e.g. for water a time constant of TC ~ L sqrt(dp/rho) = 0.1s (L = dropOfCommons.L, dp = 1 bar, rho = 1000 kg/s) or for air TC = 1s (L = dropOfCommons.L, dp = 0.1 bar, rho = 1 kg/s). For the instationary bernoulli the time constant T = sqrt(1/2*dp/rho)*1/l (l - length) https://www.fluid.tuwien.ac.at/322034?action=AttachFile&do=get&target=1_6_1.pdf
![TFS4](https://github.com/user-attachments/assets/07227808-139f-468d-9200-665d9206e0ba)
