### PR TITLE
Start values for DynamicPressureInlet/Outlet/Nozzle

### DIFF
--- a/ThermofluidStream/Boundaries/DynamicPressureInflow.mo
+++ b/ThermofluidStream/Boundaries/DynamicPressureInflow.mo
@@ -1,10 +1,16 @@
 within ThermofluidStream.Boundaries;
 model DynamicPressureInflow "Extension of (p,T) source to (p,T,velocity)"
 
-  extends Interfaces.SISOFlow(final clip_p_out=true);
+  extends ThermofluidStream.Interfaces.SISOFlow(clip_p_out=true,dp(start=dp_start),p_out(start=p_start),outlet(state(p(start=p_start),T(start=T_start))));
 
   parameter Boolean assumeConstantDensity=true "= true, if incompressibility is assumed (use '= false' for Ma > 0.3)"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
+  parameter SI.PressureDifference dp_start = 0 "Start value for pressure difference for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable = not assumeConstantDensity));
+  parameter SI.Pressure p_start = Medium.p_default "Start value for outlet pressure for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable= not assumeConstantDensity));
+  parameter SI.Temperature T_start = Medium.T_default "Start value for outlet temperature for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable= not assumeConstantDensity));
   parameter Boolean velocityFromInput = false "= true, if input connector for outlet velocity is enabled"
     annotation(Dialog(group="Nozzle / Diffusor definition"),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Velocity v_in_par = 0 "Inlet velocity"

--- a/ThermofluidStream/Boundaries/DynamicPressureOutflow.mo
+++ b/ThermofluidStream/Boundaries/DynamicPressureOutflow.mo
@@ -1,10 +1,16 @@
 within ThermofluidStream.Boundaries;
 model DynamicPressureOutflow "Extension of (p) sink to (p,velocity)"
 
-  extends Interfaces.SISOFlow(final clip_p_out=true);
+  extends ThermofluidStream.Interfaces.SISOFlow(clip_p_out=true,dp(start=dp_start),p_out(start=p_start),outlet(state(p(start=p_start),T(start=T_start))));
 
   parameter Boolean assumeConstantDensity= true "= true, if incompressibility is assumed (use '= false' for Ma > 0.3)"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
+  parameter SI.PressureDifference dp_start = 0 "Start value for pressure difference for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable = not assumeConstantDensity));
+  parameter SI.Pressure p_start = Medium.p_default "Start value for outlet pressure for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable= not assumeConstantDensity));
+  parameter SI.Temperature T_start = Medium.T_default "Start value for outlet temperature for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable= not assumeConstantDensity));
   parameter Boolean areaFromInput = false "= true, if input connector for inlet cross section area is enabled"
     annotation(Dialog(group="Nozzle / Diffusor definition"),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Area A_par = 1 "Inlet cross-section area"

--- a/ThermofluidStream/Processes/Nozzle.mo
+++ b/ThermofluidStream/Processes/Nozzle.mo
@@ -1,9 +1,15 @@
 within ThermofluidStream.Processes;
 model Nozzle "Model for dynamic pressure difference"
-  extends ThermofluidStream.Interfaces.SISOFlow(final L = L_value, final clip_p_out=true);
+  extends ThermofluidStream.Interfaces.SISOFlow(clip_p_out=true,dp(start=dp_start),p_out(start=p_start),outlet(state(p(start=p_start),T(start=T_start))));
 
   parameter Boolean assumeConstantDensity=true "= true, if incompressibility is assumed (use '= false' for Ma > 0.3)"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
+  parameter SI.PressureDifference dp_start = 0 "Start value for pressure difference for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable = not assumeConstantDensity));
+  parameter SI.Pressure p_start = Medium.p_default "Start value for outlet pressure for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable= not assumeConstantDensity));
+  parameter SI.Temperature T_start = Medium.T_default "Start value for outlet temperature for solving nonlinear equation system"
+    annotation(Dialog(group="Numerics",enable= not assumeConstantDensity));
   parameter Boolean area_in_FromInput = false "= true, if input connector for inlet cross section area is enabled"
     annotation(Dialog(group="Nozzle / Diffusor definition"),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Area A_in = 1 "Inlet cross-sectional area"


### PR DESCRIPTION
assumeConstantDensity=false causes a nonlinear equation system for `ThermofluidStream.Boundaries.DynamicPressureInflow`
`ThermofluidStream.Boundaries.DynamicPressureOutflow` and
`ThermofluidStream.Processes.Nozzle`. 

I added the parameters `dp_start`, `p_start`, `T_start` to provide start values for this NLE. One could add the start values individualy on text layer, but i think thats rather inconvenient.