### PR TITLE
Annotation update + use of defaultComponentName

### DIFF
--- a/ThermofluidStream/Boundaries/CreateState.mo
+++ b/ThermofluidStream/Boundaries/CreateState.mo
@@ -51,15 +51,13 @@ model CreateState "Create state signal as output"
       Placement(transformation(extent={{80,-20},{120,20}}), iconTransformation(
           extent={{80,-20},{120,20}})));
   Modelica.Blocks.Interfaces.RealInput p_inp(unit="Pa") if PFromInput "Input for pressure [Pa]"
-    annotation (Placement(transformation(extent={{-120,40},{-80,80}}),
-        iconTransformation(extent={{-120,40},{-80,80}})));
+    annotation (Placement(transformation(extent={{-120,40},{-80,80}})));
   Modelica.Blocks.Interfaces.RealInput T_inp(unit="K") if not setEnthalpy and TFromInput "Input for Temperature [K]"
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if setEnthalpy and hFromInput "Enthalpy input connector [J/kg]"
-    annotation (Placement(transformation(extent={{-40,-20},{0,20}}),iconTransformation(extent={{-40,-20},{0,20}})));
+    annotation (Placement(transformation(extent={{-40,-20},{0,20}}),iconTransformation(extent={{-120,-20},{-80,20}})));
   Modelica.Blocks.Interfaces.RealInput Xi_inp[Medium.nXi](each unit="kg/kg") if XiFromInput "Vector input for Mass fraction [kg/kg]"
-    annotation (Placement(transformation(extent={{-120,-80},{-80,-40}}),
-        iconTransformation(extent={{-120,-80},{-80,-40}})));
+    annotation (Placement(transformation(extent={{-120,-80},{-80,-40}})));
 
 protected
   Modelica.Blocks.Interfaces.RealInput p(unit="Pa") "Internal pressure connector";

--- a/ThermofluidStream/Boundaries/DynamicPressureInflow.mo
+++ b/ThermofluidStream/Boundaries/DynamicPressureInflow.mo
@@ -29,7 +29,7 @@ model DynamicPressureInflow "Extension of (p,T) source to (p,T,velocity)"
     annotation(Dialog(tab="Layout",group="Display parameters",enable=displayParameters),Evaluate=true, HideResult=true, choices(checkBox=true));
   final parameter Boolean dv_in = displayParameters and not velocityFromInput and displayInletVelocity "Display inlet velocity"
     annotation(Evaluate=true, HideResult=true);
-  final parameter Boolean displayA = displayOutletArea and not areaFromInput "Display outlet cross section area"
+  final parameter Boolean displayA = displayParameters and displayOutletArea and not areaFromInput "Display outlet cross section area"
     annotation(Evaluate=true, HideResult=true);
   final parameter String compressibilityString = if assumeConstantDensity then "incompressible" else "compressible"
     annotation(Evaluate=true, HideResult=true);
@@ -53,19 +53,10 @@ model DynamicPressureInflow "Extension of (p,T) source to (p,T,velocity)"
     else "" annotation(Evaluate=true, HideResult=true);
   //----------------------------------------------------------------
 
-  Modelica.Blocks.Interfaces.RealInput A_var(unit = "m2") if areaFromInput "Outlet cross section area input connector [m2]" annotation (Placement(transformation(
-          extent={{-20,20},{20,-20}},
-        rotation=180,
-        origin={120,-60}),iconTransformation(extent={{-20,-20},{20,20}},
-        rotation=180,
-        origin={120,-60})));
-  Modelica.Blocks.Interfaces.RealInput v_in_var(unit="m/s") if velocityFromInput "Inlet velocity input connector [m/s]" annotation (Placement(transformation(
-          extent={{-20,-20},{20,20}},
-        rotation=0,
-        origin={-118,-60}),
-                         iconTransformation(extent={{-20,-20},{20,20}},
-        rotation=0,
-        origin={-120,-60})));
+  Modelica.Blocks.Interfaces.RealInput A_var(unit = "m2") if areaFromInput "Outlet cross section area input connector [m2]"
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=180,origin={120,-60})));
+  Modelica.Blocks.Interfaces.RealInput v_in_var(unit="m/s") if velocityFromInput "Inlet velocity input connector [m/s]"
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=0,origin={-120,-60})));
 
 protected
   Modelica.Blocks.Interfaces.RealInput A(unit = "m2") "Internal connector for cross-section area of outlet";

--- a/ThermofluidStream/Boundaries/DynamicPressureOutflow.mo
+++ b/ThermofluidStream/Boundaries/DynamicPressureOutflow.mo
@@ -27,9 +27,9 @@ model DynamicPressureOutflow "Extension of (p) sink to (p,velocity)"
     annotation(Dialog(tab="Layout",group="Display parameters",enable=displayParameters),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter Boolean displayInertance = false "= true, if inertance L is displayed"
     annotation(Dialog(tab="Layout",group="Display parameters",enable=displayParameters),Evaluate=true, HideResult=true, choices(checkBox=true));
-  final parameter Boolean displayA = displayInletArea  and not areaFromInput
+  final parameter Boolean displayA = displayParameters and displayInletArea  and not areaFromInput
     annotation(Evaluate=true, HideResult=true);
-  final parameter Boolean dv_out = displayOutletVelocity and not velocityFromInput
+  final parameter Boolean dv_out = displayParameters and displayOutletVelocity and not velocityFromInput
     annotation(Evaluate=true, HideResult=true);
   final parameter String compressibilityString = if assumeConstantDensity then "incompressible" else "compressible"
     annotation(Evaluate=true, HideResult=true);
@@ -57,16 +57,10 @@ model DynamicPressureOutflow "Extension of (p) sink to (p,velocity)"
   //----------------------------------------------------------------
 
 
-  Modelica.Blocks.Interfaces.RealInput A_var(unit = "m2") if areaFromInput "Inlet cross section area input connector [m2]" annotation (Placement(transformation(
-          extent={{-20,-20},{20,20}},
-        rotation=0,
-        origin={-120,-60})));
-  Modelica.Blocks.Interfaces.RealInput v_out_var(unit="m/s") if velocityFromInput "Outlet velocity input connector [m/s]" annotation (Placement(transformation(
-          extent={{20,-20},{-20,20}},
-        rotation=0,
-        origin={120,-60}), iconTransformation(extent={{-20,-20},{20,20}},
-        rotation=180,
-        origin={120,-60})));
+  Modelica.Blocks.Interfaces.RealInput A_var(unit = "m2") if areaFromInput "Inlet cross section area input connector [m2]"
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=0,origin={-120,-60})));
+  Modelica.Blocks.Interfaces.RealInput v_out_var(unit="m/s") if velocityFromInput "Outlet velocity input connector [m/s]"
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=180,origin={120,-60})));
 
 protected
   Modelica.Blocks.Interfaces.RealInput A(unit = "m2") "Internal connector for inlet cross-section area";

--- a/ThermofluidStream/Boundaries/Internal/PartialVolume.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialVolume.mo
@@ -51,12 +51,9 @@ inlets and outlets the volume is connected to.
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort(Q_flow=Q_flow, T=T_heatPort) if useHeatport
     annotation (Placement(transformation(extent={{-10,-90},{10,-70}})));
   Interfaces.Inlet inlet(redeclare package Medium=Medium, m_flow=m_flow_in, r=r_in, state=state_in) if useInlet
-    annotation (Placement(transformation(extent={{-120,
-            -20},{-80,20}}),
-                        iconTransformation(extent={{-120,-20},{-80,20}})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Outlet outlet(redeclare package Medium=Medium, m_flow=m_flow_out, r=r_out, state=state_out) if useOutlet
-    annotation (Placement(transformation(extent={{80,-20},
-            {120,20}}), iconTransformation(extent={{80,-20},{120,20}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
   Medium.BaseProperties medium(preferredMediumStates=usePreferredMediumStates);
 

--- a/ThermofluidStream/Boundaries/Sink.mo
+++ b/ThermofluidStream/Boundaries/Sink.mo
@@ -39,14 +39,7 @@ the outlet the sink is connected to.
   Interfaces.Inlet inlet(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
-    annotation (Placement(
-        transformation(
-        extent={{-20,-20},{20,20}},
-        rotation=180,
-        origin={20,0}), iconTransformation(
-        extent={{-20,-20},{20,20}},
-        rotation=180,
-        origin={20,0})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=180,origin={20,0})));
 
 protected
   Modelica.Blocks.Interfaces.RealInput p0(unit="Pa") "Internal pressure connector";

--- a/ThermofluidStream/Boundaries/Source.mo
+++ b/ThermofluidStream/Boundaries/Source.mo
@@ -86,14 +86,13 @@ the inlet the source is connected to.
   //-----------------------------------------------------------------
 
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
-    annotation (Placement(transformation(extent={{-40,40},{0,80}}), iconTransformation(extent={{-40,40},{0,80}})));
+    annotation (Placement(transformation(extent={{-40,40},{0,80}})));
   Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if not setEnthalpy and temperatureFromInput "Temperature input connector [K]"
-    annotation (Placement(transformation(extent={{-40,-20},{0,20}}),
-                                                                   iconTransformation(extent={{-40,-20},{0,20}})));
+    annotation (Placement(transformation(extent={{-40,-20},{0,20}})));
   Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if setEnthalpy and enthalpyFromInput "Enthalpy input connector [J/kg]"
     annotation (Placement(transformation(extent={{0,-20},{40,20}}), iconTransformation(extent={{-40,-20},{0,20}})));
   Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fractions connector [kg/kg]"
-    annotation (Placement(transformation(extent={{-40,-80},{0,-40}}), iconTransformation(extent={{-40,-80},{0,-40}})));
+    annotation (Placement(transformation(extent={{-40,-80},{0,-40}})));
   Interfaces.Outlet outlet(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 

--- a/ThermofluidStream/Boundaries/TerminalSink.mo
+++ b/ThermofluidStream/Boundaries/TerminalSink.mo
@@ -12,7 +12,7 @@ the inlet the source is connected to.
 </html>"));
 
   Interfaces.Inlet inlet(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}), iconTransformation(extent={{-120,-20},{-80,20}})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
 
 equation
   inlet.m_flow = 0;

--- a/ThermofluidStream/Boundaries/TerminalSource.mo
+++ b/ThermofluidStream/Boundaries/TerminalSource.mo
@@ -17,7 +17,7 @@ the inlet the source is connected to.
   parameter SI.Pressure p_0 = Medium.p_default "Initial pressure";
 
   Interfaces.Outlet outlet(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{80,-20},{120,20}}), iconTransformation(extent={{80,-20},{120,20}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
 protected
   SI.Pressure p(stateSelect=StateSelect.prefer);

--- a/ThermofluidStream/FlowControl/FourWaySwitch.mo
+++ b/ThermofluidStream/FlowControl/FourWaySwitch.mo
@@ -15,31 +15,20 @@ model FourWaySwitch
     annotation(Dialog(tab="Advanced"));
 
   ThermofluidStream.Interfaces.Inlet inletA(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-120,40},{-80,80}}), iconTransformation(extent={{-120,40},{-80,80}})));
+    annotation (Placement(transformation(extent={{-120,40},{-80,80}})));
   ThermofluidStream.Interfaces.Inlet inletB(redeclare package Medium = Medium)
-    annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=180,
-        origin={100,-60}), iconTransformation(
-        extent={{-28.2354,51.7646},{11.7646,11.7646}},
-        rotation=180,
-        origin={91.7646,-28.2354})));
+    annotation (Placement(transformation(extent={{-20,20},{20,-20}},rotation=180,origin={100,-60})));
   ThermofluidStream.Interfaces.Outlet outletA(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{80,40},{120,80}}), iconTransformation(extent={{80,40},{120,80}})));
+    annotation (Placement(transformation(extent={{80,40},{120,80}})));
   ThermofluidStream.Interfaces.Outlet outletB(redeclare package Medium = Medium)
-    annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=180,
-        origin={-100,-60}), iconTransformation(
-        extent={{-27.5,52.5},{12.5,12.5}},
-        rotation=180,
-        origin={-107.5,-27.5})));
+    annotation (Placement(transformation(extent={{-20,20},{20,-20}},rotation=180,origin={-100,-60})));
   Modelica.Blocks.Interfaces.RealInput u
     annotation (Placement(transformation(
         extent={{-20,-20},{20,20}},
         rotation=90,
         origin={0,-100})));
   Switch switch(
+    displayInstanceName=true,
     redeclare package Medium = Medium,
     final m_flow_ref=m_flow_ref,
     final p_ref=p_ref,
@@ -51,6 +40,7 @@ model FourWaySwitch
         rotation=180,
         origin={-60,60})));
   Switch switch1(
+    displayInstanceName=true,
     redeclare package Medium = Medium,
     final m_flow_ref=m_flow_ref,
     final p_ref=p_ref,
@@ -61,11 +51,11 @@ model FourWaySwitch
         extent={{-10,10},{10,-10}},
         rotation=180,
         origin={60,-60})));
-  ThermofluidStream.Topology.JunctionT2 junctionT2_1(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-70,-70},{-50,-50}})));
-  ThermofluidStream.Topology.JunctionT2 junctionT2_2(redeclare package Medium = Medium)
+  ThermofluidStream.Topology.JunctionT2 junctionT2_1(displayInstanceName=true, redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{-50,-70},{-70,-50}})));
+  ThermofluidStream.Topology.JunctionT2 junctionT2_2(displayInstanceName=true, redeclare package Medium = Medium)
     annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
+        extent={{10,-10},{-10,10}},
         rotation=180,
         origin={60,60})));
 protected
@@ -86,15 +76,15 @@ equation
       color={28,108,200},
       thickness=0.5));
   connect(junctionT2_1.outlet,outletB) annotation (Line(
-      points={{-50,-60},{-100,-60}},
+      points={{-70,-60},{-100,-60}},
       color={28,108,200},
       thickness=0.5));
   connect(switch1.outletA, junctionT2_1.inletB) annotation (Line(
-      points={{50,-60},{-70,-60}},
+      points={{50,-60},{-50,-60}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionT2_2.inletB, switch.outletA) annotation (Line(
-      points={{70,60},{-50,60}},
+      points={{50,60},{-50,60}},
       color={28,108,200},
       thickness=0.5));
   connect(switch1.outletB, junctionT2_2.inletA) annotation (Line(
@@ -102,7 +92,7 @@ equation
       color={28,108,200},
       thickness=0.5));
   connect(junctionT2_2.outlet, outletA) annotation (Line(
-      points={{50,60},{86,60},{86,60},{100,60}},
+      points={{70,60},{86,60},{86,60},{100,60}},
       color={28,108,200},
       thickness=0.5));
   connect(switch1.u, switch.u) annotation (Line(points={{60,-72},{60,-76},{0,-76},{0,76},{-60,76},{-60,72}}, color={0,0,127}));

--- a/ThermofluidStream/FlowControl/Internal/PartialValve.mo
+++ b/ThermofluidStream/FlowControl/Internal/PartialValve.mo
@@ -8,11 +8,7 @@ partial model PartialValve "Partial implementation of a physical valve"
   parameter Real k_min(unit="1", min = 1e-5, max = 1) = 0.03 "Remaining flow at actuation signal u = 0";
 
   Modelica.Blocks.Interfaces.RealInput u_in(unit="1") "Valve control input signal []"
-    annotation (Placement(
-        transformation(
-        extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={0,80})));
 
   Real u(unit="1") "Actuation input for flow calculation";
   parameter Modelica.Units.SI.Pressure dp_ref=1e5

--- a/ThermofluidStream/FlowControl/MCV.mo
+++ b/ThermofluidStream/FlowControl/MCV.mo
@@ -39,21 +39,9 @@ model MCV "Flow rate control valve"
 
 
   Modelica.Blocks.Interfaces.RealInput setpoint_var if setpointFromInput "Flow rate input connector"
-    annotation (Placement(
-        transformation(extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80}), iconTransformation(
-        extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={0,80})));
   Modelica.Blocks.Interfaces.RealOutput clippingOutput = (dp - dp_int) if enableClippingOutput ""
-    annotation (Placement(
-        transformation(extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={0,-120}), iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={0,-110})));
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=270,origin={0,-110})));
 
   SI.Density rho_in = Medium.density(inlet.state) "Inlet density";
   SI.VolumeFlowRate V_flow = m_flow/rho_in "Inlet volume flow rate";

--- a/ThermofluidStream/FlowControl/PCV.mo
+++ b/ThermofluidStream/FlowControl/PCV.mo
@@ -15,13 +15,7 @@ model PCV "Pressure and pressure-drop control valve"
     annotation(Dialog(tab="Advanced"));
 
   Modelica.Blocks.Interfaces.RealInput pressure_set_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
-    annotation (Placement(
-        transformation(extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80}), iconTransformation(
-        extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={0,80})));
 
 protected
   Modelica.Blocks.Interfaces.RealInput pressure_set(unit="Pa") "Internal pressure connector [Pa]";

--- a/ThermofluidStream/FlowControl/Switch.mo
+++ b/ThermofluidStream/FlowControl/Switch.mo
@@ -17,38 +17,42 @@ model Switch
     annotation(Dialog(tab="Advanced"));
 
   ThermofluidStream.Interfaces.Inlet inlet(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   ThermofluidStream.Interfaces.Outlet outletA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   ThermofluidStream.Interfaces.Outlet outletB(redeclare package Medium=Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,100})));
 
   Modelica.Blocks.Interfaces.RealInput u(min=0, max=1, unit="1") "Flow split"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,-130}), iconTransformation(
-        extent={{-20,-20},{20,20}},
-        rotation=90,
-        origin={0,-120})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,-120})));
 
-  ThermofluidStream.FlowControl.TanValve tanValve(redeclare package Medium = Medium,
-                                                  final invertInput=invertInput,
-                                                  final m_flow_ref=m_flow_ref,
-                                                  final p_ref=p_ref,
-                                                  final relativeLeakiness=relativeLeakiness,
-                                  outlet(m_flow(stateSelect=StateSelect.prefer)))
+  ThermofluidStream.FlowControl.TanValve tanValve(
+    displayInstanceName=true,
+    redeclare package Medium = Medium,
+    final invertInput=invertInput,
+    final m_flow_ref=m_flow_ref,
+    final p_ref=p_ref,
+    final relativeLeakiness=relativeLeakiness,
+    outlet(m_flow(stateSelect=StateSelect.prefer)))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={0,40})));
-  ThermofluidStream.FlowControl.TanValve tanValve1(redeclare package Medium = Medium,
-                                                  final invertInput=not invertInput,
-                                                  final m_flow_ref=m_flow_ref,
-                                                  final p_ref=p_ref,
-                                                  final relativeLeakiness=relativeLeakiness)
+  ThermofluidStream.FlowControl.TanValve tanValve1(
+    displayInstanceName=true,
+    redeclare package Medium = Medium,
+    final invertInput=not invertInput,
+    final m_flow_ref=m_flow_ref,
+    final p_ref=p_ref,
+    final relativeLeakiness=relativeLeakiness)
     annotation (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=0,
         origin={40,0})));
-  ThermofluidStream.Topology.SplitterT2 splitterT2_1(redeclare package Medium = Medium, L=0)
+  ThermofluidStream.Topology.SplitterT2 splitterT2_1(
+    displayInstanceName=true,
+    redeclare package Medium = Medium,
+    L=0)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 
   // for dynamic select of graphics only
@@ -88,8 +92,8 @@ equation
       points={{6.66134e-16,50},{0,50},{0,100}},
       color={28,108,200},
       thickness=0.5));
-  connect(tanValve1.u, u) annotation (Line(points={{40,-8},{40,-20},{0,-20},{0,-130}},color={0,0,127}));
-  connect(tanValve.u, u) annotation (Line(points={{-8,40},{-20,40},{-20,-20},{0,-20},{0,-130}},color={0,0,127}));
+  connect(tanValve1.u, u) annotation (Line(points={{40,-8},{40,-20},{0,-20},{0,-120}},color={0,0,127}));
+  connect(tanValve.u, u) annotation (Line(points={{-8,40},{-20,40},{-20,-20},{0,-20},{0,-120}},color={0,0,127}));
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible= displayInstanceName,

--- a/ThermofluidStream/FlowControl/TanValve.mo
+++ b/ThermofluidStream/FlowControl/TanValve.mo
@@ -3,13 +3,7 @@ model TanValve "Valve with tan-shaped flow resistance"
   extends Interfaces.SISOFlow(final clip_p_out=true);
 
   Modelica.Blocks.Interfaces.RealInput u(unit="1") "Valve control signal []"
-    annotation (Placement(
-        transformation(extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80}), iconTransformation(
-        extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={0,80})));
 
   parameter Utilities.Units.Inertance L = dropOfCommons.L "Inertance"
     annotation(Dialog(tab="Advanced"));

--- a/ThermofluidStream/Processes/Internal/PartialConductionElement.mo
+++ b/ThermofluidStream/Processes/Internal/PartialConductionElement.mo
@@ -21,7 +21,8 @@ partial model PartialConductionElement "Partial model of quasi-stationary mass a
   parameter SI.Time T_e = 100 "Time constant for global conservation of energy"
     annotation(Dialog(tab="Advanced",group="global energy conservation", enable = enforce_global_energy_conservation));
 
-  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort(Q_flow=Q_flow, T=T_heatPort) annotation (Placement(transformation(extent={{-10,-110},{10,-90}}), iconTransformation(extent={{-10,-110},{10,-90}})));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort(Q_flow=Q_flow, T=T_heatPort)
+    annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
 
   SI.SpecificEnthalpy h(start=Medium.h_default, stateSelect = StateSelect.prefer) "Volume? specific enthalpy";
 

--- a/ThermofluidStream/Processes/Internal/PartialTurboComponent.mo
+++ b/ThermofluidStream/Processes/Internal/PartialTurboComponent.mo
@@ -35,21 +35,13 @@ partial model PartialTurboComponent "Partial model of turbo component"
     annotation(Dialog(tab= "Initialization", group="Angle", enable=initPhi));
 
   Modelica.Mechanics.Rotational.Interfaces.Flange_a flange(phi=phi, tau=tau) if not omega_from_input "Flange"
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}}, origin={0,-100}, rotation=-90),
-      iconTransformation(extent={{-10,-110},{10,-90}})));
+    annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
   Modelica.Blocks.Interfaces.RealInput omega_input(unit = "rad/s") = omega if omega_from_input "Angular velocity input connector [rad/s]"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-100}, rotation=-90),
-      iconTransformation(extent={{-20,-20},{20,20}}, origin={0,-120}, rotation=90)));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-120}, rotation=90)));
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatport(Q_flow = Q_t) if enableAccessHeatPort "HeatPort"
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}}, origin={-60,-100},
-                                                                                     rotation=90),
-      iconTransformation(extent={{-10,-10},{10,10}}, origin={-60,-100},
-                                                                     rotation=90)));
+    annotation (Placement(transformation(extent={{-70,-110},{-50,-90}})));
   Modelica.Blocks.Interfaces.RealOutput output_val(unit=Sensors.Internal.getFlowUnit(outputQuantity)) = getQuantity(inlet.state, m_flow, outputQuantity, rho_min) if enableOutput "Quantity output connector"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-80,-100}, rotation=270), iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={60,-110})));
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=270,origin={60,-110})));
 
   replaceable function dp_tau = TurboComponent.pleaseSelect_dp_tau
     constrainedby TurboComponent.partial_dp_tau(redeclare package Medium=Medium)  "Component characteristic curve"

--- a/ThermofluidStream/Processes/Nozzle.mo
+++ b/ThermofluidStream/Processes/Nozzle.mo
@@ -24,9 +24,9 @@ model Nozzle "Model for dynamic pressure difference"
     annotation(Dialog(tab="Layout",group="Display parameters",enable=displayParameters),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter Boolean displayInertance = false "=true, if inertance L is displayed"
     annotation(Dialog(tab="Layout",group="Display parameters",enable=displayParameters),Evaluate=true, HideResult=true, choices(checkBox=true));
-  final parameter Boolean dA_in = displayInletArea and not area_in_FromInput "Display inlet area"
+  final parameter Boolean dA_in = displayParameters and displayInletArea and not area_in_FromInput "Display inlet area"
     annotation(Evaluate=true, HideResult=true);
-  final parameter Boolean dA_out = displayOutletArea and not area_out_FromInput "Display outlet area"
+  final parameter Boolean dA_out = displayParameters and displayOutletArea and not area_out_FromInput "Display outlet area"
     annotation(Evaluate=true, HideResult=true);
   final parameter Boolean displayA = dA_in or dA_out "Display inlet area or display outlet area"
     annotation(Evaluate=true, HideResult=true);
@@ -60,18 +60,10 @@ model Nozzle "Model for dynamic pressure difference"
     else "" annotation(Evaluate=true, HideResult=true);
   //-----------------------------------------------------------------
 
-  Modelica.Blocks.Interfaces.RealInput A_in_var(unit = "m2") if area_in_FromInput "Inlet cross-sectional area input connector [m2]" annotation (Placement(transformation(
-          extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,170}), iconTransformation(extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={-120,-60})));
-  Modelica.Blocks.Interfaces.RealInput A_out_var(unit = "m2") if area_out_FromInput "Outlet cross-sectional area input connector [m2]" annotation (Placement(transformation(
-          extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,170}), iconTransformation(extent={{20,-20},{-20,20}},
-        rotation=0,
-        origin={120,-60})));
+  Modelica.Blocks.Interfaces.RealInput A_in_var(unit = "m2") if area_in_FromInput "Inlet cross-sectional area input connector [m2]"
+    annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
+  Modelica.Blocks.Interfaces.RealInput A_out_var(unit = "m2") if area_out_FromInput "Outlet cross-sectional area input connector [m2]"
+    annotation (Placement(transformation(extent={{140,-80},{100,-40}})));
 
 
 protected

--- a/ThermofluidStream/Processes/ThermalConvectionPipe.mo
+++ b/ThermofluidStream/Processes/ThermalConvectionPipe.mo
@@ -31,10 +31,8 @@ model ThermalConvectionPipe "Very simple model of thermal convection"
 
   Integer turb_flag "= 0 for laminar flow, = 1 for turbulent flow (Re > 2300)";
 
-  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort annotation (
-      Placement(transformation(extent={{-10,-110},{10,-90}}),
-                                                            iconTransformation(
-          extent={{-10,-110},{10,-90}})));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort
+    annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
 
 
 protected

--- a/ThermofluidStream/Topology/Internal.mo
+++ b/ThermofluidStream/Topology/Internal.mo
@@ -30,14 +30,10 @@ package Internal
 
     ThermofluidStream.Interfaces.Inlet inlet(redeclare package Medium = Medium)
       annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
-    ThermofluidStream.Interfaces.Outlet outletA(redeclare package Medium = Medium) annotation (Placement(transformation(
-          extent={{-20,-20},{20,20}},
-          rotation=90,
-          origin={0,100})));
-    ThermofluidStream.Interfaces.Outlet outletB(redeclare package Medium = Medium) annotation (Placement(transformation(
-          extent={{-20,-20},{20,20}},
-          rotation=0,
-          origin={100,0})));
+    ThermofluidStream.Interfaces.Outlet outletA(redeclare package Medium = Medium)
+      annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,100})));
+    ThermofluidStream.Interfaces.Outlet outletB(redeclare package Medium = Medium)
+      annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
     Modelica.Blocks.Interfaces.RealInput splitRatio(min=0, max=1) annotation (Placement(transformation(
           extent={{-20,-20},{20,20}},

--- a/ThermofluidStream/Topology/JunctionT1.mo
+++ b/ThermofluidStream/Topology/JunctionT1.mo
@@ -14,36 +14,34 @@ model JunctionT1 "Junction with two inlets and one oulet"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Outlet outlet(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{20,-20},{-20,20}}, rotation=180,
-        origin={100,0}), iconTransformation(
-        extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   Interfaces.Inlet inletA(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,100})));
   Interfaces.Inlet inletB(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=90, origin={0,-100})));
-  JunctionN junctionN(final N=2, redeclare package Medium = Medium, final L=L,
-    final assumeConstantDensity = assumeConstantDensity, final m_flow_eps=m_flow_eps)
-    annotation (Placement(transformation(
-        extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={40,3.55271e-15})));
+  JunctionN junctionN(
+    displayInstanceName=true,
+    final N=2,
+    redeclare package Medium = Medium,
+    final L=L,
+    final assumeConstantDensity = assumeConstantDensity,
+    final m_flow_eps=m_flow_eps)
+    annotation (Placement(transformation(extent={{20,-10},{40,10}})));
 
 equation
   connect(junctionN.outlet, outlet) annotation (Line(
-      points={{60,2.22045e-15},{80,2.22045e-15},{80,0},{100,0}},
+      points={{40,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(inletA, junctionN.inlets[1]) annotation (Line(
-      points={{0,100},{0,1},{20,1}},
+      points={{0,100},{0,-0.5},{20,-0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionN.inlets[2], inletB) annotation (Line(
-      points={{20,-1},{0,-1},{0,-100}},
+      points={{20,0.5},{0,0.5},{0,-100}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction",Icon(coordinateSystem(preserveAspectRatio=true), graphics={
        Text(visible=displayInstanceName,
           extent={{-150,25},{150,65}},
           textString="%name",

--- a/ThermofluidStream/Topology/JunctionT2.mo
+++ b/ThermofluidStream/Topology/JunctionT2.mo
@@ -15,32 +15,34 @@ model JunctionT2 "Junction with two inlets and one outlet"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Outlet outlet(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{20,-20},{-20,20}}, rotation=180, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}}), iconTransformation(extent={{80,-20},{120,20}})));
   Interfaces.Inlet inletA(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,100})));
   Interfaces.Inlet inletB(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{20,-20},{-20,20}}, rotation=180, origin={-100,0})));
-  JunctionN junctionN(final N=2, redeclare package Medium = Medium, final L=L,
-    final assumeConstantDensity = assumeConstantDensity, final m_flow_eps=m_flow_eps)
-    annotation (Placement(transformation(
-        extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={40,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
+  JunctionN junctionN(
+    displayInstanceName=true,
+    final N=2,
+    redeclare package Medium = Medium,
+    final L=L,
+    final assumeConstantDensity = assumeConstantDensity,
+    final m_flow_eps=m_flow_eps)
+    annotation (Placement(transformation(extent={{20,-10},{40,10}})));
 
 equation
   connect(junctionN.inlets[2], inletB) annotation (Line(
-      points={{20,-1},{-39,-1},{-39,0},{-100,0}},
+      points={{20,0.5},{18,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(inletA, junctionN.inlets[1]) annotation (Line(
-      points={{0,100},{0,1},{20,1}},
+      points={{0,100},{0,-0.5},{20,-0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionN.outlet, outlet) annotation (Line(
-      points={{60,-1.33227e-15},{81,-1.33227e-15},{81,0},{100,0}},
+      points={{40,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
        Text(visible=displayInstanceName,
           extent={{-150,-25},{150,-65}},
           textString="%name",

--- a/ThermofluidStream/Topology/JunctionX1.mo
+++ b/ThermofluidStream/Topology/JunctionX1.mo
@@ -14,49 +14,45 @@ model JunctionX1 "Splitter/Junction with two inlets and two outlets"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Outlet outleta(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{20,-20},{-20,20}}, rotation=180, origin={100,0}),  iconTransformation(
-        extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   Interfaces.Outlet outletb(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,-100}), iconTransformation(
-        extent={{-20,-20},{20,20}},
-        rotation=-90,
-        origin={0,-100})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,-100})));
   Interfaces.Inlet inletA(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,100})));
   Interfaces.Inlet inletB(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{20,-20},{-20,20}}, rotation=180, origin={-100,0}),iconTransformation(
-        extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={-100,0})));
-  JunctionNM junctionNM(N=2, M=2, redeclare package Medium = Medium, final L=L,
-    final assumeConstantDensity = assumeConstantDensity, final m_flow_eps=m_flow_eps)
-    annotation (Placement(transformation(extent={{20,-20},{-20,20}},
-        rotation=180)));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
+  JunctionNM junctionNM(
+    displayInstanceName=true,
+    N=2,
+    M=2,
+    redeclare package Medium = Medium,
+    final L=L,
+    final assumeConstantDensity = assumeConstantDensity,
+    final m_flow_eps=m_flow_eps)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 
 equation
   connect(inletB, junctionNM.inlets[2]) annotation (Line(
-      points={{-100,0},{-20,0},{-20,-1}},
+      points={{-100,0},{-98,0.5},{-10,0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionNM.outlets[1], outleta) annotation (Line(
-      points={{20,1},{100,1},{100,0}},
+      points={{10,-0.5},{12,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(inletA, junctionNM.inlets[1]) annotation (Line(
-      points={{0,100},{0,20},{-40,20},{-40,1},{-20,1}},
+      points={{0,100},{0,14},{-18,14},{-18,-0.5},{-10,-0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(outletb, junctionNM.outlets[2]) annotation (Line(
-      points={{0,-100},{0,-20},{30,-20},{30,-1},{20,-1}},
+      points={{0,-100},{0,-14},{18,-14},{18,0.5},{10,0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(outleta, outleta) annotation (Line(
       points={{100,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junctionX", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,65},{150,25}},
           textString="%name",

--- a/ThermofluidStream/Topology/JunctionX2.mo
+++ b/ThermofluidStream/Topology/JunctionX2.mo
@@ -17,17 +17,20 @@ model JunctionX2 "Splitter/Junction with two inlets and two outlets"
   Interfaces.Outlet outleta(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={-100,0})));
   Interfaces.Outlet outletb(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=0, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   Interfaces.Inlet inletA(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,100})));
   Interfaces.Inlet inletB(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=90, origin={0,-100})));
-  JunctionNM junctionNM(N=2, M=2, redeclare package Medium = Medium, final L=L,
-    final assumeConstantDensity = assumeConstantDensity, final m_flow_eps=m_flow_eps)
-    annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={0,20})));
+  JunctionNM junctionNM(
+    displayInstanceName=true,
+    N=2,
+    M=2,
+    redeclare package Medium = Medium,
+    final L=L,
+    final assumeConstantDensity = assumeConstantDensity,
+    final m_flow_eps=m_flow_eps)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=270,origin={0,20})));
 
 equation
 
@@ -47,7 +50,7 @@ equation
       points={{0,-100},{0,-40},{40,-40},{40,52},{0.5,52},{0.5,30}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junctionX", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,65},{150,25}},
           textString="%name",

--- a/ThermofluidStream/Topology/JunctionX3.mo
+++ b/ThermofluidStream/Topology/JunctionX3.mo
@@ -15,45 +15,41 @@ model JunctionX3 "Junction with three inlets and one outlet"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Outlet outlet(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{20,-20},{-20,20}}, rotation=180, origin={100,0}), iconTransformation(
-        extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   Interfaces.Inlet inletA(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,100})));
   Interfaces.Inlet inletB(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{20,-20},{-20,20}}, rotation=180, origin={-100,0}), iconTransformation(
-        extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={-100,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Inlet inletC(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=90, origin={0,-100})));
-  JunctionN junctionN(final N=3, redeclare package Medium = Medium, final L=L,
-    final m_flow_eps=m_flow_eps, final assumeConstantDensity = assumeConstantDensity)
-    annotation (Placement(transformation(
-        extent={{20,-20},{-20,20}},
-        rotation=180,
-        origin={40,0})));
+  JunctionN junctionN(
+    displayInstanceName=true,
+    final N=3,
+    redeclare package Medium = Medium,
+    final L=L,
+    final m_flow_eps=m_flow_eps,
+    final assumeConstantDensity = assumeConstantDensity)
+    annotation (Placement(transformation(extent={{20,-10},{40,10}})));
 
 equation
 
   connect(junctionN.inlets[2], inletB) annotation (Line(
-      points={{20,3.10862e-15},{-40,3.10862e-15},{-40,0},{-100,0}},
+      points={{20,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(inletC, junctionN.inlets[3]) annotation (Line(
-      points={{0,-100},{0,-1.33333},{20,-1.33333}},
+      points={{0,-100},{0,0.666667},{20,0.666667}},
       color={28,108,200},
       thickness=0.5));
   connect(inletA, junctionN.inlets[1]) annotation (Line(
-      points={{0,100},{0,1.33333},{20,1.33333}},
+      points={{0,100},{0,-0.666667},{20,-0.666667}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionN.outlet, outlet) annotation (Line(
-      points={{60,-1.33227e-15},{81,-1.33227e-15},{81,0},{100,0}},
+      points={{40,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junctionX", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,65},{150,25}},
           textString="%name",

--- a/ThermofluidStream/Topology/NonPhysical.mo
+++ b/ThermofluidStream/Topology/NonPhysical.mo
@@ -53,16 +53,14 @@ package NonPhysical "Junctions and splitters with non-physical constraints"
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
 
     Interfaces.Outlet outlet(redeclare package Medium = Medium)
-      annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={-100,0})));
+      annotation (Placement(transformation(extent={{80,-20},{120,20}})));
     Interfaces.Inlet inletA(redeclare package Medium = Medium)
       annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,100})));
     Interfaces.Inlet inletB(redeclare package Medium = Medium)
-      annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={100,0})));
+      annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
 
-    Modelica.Blocks.Interfaces.RealInput splitRatio(min=0, max=1) annotation (Placement(transformation(
-          extent={{-20,-20},{20,20}},
-          rotation=90,
-          origin={0,-30})));
+    Modelica.Blocks.Interfaces.RealInput splitRatio(min=0, max=1)
+      annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,-30})));
 
     // these are needed by DynamicJunctionN
   protected
@@ -163,7 +161,7 @@ package NonPhysical "Junctions and splitters with non-physical constraints"
             textColor={175,175,175},
             textString="A"),
           Text(
-            extent={{80,-20},{120,-60}},
+            extent={{-120,-20},{-80,-60}},
             textColor={175,175,175},
             textString="B")}),
       Diagram(coordinateSystem(preserveAspectRatio=true)),

--- a/ThermofluidStream/Topology/SplitterT1.mo
+++ b/ThermofluidStream/Topology/SplitterT1.mo
@@ -11,28 +11,37 @@ model SplitterT1 "Splitter with one inlet and two outlets"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Inlet inlet(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=0, origin={-100,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Outlet outletA(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=90, origin={0,100})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},
+        rotation=90,
+        origin={0,100}), iconTransformation(
+        extent={{-20,-20},{20,20}},
+        rotation=90,
+        origin={0,100})));
   Interfaces.Outlet outletB(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=-90, origin={0,-100})));
-  SplitterN splitterN(final N=2, final L=L, redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-28,-10},{-8,10}})));
+  SplitterN splitterN(
+    displayInstanceName=true,
+    final N=2,
+    final L=L,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
 
 equation
   connect(splitterN.inlet, inlet) annotation (Line(
-      points={{-28,0},{-100,0}},
+      points={{-40,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(splitterN.outlets[2], outletA) annotation (Line(
-      points={{-8,0.5},{0,0.5},{0,100}},
+      points={{-20,0.5},{0,0.5},{0,100}},
       color={28,108,200},
       thickness=0.5));
   connect(outletB, splitterN.outlets[1]) annotation (Line(
-      points={{0,-100},{0,-0.5},{-8,-0.5}},
+      points={{0,-100},{0,-0.5},{-20,-0.5}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "splitter",Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,-65},{150,-25}},
           textString="%name",

--- a/ThermofluidStream/Topology/SplitterT2.mo
+++ b/ThermofluidStream/Topology/SplitterT2.mo
@@ -15,8 +15,12 @@ model SplitterT2 "Splitter with one inlet and two oulets"
   Interfaces.Outlet outletA(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,100})));
   Interfaces.Outlet outletB(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=0,origin={100,0})));
-  SplitterN splitterN(final N=2, final L=L, redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
+  SplitterN splitterN(
+    displayInstanceName=true,
+    final N=2,
+    final L=L,
+    redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
 
 equation
@@ -25,14 +29,14 @@ equation
       color={28,108,200},
       thickness=0.5));
   connect(splitterN.outlets[1], outletB) annotation (Line(
-      points={{-20,-0.5},{-20,0},{100,0}},
+      points={{-20,-0.5},{-18,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(outletA, splitterN.outlets[2]) annotation (Line(
       points={{0,100},{0,0.5},{-20,0.5}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "splitter",Icon(coordinateSystem(preserveAspectRatio=true), graphics={
        Text(visible=displayInstanceName,
           extent={{-150,-25},{150,-65}},
           textString="%name",

--- a/ThermofluidStream/Topology/SplitterX.mo
+++ b/ThermofluidStream/Topology/SplitterX.mo
@@ -15,27 +15,31 @@ model SplitterX "Splitter with one inlet and three outlets"
   Interfaces.Outlet outletA(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-20,-20}, {20,20}}, rotation=90, origin={0,100})));
   Interfaces.Outlet outletB(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=270, origin={3.55271e-15,-100})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=270, origin={0,-100})));
   Interfaces.Outlet outletC(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-20,-20}, {20,20}},rotation=0,origin={100,0})));
-  SplitterN splitterN(final N=3, final L=L, redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-32,-10},{-12,10}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
+  SplitterN splitterN(
+    displayInstanceName=true,
+    final N=3,
+    final L=L,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
 
 equation
   connect(splitterN.inlet, inlet) annotation (Line(
-      points={{-32,0},{-100,0}},
+      points={{-40,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(splitterN.outlets[3], outletA) annotation (Line(
-      points={{-12,0.666667},{0,0.666667},{0,100}},
+      points={{-20,0.666667},{0,0.666667},{0,100}},
       color={28,108,200},
       thickness=0.5));
   connect(splitterN.outlets[2], outletC) annotation (Line(
-      points={{-12,0},{100,0}},
+      points={{-20,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(splitterN.outlets[1], outletB) annotation (Line(
-      points={{-12,-0.666667},{0,-0.666667},{0,-100},{3.55271e-15,-100}},
+      points={{-20,-0.666667},{0,-0.666667},{0,-100}},
       color={28,108,200},
       thickness=0.5));
   annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={

--- a/ThermofluidStream/Undirected/Boundaries/BoundaryFore.mo
+++ b/ThermofluidStream/Undirected/Boundaries/BoundaryFore.mo
@@ -62,20 +62,16 @@ model BoundaryFore "Generic Boundary model (may act as source or sink)"
   //-----------------------------------------------------------------
 
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,60}),
-      iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,60})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,60})));
   Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if not setEnthalpy and temperatureFromInput "Temperature input connector [K]"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,20}),
-      iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,0})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,0})));
   Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if setEnthalpy and enthalpyFromInput "Enthalpy input connector"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-20}),
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={-20,0}),
       iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,0})));
   Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fraction connector [kg/kg]"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-60}),
-      iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-60})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-60}), iconTransformation(extent={{-20,-20},{20,20}}, rotation=180, origin={20,-60})));
   Interfaces.Rear rear(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}),
-      iconTransformation(extent={{-80,-20},{-120,20}})));
+    annotation (Placement(transformation(extent={{-80,-20},{-120,20}})));
 
 protected
   SI.Pressure p_forwards = Medium.pressure(rear.state_forwards);

--- a/ThermofluidStream/Undirected/Boundaries/BoundaryRear.mo
+++ b/ThermofluidStream/Undirected/Boundaries/BoundaryRear.mo
@@ -62,16 +62,15 @@ model BoundaryRear "Generic Boundary model (may act as source or sink)"
   //-----------------------------------------------------------------
 
   Modelica.Blocks.Interfaces.RealInput p0_var(unit="Pa") if pressureFromInput "Pressure input connector [Pa]"
-    annotation (Placement(transformation(extent={{-40,40},{0,80}}), iconTransformation(extent={{-40,40},{0,80}})));
+    annotation (Placement(transformation(extent={{-40,40},{0,80}})));
   Modelica.Blocks.Interfaces.RealInput T0_var(unit = "K") if not setEnthalpy and temperatureFromInput "Temperature input connector [K]"
-    annotation (Placement(transformation(extent={{-40,0},{0,40}}), iconTransformation(extent={{-40,-20},{0,20}})));
+    annotation (Placement(transformation(extent={{-40,-20},{0,20}})));
   Modelica.Blocks.Interfaces.RealInput h0_var(unit = "J/kg") if setEnthalpy and enthalpyFromInput "Specific enthalpy input connector [J/kg]"
-    annotation (Placement(transformation(extent={{-40,-40},{0,0}}), iconTransformation(extent={{-40,-20},{0,20}})));
+    annotation (Placement(transformation(extent={{0,-20},{40,20}}), iconTransformation(extent={{-40,-20},{0,20}})));
   Modelica.Blocks.Interfaces.RealInput xi_var[Medium.nXi](each unit = "kg/kg") if xiFromInput "Mass fractions input connector [kg/kg]"
-    annotation (Placement(transformation(extent={{-40,-80},{0,-40}}), iconTransformation(extent={{-40,-80},{0,-40}})));
+    annotation (Placement(transformation(extent={{-40,-80},{0,-40}})));
   Interfaces.Fore fore(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{80,-20},{120,20}}),
-      iconTransformation(extent={{80,-20},{120,20}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
 protected
   SI.Pressure p_rearwards = Medium.pressure(fore.state_rearwards);

--- a/ThermofluidStream/Undirected/Boundaries/Internal/PartialVolume.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Internal/PartialVolume.mo
@@ -51,11 +51,9 @@ the fores and rears the volume is connected to.
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort(Q_flow=Q_flow, T=T_heatPort) if useHeatport
     annotation (Placement(transformation(extent={{-10,-90},{10,-70}})));
   Interfaces.Rear rear(redeclare package Medium=Medium, m_flow=m_flow_rear, r=r_rear_port, state_rearwards=state_out_rear, state_forwards=state_in_rear) if useRear
-    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}),
-        iconTransformation(extent={{-120,-20},{-80,20}})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Fore fore(redeclare package Medium=Medium, m_flow=m_flow_fore, r=r_fore_port, state_forwards=state_out_fore, state_rearwards=state_in_fore) if useFore
-    annotation (Placement(transformation(extent={{80,-20},{120,20}}),
-        iconTransformation(extent={{80,-20},{120,20}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
   Medium.BaseProperties medium(preferredMediumStates=usePreferredMediumStates);
 

--- a/ThermofluidStream/Undirected/Boundaries/Internal/PartialVolumeN.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Internal/PartialVolumeN.mo
@@ -50,11 +50,9 @@ the fores and rears the volume is connected to.
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort(Q_flow=Q_flow, T=T_heatPort) if useHeatport
     annotation (Placement(transformation(extent={{-10,-90},{10,-70}})));
   Interfaces.Rear rear[N_rear](redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}),
-        iconTransformation(extent={{-120,-20},{-80,20}})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Fore fore[N_fore](redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{80,-20},{120,20}}),
-        iconTransformation(extent={{80,-20},{120,20}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
   Medium.BaseProperties medium(preferredMediumStates=usePreferredMediumStates);
 

--- a/ThermofluidStream/Undirected/Boundaries/TerminalFore.mo
+++ b/ThermofluidStream/Undirected/Boundaries/TerminalFore.mo
@@ -17,8 +17,7 @@ the one the inlet the source is connected to.
   parameter SI.Pressure p_0 = Medium.p_default "Initial pressure";
 
   Interfaces.Rear rear(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}),
-                                                                      iconTransformation(extent={{-120,-20},{-80,20}})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
 
 protected
   SI.Pressure p(stateSelect=StateSelect.prefer) "Pressure";

--- a/ThermofluidStream/Undirected/Boundaries/TerminalRear.mo
+++ b/ThermofluidStream/Undirected/Boundaries/TerminalRear.mo
@@ -18,7 +18,7 @@ the one the inlet the source is connected to.
   parameter SI.Pressure p_0 = Medium.p_default "Initial pressure";
 
   Interfaces.Fore fore(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{80,-20},{120,20}}), iconTransformation(extent={{80,-20},{120,20}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
 protected
   SI.Pressure p(stateSelect=StateSelect.prefer) "Pressure";

--- a/ThermofluidStream/Undirected/FlowControl/Internal/PartialValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Internal/PartialValve.mo
@@ -14,11 +14,7 @@ partial model PartialValve "Partial valve model"
     annotation (Dialog(tab="Advanced", group="Reference values"));
 
   Modelica.Blocks.Interfaces.RealInput u_in(unit="1") "Valve control signal []"
-    annotation (Placement(
-        transformation(
-        extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={0,80})));
 
   Real u(unit="1") "Actuation input for flow calculation";
 

--- a/ThermofluidStream/Undirected/FlowControl/MCV.mo
+++ b/ThermofluidStream/Undirected/FlowControl/MCV.mo
@@ -25,21 +25,9 @@ model MCV "Flow rate control valve"
   parameter Boolean enableClippingOutput = false "= true, if clippingOutput is enabled";
 
   Modelica.Blocks.Interfaces.RealInput setpoint_var if setpointFromInput "Flow rate input connector"
-    annotation (Placement(
-        transformation(extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80}), iconTransformation(
-        extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,80})));
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={0,80})));
   Modelica.Blocks.Interfaces.RealOutput clippingOutput = (dp - dp_int) if enableClippingOutput ""
-    annotation (Placement(
-        transformation(extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={0,-120}), iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={0,-110})));
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=270,origin={0,-110})));
 
   SI.Density rho_rear_in = Medium.density(rear.state_forwards) "Inlet density rear port";
   SI.Density rho_fore_in = Medium.density(fore.state_rearwards) "Inlet density fore port";

--- a/ThermofluidStream/Undirected/Interfaces/SISOBiFlow.mo
+++ b/ThermofluidStream/Undirected/Interfaces/SISOBiFlow.mo
@@ -28,11 +28,9 @@ partial model SISOBiFlow "Base Model with basic flow eqautions for SISO"
     annotation(Dialog(tab="Advanced", enable=clip_p_out));
 
   Fore fore(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{80,-20},{120,20}}),
-        iconTransformation(extent={{80,-20},{120,20}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   Rear rear(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}),
-        iconTransformation(extent={{-120,-20},{-80,20}})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
 
   SI.MassFlowRate m_flow(stateSelect=m_flowStateSelect) = rear.m_flow "Mass flow rate";
 

--- a/ThermofluidStream/Undirected/Processes/Internal/PartialConductionElement.mo
+++ b/ThermofluidStream/Undirected/Processes/Internal/PartialConductionElement.mo
@@ -22,7 +22,7 @@ partial model PartialConductionElement "Partial model of quasi-stationary mass a
     annotation(Dialog(tab="Advanced",group="global energy conservation", enable = enforce_global_energy_conservation));
 
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort(Q_flow=Q_flow, T=T_heatPort)
-    annotation (Placement(transformation(extent={{-10,88},{10,108}})));
+    annotation (Placement(transformation(extent={{-10,90},{10,110}})));
 
   SI.SpecificEnthalpy h(start=Medium.h_default, stateSelect = StateSelect.prefer) "Medium specific enthalpy";
 

--- a/ThermofluidStream/Undirected/Topology/ConnectForeFore.mo
+++ b/ThermofluidStream/Undirected/Topology/ConnectForeFore.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.Topology;
 model ConnectForeFore "Connects two fore ports"
 
-  extends ThermofluidStream.Utilities.DropOfCommonsPlus;
+  extends ThermofluidStream.Utilities.DropOfCommonsPlus(displayInstanceName=false);
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium "Medium model"
     annotation (Documentation(info="<html>
@@ -11,11 +11,9 @@ model ConnectForeFore "Connects two fore ports"
     annotation(Dialog(tab="Advanced"));
 
   Interfaces.Fore fore_a(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-30,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={-30,0})));
+    annotation (Placement(transformation(extent={{-50,-20},{-10,20}})));
   Interfaces.Fore fore_b(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={30,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={30,0})));
+    annotation (Placement(transformation(extent={{10,-20},{50,20}})));
 
 equation
   fore_b.state_forwards = fore_a.state_rearwards;

--- a/ThermofluidStream/Undirected/Topology/ConnectForeOutlet.mo
+++ b/ThermofluidStream/Undirected/Topology/ConnectForeOutlet.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.Topology;
 model ConnectForeOutlet "Connects fore port to outlet"
 
-  extends ThermofluidStream.Utilities.DropOfCommonsPlus;
+  extends ThermofluidStream.Utilities.DropOfCommonsPlus(displayInstanceName=false);
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium "Medium model"
     annotation (Documentation(info="<html>
@@ -12,40 +12,38 @@ model ConnectForeOutlet "Connects fore port to outlet"
   parameter Boolean useDefaultStateAsRear = false "=true, if default medium state is used for rear.state_rearwards";
 
   Interfaces.Fore fore(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-40,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={-30,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}),iconTransformation(extent={{-60,-20},{-20,20}})));
   ThermofluidStream.Interfaces.Outlet outlet(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={40,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={30,0})));
-  ConnectRearOutlet connectRearOutlet(redeclare package Medium=Medium, final L=L/2, final useDefaultStateAsRear = useDefaultStateAsRear)
-    annotation (Placement(transformation(extent={{0,-10},{20,10}})));
-  ConnectForeFore connectForeFore(redeclare package Medium=Medium, final L=L/2)
-    annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}}),iconTransformation(extent={{20,-20},{60,20}})));
+  ConnectRearOutlet connectRearOutlet(
+    displayInstanceName=true,
+    redeclare package Medium=Medium,
+    final L=L/2,
+    final useDefaultStateAsRear = useDefaultStateAsRear)
+    annotation (Placement(transformation(extent={{30,-10},{50,10}})));
+  ConnectForeFore connectForeFore(
+    displayInstanceName=true,
+    redeclare package Medium=Medium,
+    final L=L/2)
+    annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
   ThermofluidStream.Interfaces.StateInput state_rear(redeclare package Medium=Medium) if not useDefaultStateAsRear
-    annotation (Placement(
-        transformation(
-        extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,40}), iconTransformation(
-        extent={{20,-20},{-20,20}},
-        rotation=270,
-        origin={0,-40})));
+    annotation (Placement(transformation(extent={{20,-20},{-20,20}},rotation=270,origin={0,-40})));
 
 equation
 
   connect(connectRearOutlet.rear, connectForeFore.fore_b) annotation (Line(
-      points={{7,0},{-7,0}},
+      points={{37,0},{-37,0}},
       color={28,108,200},
       thickness=0.5));
   connect(connectRearOutlet.outlet, outlet) annotation (Line(
-      points={{13,0},{40,0}},
+      points={{43,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(connectForeFore.fore_a, fore) annotation (Line(
-      points={{-13,0},{-40,0}},
+      points={{-43,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
-  connect(connectRearOutlet.state_rear, state_rear) annotation (Line(points={{10,-4},{10,12},{0,12},{0,40}},
+  connect(connectRearOutlet.state_rear, state_rear) annotation (Line(points={{40,-4},{40,-12},{0,-12},{0,-40}},
                                  color={162,29,33}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=true),
       graphics={

--- a/ThermofluidStream/Undirected/Topology/ConnectInletFore.mo
+++ b/ThermofluidStream/Undirected/Topology/ConnectInletFore.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.Topology;
 model ConnectInletFore "Connects inlet to fore port"
 
-  extends ThermofluidStream.Utilities.DropOfCommonsPlus;
+  extends ThermofluidStream.Utilities.DropOfCommonsPlus(displayInstanceName=false);
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium "Medium model"
     annotation (Documentation(info="<html>
@@ -11,11 +11,9 @@ model ConnectInletFore "Connects inlet to fore port"
     annotation(Dialog(tab="Advanced"));
 
   ThermofluidStream.Interfaces.Inlet inlet(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-30,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={-30,0})));
+    annotation (Placement(transformation(extent={{-50,-20},{-10,20}})));
   Interfaces.Fore fore(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={30,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={30,0})));
+    annotation (Placement(transformation(extent={{10,-20},{50,20}})));
 
 protected
   SI.Pressure r_fore, r_inlet "Inertial pressures";

--- a/ThermofluidStream/Undirected/Topology/ConnectInletRear.mo
+++ b/ThermofluidStream/Undirected/Topology/ConnectInletRear.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.Topology;
 model ConnectInletRear "Connects inlet to rear port"
 
-  extends ThermofluidStream.Utilities.DropOfCommonsPlus;
+  extends ThermofluidStream.Utilities.DropOfCommonsPlus(displayInstanceName=false);
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium "Medium model"
     annotation (Documentation(info="<html>
@@ -11,27 +11,31 @@ model ConnectInletRear "Connects inlet to rear port"
     annotation(Dialog(tab="Advanced"));
 
   ThermofluidStream.Interfaces.Inlet inlet(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-40,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={-30,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}), iconTransformation(extent={{-50,-20},{-10,20}})));
   Interfaces.Rear rear(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={40,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={30,0})));
-  ConnectInletFore connectInletFore(redeclare package Medium=Medium, final L=L/2)
-    annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
-  ConnectRearRear connectRearRear(redeclare package Medium=Medium, final L=L/2)
-    annotation (Placement(transformation(extent={{2,-10},{22,10}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}}),iconTransformation(extent={{10,-20},{50,20}})));
+  ConnectInletFore connectInletFore(
+    displayInstanceName=true,
+    redeclare package Medium=Medium,
+    final L=L/2)
+    annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
+  ConnectRearRear connectRearRear(
+    displayInstanceName=true,
+    redeclare package Medium=Medium,
+    final L=L/2)
+    annotation (Placement(transformation(extent={{30,-10},{50,10}})));
 
 equation
   connect(connectInletFore.fore, connectRearRear.rear_a) annotation (Line(
-      points={{-7,0},{9,0}},
+      points={{-37,0},{37,0}},
       color={28,108,200},
       thickness=0.5));
   connect(inlet, connectInletFore.inlet) annotation (Line(
-      points={{-40,0},{-13,0}},
+      points={{-100,0},{-43,0}},
       color={28,108,200},
       thickness=0.5));
   connect(connectRearRear.rear_b, rear) annotation (Line(
-      points={{15,0},{40,0}},
+      points={{43,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
   annotation (Icon(

--- a/ThermofluidStream/Undirected/Topology/ConnectRearOutlet.mo
+++ b/ThermofluidStream/Undirected/Topology/ConnectRearOutlet.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.Topology;
 model ConnectRearOutlet "Connects rear port to outlet"
 
-  extends ThermofluidStream.Utilities.DropOfCommonsPlus;
+  extends ThermofluidStream.Utilities.DropOfCommonsPlus(displayInstanceName=false);
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium "Medium model"
     annotation (Documentation(info="<html>
@@ -12,20 +12,11 @@ model ConnectRearOutlet "Connects rear port to outlet"
   parameter Boolean useDefaultStateAsRear = false "= true, if default medium state is used for rear.state_rearwards";
 
   Interfaces.Rear rear(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-30,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={-30,0})));
+    annotation (Placement(transformation(extent={{-50,-20},{-10,20}})));
   ThermofluidStream.Interfaces.Outlet outlet(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={30,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={30,0})));
+    annotation (Placement(transformation(extent={{10,-20},{50,20}})));
   ThermofluidStream.Interfaces.StateInput state_rear(redeclare package Medium=Medium, state = rear.state_rearwards) if not useDefaultStateAsRear
-    annotation (Placement(
-        transformation(
-        extent={{-20,-20},{20,20}},
-        rotation=270,
-        origin={0,40}), iconTransformation(
-        extent={{20,-20},{-20,20}},
-        rotation=270,
-        origin={0,-40})));
+    annotation (Placement(transformation(extent={{20,-20},{-20,20}},rotation=270,origin={0,-40})));
 
 protected
   SI.Pressure r_rear, r_outlet "Inertial pressures";

--- a/ThermofluidStream/Undirected/Topology/ConnectRearRear.mo
+++ b/ThermofluidStream/Undirected/Topology/ConnectRearRear.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.Topology;
 model ConnectRearRear "Connects two rear ports"
 
-  extends ThermofluidStream.Utilities.DropOfCommonsPlus;
+  extends ThermofluidStream.Utilities.DropOfCommonsPlus(displayInstanceName=false);
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium "Medium model"
     annotation (Documentation(info="<html>
@@ -11,11 +11,9 @@ model ConnectRearRear "Connects two rear ports"
     annotation(Dialog(tab="Advanced"));
 
   Interfaces.Rear rear_a(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-30,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={-30,0})));
+    annotation (Placement(transformation(extent={{-50,-20},{-10,20}})));
   Interfaces.Rear rear_b(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={30,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={30,0})));
+    annotation (Placement(transformation(extent={{10,-20},{50,20}})));
 
 equation
   rear_b.state_rearwards = rear_a.state_forwards;

--- a/ThermofluidStream/Undirected/Topology/ConnectorInletOutletFore.mo
+++ b/ThermofluidStream/Undirected/Topology/ConnectorInletOutletFore.mo
@@ -19,13 +19,11 @@ model ConnectorInletOutletFore "Connects fore port to directed flow"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Fore fore(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-20,-120},{20,-80}}), iconTransformation(extent={{-20,-120},{20,-80}})));
+    annotation (Placement(transformation(extent={{-20,-120},{20,-80}})));
   ThermofluidStream.Interfaces.Inlet inlet(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{-120,-20},{-80,20}}), iconTransformation(extent={{-120,-20},{
-            -80,20}})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   ThermofluidStream.Interfaces.Outlet outlet(redeclare package Medium = Medium)
-    annotation (Placement(transformation(extent={{80,-20},{120,20}}), iconTransformation(extent={{80,-20},{120,
-            20}})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   ThermofluidStream.FlowControl.CheckValve checkValve(
     redeclare package Medium = Medium,
     final L=L,
@@ -42,7 +40,7 @@ model ConnectorInletOutletFore "Connects fore port to directed flow"
     redeclare package Medium = Medium,
     final L=L,
     final useDefaultStateAsRear=false)
-      annotation (Placement(transformation(extent={{20,-10},{40,10}})));
+      annotation (Placement(transformation(extent={{20,10},{40,-10}})));
   ConnectInletFore connectInletFore(
     redeclare package Medium = Medium,
     final L=L)
@@ -91,7 +89,7 @@ equation
       points={{-10,18},{-40,18},{-40,0},{-50,0}},
       color={28,108,200},
       thickness=0.5));
-  connect(sensorState.state_out, connectRearOutlet.state_rear) annotation (Line(points={{8,18},{30,18},{30,-4}}, color={162,29,33}));
+  connect(sensorState.state_out, connectRearOutlet.state_rear) annotation (Line(points={{8,18},{30,18},{30,4}},  color={162,29,33}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,65},{150,25}},

--- a/ThermofluidStream/Undirected/Topology/JunctionMN.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionMN.mo
@@ -17,11 +17,9 @@ model JunctionMN "Generalized junction/splitter for undirected flow"
     annotation(Dialog(tab="Advanced"));
 
   Interfaces.Rear rears[N](redeclare package Medium = Medium) "Rear ports"
-      annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
+      annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Fore fores[M](redeclare package Medium = Medium) "Fore ports"
-      annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0}),
-        iconTransformation(extent={{-20,-20},{20,20}}, origin={100,0})));
+      annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
   SI.Pressure p_mix "(Steady-state) pressure of mixture (assuming positive mass flow rates)";
 

--- a/ThermofluidStream/Undirected/Topology/JunctionRFF.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRFF.mo
@@ -15,12 +15,13 @@ model JunctionRFF "Junction of one rear and two fore ports"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Rear rear(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Fore foreA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,100})));
+    annotation (Placement(transformation(extent={{-20,80},{20,120}})));
   Interfaces.Fore foreB(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-100})));
+    annotation (Placement(transformation(extent={{-20,-120},{20,-80}})));
   JunctionMN junctionMN(
+    displayInstanceName=true,
     final M=2,
     final N=1,
     final assumeConstantDensity=assumeConstantDensity,
@@ -31,7 +32,7 @@ model JunctionRFF "Junction of one rear and two fore ports"
 
 equation
   connect(junctionMN.rears[1], rear) annotation (Line(
-      points={{-50,0},{-76,0},{-76,0},{-100,0}},
+      points={{-50,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionMN.fores[1], foreB) annotation (Line(
@@ -42,7 +43,7 @@ equation
       points={{0,100},{0,0.5},{-30,0.5}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction",Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,-25},{150,-65}},
           textString="%name",

--- a/ThermofluidStream/Undirected/Topology/JunctionRFF2.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRFF2.mo
@@ -15,12 +15,13 @@ model JunctionRFF2 "Junction of one rear and two fore ports"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Rear rear(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Fore foreA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,100})));
+    annotation (Placement(transformation(extent={{-20,80},{20,120}})));
   Interfaces.Fore foreB(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   JunctionMN junctionMN(
+    displayInstanceName=true,
     final M=2,
     final N=1,
     final assumeConstantDensity=assumeConstantDensity,
@@ -32,18 +33,18 @@ model JunctionRFF2 "Junction of one rear and two fore ports"
 equation
 
   connect(junctionMN.rears[1], rear) annotation (Line(
-      points={{-50,0},{-76,0},{-76,0},{-100,0}},
+      points={{-50,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionMN.fores[2], foreA) annotation (Line(
-      points={{-30,0.5},{-30,1},{0,1},{0,100}},
+      points={{-30,0.5},{0,0.5},{0,100}},
       color={28,108,200},
       thickness=0.5));
   connect(foreB, junctionMN.fores[1]) annotation (Line(
-      points={{100,0},{20,0},{20,-0.5},{-30,-0.5}},
+      points={{100,0},{98,-0.5},{-30,-0.5}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,-25},{150,-65}},
           textString="%name",

--- a/ThermofluidStream/Undirected/Topology/JunctionRFFF.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRFFF.mo
@@ -15,14 +15,15 @@ model JunctionRFFF "Junction of one rear and three fore ports"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Rear rear(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Fore foreA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,100})));
+    annotation (Placement(transformation(extent={{-20,80},{20,120}})));
   Interfaces.Fore foreB(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   Interfaces.Fore foreC(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-100})));
+    annotation (Placement(transformation(extent={{-20,-120},{20,-80}})));
   JunctionMN junctionMN(
+    displayInstanceName=true,
     final M=3,
     final N=1,
     final assumeConstantDensity=assumeConstantDensity,
@@ -33,7 +34,7 @@ model JunctionRFFF "Junction of one rear and three fore ports"
 
 equation
   connect(junctionMN.rears[1], rear) annotation (Line(
-      points={{-50,0},{-76,0},{-76,0},{-100,0}},
+      points={{-50,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionMN.fores[3], foreA) annotation (Line(
@@ -48,7 +49,7 @@ equation
       points={{0,-100},{0,-0.666667},{-30,-0.666667}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,65},{150,25}},
           textString="%name",

--- a/ThermofluidStream/Undirected/Topology/JunctionRRF.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRRF.mo
@@ -15,11 +15,11 @@ model JunctionRRF "Junction of two rear and one fore ports"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Fore fore(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   Interfaces.Rear rearA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,100})));
+    annotation (Placement(transformation(extent={{-20,80},{20,120}})));
   Interfaces.Rear rearB(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-100})));
+    annotation (Placement(transformation(extent={{-20,-120},{20,-80}})));
   JunctionMN junctionMN(
     final M=1,
     final N=2,
@@ -31,18 +31,18 @@ model JunctionRRF "Junction of two rear and one fore ports"
 
 equation
   connect(rearB, junctionMN.rears[1]) annotation (Line(
-      points={{0,-100},{0,-2},{30,-2},{30,-0.5}},
+      points={{0,-100},{0,-0.5},{30,-0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(rearA, junctionMN.rears[2]) annotation (Line(
-      points={{0,100},{0,0.5},{30,0.5}},
+      points={{0,100},{0,-2},{30,-2},{30,0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionMN.fores[1], fore) annotation (Line(
-      points={{50,0},{76,0},{76,0},{100,0}},
+      points={{50,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,25},{150,65}},
           textString="%name",

--- a/ThermofluidStream/Undirected/Topology/JunctionRRF2.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRRF2.mo
@@ -14,7 +14,15 @@ model JunctionRRF2 "Junction of two rear and one fore ports"
   parameter Utilities.Units.Inertance L=dropOfCommons.L "Inertance of each branch"
     annotation (Dialog(tab="Advanced"));
 
+  Interfaces.Rear rearA(redeclare package Medium=Medium)
+    annotation (Placement(transformation(extent={{-20,-120},{20,-80}})));
+  Interfaces.Rear rearB(redeclare package Medium=Medium)
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
+  Interfaces.Fore fore(redeclare package Medium=Medium)
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
+
   JunctionMN junctionMN(
+    displayInstanceName=true,
     final M=1,
     final N=2,
     final assumeConstantDensity=assumeConstantDensity,
@@ -22,27 +30,20 @@ model JunctionRRF2 "Junction of two rear and one fore ports"
     final L=L,
     redeclare package Medium=Medium)
     annotation (Placement(transformation(extent={{30,-10},{50,10}})));
-  Interfaces.Rear rearA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-100})));
-  Interfaces.Rear rearB(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
-  Interfaces.Fore fore(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0})));
-
 equation
   connect(junctionMN.rears[1], rearA) annotation (Line(
       points={{30,-0.5},{0,-0.5},{0,-100}},
       color={28,108,200},
       thickness=0.5));
   connect(fore, junctionMN.fores[1]) annotation (Line(
-      points={{100,0},{76,0},{76,0},{50,0}},
+      points={{100,0},{50,0}},
       color={28,108,200},
       thickness=0.5));
   connect(rearB, junctionMN.rears[2]) annotation (Line(
-      points={{-100,0},{-36,0},{-36,0.5},{30,0.5}},
+      points={{-100,0},{-98,0.5},{30,0.5}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
   Text(visible=displayInstanceName,
           extent={{-150,25},{150,65}},
           textString="%name",

--- a/ThermofluidStream/Undirected/Topology/JunctionRRFF.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRRFF.mo
@@ -15,14 +15,15 @@ model JunctionRRFF "Junction of two rear and two fore ports"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Rear reara(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Rear rearb(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,100})));
+    annotation (Placement(transformation(extent={{-20,80},{20,120}})));
   Interfaces.Fore foreB(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   Interfaces.Fore foreA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-100})));
+    annotation (Placement(transformation(extent={{-20,-120},{20,-80}})));
   JunctionMN junctionMN(
+    displayInstanceName=true,
     final M=2,
     final N=2,
     final assumeConstantDensity=assumeConstantDensity,
@@ -33,22 +34,22 @@ model JunctionRRFF "Junction of two rear and two fore ports"
 
 equation
   connect(foreB, junctionMN.fores[2]) annotation (Line(
-      points={{100,0},{40,0},{40,0.5},{10,0.5}},
+      points={{100,0},{98,0.5},{10,0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(foreA, junctionMN.fores[1]) annotation (Line(
-      points={{0,-100},{0,-20},{10,-20},{10,-0.5}},
+      points={{0,-100},{0,-14},{18,-14},{18,-0.5},{10,-0.5}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionMN.rears[1], reara) annotation (Line(
-      points={{-10,-0.5},{-40,-0.5},{-40,0},{-100,0}},
+      points={{-10,-0.5},{-12,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(rearb, junctionMN.rears[2]) annotation (Line(
-      points={{0,100},{0,20},{-10,20},{-10,0.5}},
+      points={{0,100},{0,14},{-18,14},{-18,0.5},{-10,0.5}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,65},{150,25}},
           textString="%name",

--- a/ThermofluidStream/Undirected/Topology/JunctionRRFF2.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRRFF2.mo
@@ -15,42 +15,41 @@ model JunctionRRFF2 "Junction of two rear and two fore ports"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Rear reara(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,100})));
+    annotation (Placement(transformation(extent={{-20,80},{20,120}})));
   Interfaces.Rear rearb(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-100})));
+    annotation (Placement(transformation(extent={{-20,-120},{20,-80}})));
   Interfaces.Fore foreA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Interfaces.Fore foreB(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
   JunctionMN junctionMN(
+    displayInstanceName=true,
     final M=2,
     final N=2,
     final assumeConstantDensity=assumeConstantDensity,
     final m_flow_reg=m_flow_reg,
     final L=L,
     redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
-        rotation=90,
-        origin={0,10})));
+    annotation (Placement(transformation(extent={{10,10},{-10,-10}},rotation=90,origin={0,20})));
 
 equation
   connect(rearb, junctionMN.rears[1]) annotation (Line(
-      points={{0,-100},{0,-20},{20,-20},{20,20},{0.5,20}},
+      points={{0,-100},{0,-20},{20,-20},{20,38},{-0.5,38},{-0.5,30}},
       color={28,108,200},
       thickness=0.5));
   connect(reara, junctionMN.rears[2]) annotation (Line(
-      points={{0,100},{0,20},{-0.5,20}},
+      points={{0,100},{0.5,98},{0.5,30}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionMN.fores[2], foreA) annotation (Line(
-      points={{-0.5,0},{-100,0}},
+      points={{0.5,10},{0.5,0},{-100,0}},
       color={28,108,200},
       thickness=0.5));
   connect(foreB, junctionMN.fores[1]) annotation (Line(
-      points={{100,0},{0.5,0}},
+      points={{100,0},{-0.5,0},{-0.5,10}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,65},{150,25}},
           textString="%name",

--- a/ThermofluidStream/Undirected/Topology/JunctionRRRF.mo
+++ b/ThermofluidStream/Undirected/Topology/JunctionRRRF.mo
@@ -15,40 +15,40 @@ model JunctionRRRF "Junction of tree rear and one fore ports"
     annotation (Dialog(tab="Advanced"));
 
   Interfaces.Rear rearA(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,100})));
+    annotation (Placement(transformation(extent={{-20,80},{20,120}})));
   Interfaces.Fore fore(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={100,0})));
+    annotation (Placement(transformation(extent={{80,-20},{120,20}})));
+  Interfaces.Rear rearB(redeclare package Medium=Medium)
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
+  Interfaces.Rear rearC(redeclare package Medium=Medium)
+    annotation (Placement(transformation(extent={{-20,-120},{20,-80}})));
   JunctionMN junctionMN(
+    displayInstanceName=true,
     final M=1,
     final N=3,
     final assumeConstantDensity=assumeConstantDensity,
     final m_flow_reg=m_flow_reg,
     final L=L,
     redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{0,-10},{20,10}})));
-  Interfaces.Rear rearB(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={-100,0})));
-  Interfaces.Rear rearC(redeclare package Medium=Medium)
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}}, origin={0,-100})));
-
+    annotation (Placement(transformation(extent={{20,-10},{40,10}})));
 equation
   connect(rearA, junctionMN.rears[2]) annotation (Line(
-      points={{0,100},{0,0}},
+      points={{0,100},{0,0},{20,0}},
       color={28,108,200},
       thickness=0.5));
   connect(rearB, junctionMN.rears[1]) annotation (Line(
-      points={{-100,0},{0,0},{0,-0.666667}},
+      points={{-100,0},{-98,-0.666667},{20,-0.666667}},
       color={28,108,200},
       thickness=0.5));
   connect(rearC, junctionMN.rears[3]) annotation (Line(
-      points={{0,-100},{0,0.666667}},
+      points={{0,-100},{0,0.666667},{20,0.666667}},
       color={28,108,200},
       thickness=0.5));
   connect(junctionMN.fores[1], fore) annotation (Line(
-      points={{20,0},{60,0},{60,0},{100,0}},
+      points={{40,0},{100,0}},
       color={28,108,200},
       thickness=0.5));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
+  annotation (defaultComponentName = "junction", Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Text(visible=displayInstanceName,
           extent={{-150,65},{150,25}},
           textString="%name",

--- a/ThermofluidStream/Utilities/showRealValue.mo
+++ b/ThermofluidStream/Utilities/showRealValue.mo
@@ -13,7 +13,7 @@ block showRealValue "Show Real value from numberPort or from number input field 
   final parameter Boolean displayVariablefinal = displayVariable and not use_numberPort;
 
   Modelica.Blocks.Interfaces.RealInput numberPort if use_numberPort "Number to be shown in diagram layer if use_numberPort = true [variable]"
-    annotation (HideResult=true,Placement(transformation(extent={{-130,-15},{-100,15}})));
+    annotation (HideResult=true,Placement(transformation(extent={{-140,-20},{-100,20}})));
   Modelica.Blocks.Interfaces.RealOutput showNumber "Number shown on screen [variable]";
 
 equation


### PR DESCRIPTION
1) removed `iconTransformation = ...` if `transformation = ...` is sufficient
2) set `defaultComponentName='splitter/junction'` for `Topology.SplitterT1, Topology.JunctionT1`, (etc.) 
3) set `displayInstanceName=false` for `ThermofluidStream.Undirected.Topology.ConnectForeFore` (etc.) 
4) fixed small issue for `ThermofluidStream.Boundaries.DynamicPressureInflow' (Outflow/Nozzle) concerning display