### PR TITLE
Fix HTWG Pipe Examples

### DIFF
--- a/ThermofluidStream/Processes/Pipes/EdgedOrifice.mo
+++ b/ThermofluidStream/Processes/Pipes/EdgedOrifice.mo
@@ -20,7 +20,7 @@ model EdgedOrifice "Pressure drop due to sharp edged orifice using Modelica.Flui
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration dp_acceleraton_0 = 0 "Initial value for der(dp)"
     annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.derivative)));
   parameter SI.Pressure dp_smooth = 1 "Start linearisation for decreasing pressure loss"
-    annotation(Dialog(tab = "Initalization"));
+    annotation(Dialog(tab = "Initialization"));
   //Advanced
   parameter Boolean computeL = true "= true, if inertance L is computed from the geometry"
     annotation(Dialog(tab="Advanced",group="Inertance"),Evaluate=true, HideResult=true, choices(checkBox=true));

--- a/ThermofluidStream/Processes/Pipes/Interfaces/SISOFlow_nonConstArea.mo
+++ b/ThermofluidStream/Processes/Pipes/Interfaces/SISOFlow_nonConstArea.mo
@@ -59,7 +59,7 @@ initial equation
 equation
   inlet.m_flow + outlet.m_flow = 0;
   outlet.r = inlet.r + dr_corr - der(inlet.m_flow)*L;
-  dq = Medium.density(inlet.state)/2*(c_in^2 - c_out^2);
+  dq = Medium.density(inlet.state)/2*(c_out^2 - c_in^2);
   if clip_p_out then
     p_out = max(p_min, p_in + dp + dq);
     dr_corr = dp + dq - (p_out - p_in);

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_CurvedBend.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_CurvedBend.mo
@@ -21,10 +21,11 @@ model Test_CurvedBend
     T0_par=293.15) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   ThermofluidStream.Processes.Pipes.CurvedBend curvedBend(
     redeclare package Medium = Medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     d=1e-2,
     delta=1.5707963267949,
     R=15e-2,
-    ks_input=1e-6) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    ks=1e-6)       annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Modelica.Blocks.Sources.Sine pressure_sine(
     amplitude=0.4e5,
     f=3,

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_Diffusor.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_Diffusor.mo
@@ -10,41 +10,31 @@ model Test_Diffusor
       displayParameters=true)
     annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
 
-  ThermofluidStream.Boundaries.Sink sink(redeclare package Medium = Medium, p0_par=100000) annotation (Placement(transformation(extent={{60,-10},{80,10}})));
+  ThermofluidStream.Boundaries.Sink sink(redeclare package Medium = Medium, p0_par=100000) annotation (Placement(transformation(extent={{20,-10},
+            {40,10}})));
   ThermofluidStream.Processes.Pipes.Diffuser diffuser(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    m_flow_0=10,
+    m_flow_0=dropOfCommons.m_flow_reg,
     d_1=0.505,
     d_2=1.009,
     setLength=false,
     alpha_par=0.1221730476396,
-    ks_input=0) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    ks=0)       annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   ThermofluidStream.Boundaries.Source source(
     redeclare package Medium = Medium,
     p0_par=200000,
     T0_par=293.15)
     annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
 
-  ThermofluidStream.Processes.FlowResistance flowResistance(
-    redeclare package Medium = Medium,
-    redeclare function pLoss =
-        ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
-    l=1,
-    shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
-    r=0.01) annotation (Placement(transformation(extent={{20,-10},{40,10}})));
-
 equation
   connect(source.outlet, diffuser.inlet) annotation (Line(
       points={{-20,0},{-10,0}},
       color={28,108,200},
       thickness=0.5));
-  connect(diffuser.outlet, flowResistance.inlet) annotation (Line(
+  connect(diffuser.outlet, sink.inlet)
+    annotation (Line(
       points={{10,0},{20,0}},
-      color={28,108,200},
-      thickness=0.5));
-  connect(flowResistance.outlet, sink.inlet) annotation (Line(
-      points={{40,0},{60,0}},
       color={28,108,200},
       thickness=0.5));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_EdgedBend.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_EdgedBend.mo
@@ -21,9 +21,10 @@ model Test_EdgedBend
     T0_par=293.15) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   ThermofluidStream.Processes.Pipes.EdgedBend edgedBend(
     redeclare package Medium = Medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     d=1e-2,
     delta=1.5707963267949,
-    ks_input=1e-6) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    ks=1e-6)       annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Modelica.Blocks.Sources.Sine pressure_sine(
     amplitude=0.4e5,
     f=3,

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_EdgedOrifice.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_EdgedOrifice.mo
@@ -12,9 +12,10 @@ model Test_EdgedOrifice
 
   ThermofluidStream.Processes.Pipes.EdgedOrifice edgedOrifice(
     redeclare package Medium = Medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     d_1=1e-2,
-    d_0=1e-3,
-    l_0=1e-3) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    d_0=0.5e-2,
+    l_0=0.1)  annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   ThermofluidStream.Boundaries.Source source(
     redeclare package Medium = Medium,
     pressureFromInput=true,

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_Junction.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_Junction.mo
@@ -22,7 +22,7 @@ model Test_Junction
   ThermofluidStream.Boundaries.Source source1(
     redeclare package Medium = Medium,
     p0_par=200000,
-    T0_par=293.15) annotation (Placement(transformation(extent={{-56,20},{-36,40}})));
+    T0_par=293.15) annotation (Placement(transformation(extent={{-74,20},{-54,40}})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
@@ -31,6 +31,13 @@ model Test_Junction
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     l=1,
     r=1e-2) annotation (Placement(transformation(extent={{20,-10},{40,10}})));
+  FlowResistance                             flowResistance1(
+    redeclare package Medium = Medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    m_flow_0=0,
+    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
+    l=1,
+    r=1e-2) annotation (Placement(transformation(extent={{-44,20},{-24,40}})));
 equation
   connect(junctionY.outlet, flowResistance.inlet)
     annotation (Line(
@@ -41,14 +48,19 @@ equation
       points={{60,0},{40,0}},
       color={28,108,200},
       thickness=0.5));
-  connect(junctionY.inlet_branching, source1.outlet)
-    annotation (Line(
-      points={{-6,8},{-6,30},{-36,30}},
-      color={28,108,200},
-      thickness=0.5));
   connect(junctionY.inlet_straight, source.outlet)
     annotation (Line(
       points={{-10,0},{-20,0}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(source1.outlet, flowResistance1.inlet)
+    annotation (Line(
+      points={{-54,30},{-44,30}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(flowResistance1.outlet, junctionY.inlet_branching)
+    annotation (Line(
+      points={{-24,30},{-6,30},{-6,8}},
       color={28,108,200},
       thickness=0.5));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_SplitterY.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_SplitterY.mo
@@ -16,7 +16,8 @@ model Test_SplitterY
     Y_type1=true,
     d_in=0.1,
     alpha=0.5235987755983) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-  ThermofluidStream.Boundaries.Sink sink(redeclare package Medium = Medium, p0_par=100000) annotation (Placement(transformation(extent={{36,20},{56,40}})));
+  ThermofluidStream.Boundaries.Sink sink(redeclare package Medium = Medium, p0_par=100000) annotation (Placement(transformation(extent={{52,20},
+            {72,40}})));
   ThermofluidStream.Boundaries.Source source(
     redeclare package Medium = Medium,
     p0_par=110000,
@@ -29,6 +30,13 @@ model Test_SplitterY
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     l=1,
     r=1e-2) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+  FlowResistance                             flowResistance1(
+    redeclare package Medium = Medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    m_flow_0=0,
+    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
+    l=1,
+    r=1e-2) annotation (Placement(transformation(extent={{20,20},{40,40}})));
 equation
   connect(splitterY.inlet, flowResistance.outlet) annotation (Line(
       points={{-10,0},{-20,0}},
@@ -42,8 +50,13 @@ equation
       points={{10,0},{20,0}},
       color={28,108,200},
       thickness=0.5));
-  connect(splitterY.outlet_branching, sink.inlet) annotation (Line(
-      points={{6.6,8.6},{6.6,30},{36,30}},
+  connect(splitterY.outlet_branching, flowResistance1.inlet) annotation (Line(
+      points={{6.6,8.6},{6.6,24},{6,24},{6,30},{20,30}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(flowResistance1.outlet, sink.inlet)
+    annotation (Line(
+      points={{40,30},{52,30}},
       color={28,108,200},
       thickness=0.5));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_SuddenContraction.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_SuddenContraction.mo
@@ -12,6 +12,7 @@ model Test_SuddenContraction
 
   ThermofluidStream.Processes.Pipes.SuddenContraction suddenContraction(
     redeclare package Medium = Medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     d_1=1e-2,
     d_2=0.5e-2) annotation (Placement(transformation(extent={{-8,-10},{12,10}})));
   ThermofluidStream.Boundaries.Source source(

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_SuddenExpansion.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_SuddenExpansion.mo
@@ -12,6 +12,7 @@ model Test_SuddenExpansion
 
   ThermofluidStream.Processes.Pipes.SuddenExpansion suddenExpansion(
     redeclare package Medium = Medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     d_1=1e-2,
     d_2=2e-2) annotation (Placement(transformation(extent={{-12,-10},{8,10}})));
   ThermofluidStream.Boundaries.Source source(


### PR DESCRIPTION
- Initialize mass flow rate in Pipes.Tests
- Fix dq = c_out^2 - c_in^2 error in SISOFlow_nonConstArea
(Still `Diffuser` and `JunctionY` dont work with m_flow = 0)