### PR TITLE
Fix centrifugal pump for multiphase media

### DIFF
--- a/ThermofluidStream/Processes/CentrifugalPump.mo
+++ b/ThermofluidStream/Processes/CentrifugalPump.mo
@@ -180,6 +180,7 @@ equation
   dp = head*rho*Modelica.Constants.g_n;
   P = tau*w;
   h_out = h_in + w_t;
+  Xi_out = Xi_in;
   eta_is = dp*V_flow/max(P,P_reg);
   w_t = P/max(m_flow,m_flow_reg);
   annotation (Icon(graphics={


### PR DESCRIPTION
Add Xi_out = Xi_in to centrifugal pump. The documentation for the component states that it is one of the assumptions made, but the equation is missing from the component, which means that it doesn't work with multiphase media models.

I've tested the changes with trivial examples using a multiphase media (JP8DryAir), which did not previously compile or simulate. With the changes applied the examples simulate with expected behavior.