### PR TITLE
Fix faulty limiting of Reynolds number

### DIFF
--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
@@ -54,7 +54,7 @@ algorithm
 
   //absolute Reynolds number
   Re_abs := abs(m_flow)*diameter/(area*mu);
-  Re_abs_limited := max(Re_small, min(1, Re_abs));
+  Re_abs_limited := max(Re_small, Re_abs);
 
   friction_factor :=
     (-1.8/n*log10((6.9/Re_abs_limited)^n + (relative_roughness/3.75)^(1.11*n)))^(-2);


### PR DESCRIPTION
In the pressure loss correlation from Haaland used in  `ThermofluidStream.Processes.FlowResistance`, the Reynolds number limiting was not correct. It resulted in a `Re = 1`, regardless of the actual Reynolds number. This led to a faulty friction factor and hence the mass-flow assigned to the pressure drop was not correct.

Closes #243 