### PR TITLE
Make CentrifugalPump compatible with OpenModelica

### DIFF
--- a/ThermofluidStream/Processes/Internal/CentrifugalPump/Auxiliaries/res_detadV.mo
+++ b/ThermofluidStream/Processes/Internal/CentrifugalPump/Auxiliaries/res_detadV.mo
@@ -1,17 +1,15 @@
 within ThermofluidStream.Processes.Internal.CentrifugalPump.Auxiliaries;
 function res_detadV "Residuum of derivative of efficiency with respect to volume flow rate"
-  extends Modelica.Icons.Function;
+  extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
   input Real ch[3] "Coefficients of head polynomial";
   input Real cp[3] "Coefficients of power polynomial";
-  input Real Vn "Normalized volume flow rate";
-  output Real res "Residuum";
 protected
-  Real N = (ch[1] + ch[2]*Vn + ch[3]*Vn^2)*Vn "Numerator";
-  Real dN = ch[1] + 2*ch[2]*Vn + 3*ch[3]*Vn^2 "Derivative of numerator with respect to Vn (normalized flow)";
-  Real D = cp[1] + cp[2]*Vn + cp[3]*Vn^2 "Denominator";
-  Real dD = cp[2] + 2*cp[3]*Vn "Derivative of denominator with respect to Vn (normalized flow)";
+  Real N = (ch[1] + ch[2]*u + ch[3]*u^2)*u "Numerator";
+  Real dN = ch[1] + 2*ch[2]*u + 3*ch[3]*u^2 "Derivative of numerator with respect to Vn (normalized flow)";
+  Real D = cp[1] + cp[2]*u + cp[3]*u^2 "Denominator";
+  Real dD = cp[2] + 2*cp[3]*u "Derivative of denominator with respect to Vn (normalized flow)";
 algorithm
-  res := D*dN - N*dD;
+  y := D*dN - N*dD;
   // eta = rho*g*h*V/P = eta_ref*(ch[1] + ch[2]*Vn + ch[3]*Vn^2)*Vn/(cp[1] + cp[2]*Vn + cp[3]*Vn^2) (@ w = w_ref, rho = rho_ref)
   // eta = N/D (numerator/denominator)
   // -> deta/dVn = 0 -> D*dN - N*dD = 0

--- a/ThermofluidStream/Processes/Internal/CentrifugalPump/Measurements/GenericPump.mo
+++ b/ThermofluidStream/Processes/Internal/CentrifugalPump/Measurements/GenericPump.mo
@@ -6,7 +6,7 @@ record GenericPump "Generic measurement data record for centrifugal pumps"
   parameter SI.Density rho_ref(displayUnit="kg/l") = 1000 "Reference density";
   parameter SI.AngularVelocity  w_ref(displayUnit="rpm") = 314.1592653589793 "Reference angular velocity"; // 3000 rpm
   final parameter Integer N = size(V_flow,1) "Number of data points";
-  parameter SI.VolumeFlowRate V_flow[:](displayUnit="m3/h") = {0,2.777777777778e-3,4.166666666667e-3} "Volume flow rate data points"
+  parameter SI.VolumeFlowRate V_flow[:](each displayUnit="m3/h") = {0,2.777777777778e-3,4.166666666667e-3} "Volume flow rate data points"
     annotation (Dialog(group="Volume flow rate")); // {0,10,15} m3/h
   parameter Boolean setHead = true "= true, if head data points shall be given (= false, if pressure difference shall be given instead)"
     annotation(Dialog(group="Head/Pressure rise"),Evaluate=true, HideResult=true, choices(checkBox=true));


### PR DESCRIPTION
* Add "each" to displayUnit modifier in GenericPump.mo
* Change res_detadV to inherit Modelica.Math.Nonlinear.Interfaces.partialScalarFunction.


With these changes, both CentrifugalPump tests compile and simulate in OMEdit.
Resolves #241 

Marked as draft, as #244 should be merged first.