### PR TITLE
TFS in Dymola library browser

### DIFF
--- a/ThermofluidStream/Resources/Scripts/Dymola/libraryinfo.mos
+++ b/ThermofluidStream/Resources/Scripts/Dymola/libraryinfo.mos
@@ -1,0 +1,10 @@
+LibraryInfoMenuCommand(
+  category="libraries",
+  text="ThermofluidStream 1.2.0",
+  reference="ThermofluidStream",
+  version="1.2.0",
+  ModelicaVersion = ">= 4.0",
+  isModel=true,
+  description="ThermofluidStream Library by DLR",
+  iconName = "../../logo_thermofluid.svg",
+  pos=1154)


### PR DESCRIPTION
Script for Dymola library browser. If the TFS repository is in the Modelica path of the library management tool in Dymola then the library browser displays the TFS.
<img width="400" height="345" alt="image" src="https://github.com/user-attachments/assets/53debe25-fda3-4289-b5f6-5dc069b7ba87" />
<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/030beb12-de43-41f7-9d3c-717d78bfbe79" />

Closes #299 

