### PR TITLE
Correct T_pSX in moist air to avoid simulation error when size X is 1

### DIFF
--- a/ThermofluidStream/Media/myMedia/Air/MoistAir.mo
+++ b/ThermofluidStream/Media/myMedia/Air/MoistAir.mo
@@ -1277,13 +1277,19 @@ end thermalConductivity;
     end f_nonlinear;
 
   algorithm
-    T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
-      function f_nonlinear(p=p, s=s, X=X[1:nX]), 190, 647);
+    if size(X, 1) == nX then
+      T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+        function f_nonlinear(p=p, s=s, X=X), 190, 647);
+    else
+      T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+        function f_nonlinear(p=p, s=s, X=cat(1,X[1:nXi],{1 - sum(X[1:nXi])})), 190, 647);
+    end if;
     annotation (Documentation(info="<html>
 Temperature is computed from pressure, specific entropy and composition via numerical inversion of function <a href=\"modelica://Modelica.Media.Air.MoistAir.s_pTX\">s_pTX</a>.
 </html>",
         revisions="<html>
 <p>2012-01-12 Stefan Wischhusen: Initial Release.</p>
+<p>2026-04-08 Corentin Lepais: Correct algorithm to add X[Air] to the vector X if size(X,1) is different from nX.</p>
 </html>"));
   end T_psX;
 


### PR DESCRIPTION
The current implementation of the function T_psX in Moist Air leads to a simulation error when using the function without providing the complete mass fraction X vector {X[Water],X[Air]}. The function has been updated to test the size of the input mass fraction vector X and re-calculate the mass fraction of air X[Air] if missing.


Closes #302 