### PR TITLE
MoistAir isentropicExponent() and specificEntropy() 

### DIFF
--- a/ThermofluidStream/Media/myMedia/Air/MoistAir.mo
+++ b/ThermofluidStream/Media/myMedia/Air/MoistAir.mo
@@ -880,7 +880,12 @@ Derivative function for <a href=\"modelica://Modelica.Media.Air.MoistAir.h_pTX\"
 
   redeclare function extends isentropicExponent
     "Return isentropic exponent (only for gas fraction!)"
+
+  protected
+    MassFraction Xsat = Xsaturation(state) "Water mass fraction at saturation";
+
   algorithm
+    assert(state.X[Water] < 0.999*Xsat, "MoistAir.isentropicExponent() is invalid for saturated or supersaturated air; may yield grossly incorrect values (kappa = 3 instead of kappa = 1.4)", level = AssertionLevel.warning);
     gamma := specificHeatCapacityCp(state)/specificHeatCapacityCv(state);
   end isentropicExponent;
 
@@ -1058,7 +1063,12 @@ Derivative function for <a href=\"modelica://Modelica.Media.Air.MoistAir.specifi
   redeclare function extends specificEntropy
     "Return specific entropy from thermodynamic state record, only valid for phi<1"
 
+  protected
+    MassFraction Xsat = Xsaturation(state) "Water mass fraction at saturation";
+
   algorithm
+    assert(state.X[Water] <= Xsat, "MoistAir.specificEntropy() is formally defined for unsaturated air; in supersaturated states results remain continuous but may exhibit deviations", level = AssertionLevel.warning);
+
     s := s_pTX(
           state.p,
           state.T,


### PR DESCRIPTION
Closes #169 

Regression test passed.

Test model:

```
package MoistAirTests "Tests MoistAir isentropicExponent() and specificEntropy()"
  extends Modelica.Icons.Package;

  model SpecificEntropy "Checks MoistAir.specificEntropy()"
    extends Modelica.Icons.Example;
    package Medium = ThermofluidStream.Media.myMedia.Air.MoistAir;

    Medium.AbsolutePressure p = Medium.p_default;
    Medium.Temperature T = Medium.T_default;
    Real x_sat = Medium.xsaturation_pT(p,T) "[kg_H2O/kg_dryAir] at saturation";
    Medium.MassFraction X_sat = x_sat/(1+x_sat) "[kg_H2O/kg_tot] at saturation";
    Medium.MassFraction X = (0 + 2*time)*X_sat "[kg_H2O/kg_tot]";
    Real x = X/(1-X) "[kg_H2O/kg_dryAir]";

    Medium.ThermodynamicState state = Medium.setState_pTX(p,T,{X});

    Medium.SpecificEntropy s = Medium.specificEntropy(state); // Specific entropy is continuous at phi = psi = 1
    Real phi = Medium.relativeHumidity(state) "p_H2O/p_H2O,sat";
    Real psi = x/x_sat;

  end SpecificEntropy;

  model IsentropicExponent
    extends Modelica.Icons.Example;
    package Medium = ThermofluidStream.Media.myMedia.Air.MoistAir;

    Medium.AbsolutePressure p = Medium.p_default;
    Medium.Temperature T = Medium.T_default;
    Real x_sat = Medium.xsaturation_pT(p,T) "[kg_H2O/kg_dryAir] at saturation";
    Medium.MassFraction X_sat = x_sat/(1+x_sat) "[kg_H2O/kg_tot] at saturation";
    Medium.MassFraction X = (0.99 + 0.02*time)*X_sat "[kg_H2O/kg_tot]";
    Real x = X/(1-X) "[kg_H2O/kg_dryAir]";

    Medium.ThermodynamicState state = Medium.setState_pTX(p,T,{X});

    Real phi = Medium.relativeHumidity(state) "p_H2O/p_H2O,sat";
    Real psi = x/x_sat;

    Medium.IsentropicExponent kappa = Medium.isentropicExponent(state); // Isentropic exponent is heavily discontinuous at phi = psi = 1, phi < 0.998 is on the safe side, phi < 0.999 is also fine IMO
    Medium.IsentropicExponent  kappa_ref = 1.39811 "Reference isentropic exponent";
    Real eps_rel_kappa = abs(kappa-kappa_ref)/kappa_ref;

  end IsentropicExponent;

  model MoistAirEntropyAndIsentropicExponent "Warning check for moist air concerning entropy and kappa, compare XSaturation with state.X to check if oversaturated"
    extends Modelica.Icons.Example;
    package Medium = ThermofluidStream.Media.myMedia.Air.MoistAir;

    Medium.AbsolutePressure p = 1e5;
    Medium.Temperature T = 293.15 + 20*cos(10*time);
    Medium.MassFraction X = 1e-2;
    Medium.ThermodynamicState state = Medium.setState_pTX(p,T,{X});

    Medium.MassFraction X_sat =  Medium.Xsaturation(state);
    Real x_sat = Medium.xsaturation_pT(p,T) "[kg_H2O/kg_dryAir] at saturation";
    Real x = X/(1-X) "[kg_H2O/kg_dryAir]";

    Real phi = Medium.relativeHumidity(state) "p_H2O/p_H2O,sat";
    Real psi = x/x_sat;

    Medium.SpecificEntropy s = Medium.specificEntropy(state); // Specific entropy is continuous at phi = psi = 1
    Medium.IsentropicExponent kappa = Medium.isentropicExponent(state); // Isentropic exponent is heavily discontinuous at phi = psi = 1, phi < 0.998 is on the safe side, phi < 0.999 is also fine IMO

    Boolean check = X > X_sat;

  end MoistAirEntropyAndIsentropicExponent;
end MoistAirTests;
```
