### PR TITLE
PartialSimpleMedium.setState_psX replaced reference_T by T0 for consistency

### DIFF
--- a/ThermofluidStream/Media/myMedia/Interfaces.mo
+++ b/ThermofluidStream/Media/myMedia/Interfaces.mo
@@ -2222,7 +2222,7 @@ Note that the (small) influence of the pressure term p/d is neglected.
       output ThermodynamicState state "Thermodynamic state record";
     algorithm
       state := ThermodynamicState(p=p, T=Modelica.Math.exp(s/cp_const +
-        Modelica.Math.log(reference_T)))
+        Modelica.Math.log(T0)))
         "Here the incompressible limit is used, with cp as heat capacity";
     end setState_psX;
 


### PR DESCRIPTION
Regression test running.

Closes #292 

Test model:

```
model PartialSimpleMedium_setState_psX

  package Medium = ThermofluidStream.Media.myMedia.Water.ConstantPropertyLiquidWater;
  Medium.AbsolutePressure p = Medium.p_default;
  Medium.Temperature T = Medium.T_default;
  Medium.ThermodynamicState state = Medium.setState_pT(p,T);
  Medium.SpecificEntropy s = Medium.specificEntropy(state);

  Medium.ThermodynamicState state1 = Medium.setState_psX(p,s,Medium.X_default);
  Medium.SpecificEntropy s1 = Medium.specificEntropy(state1);

  Real dp = abs(state.p - state1.p);
  Real dT = abs(state.T - state1.T);
  Real ds = abs(s-s1);

end PartialSimpleMedium_setState_psX;
```

