### PR TITLE
Add instance names to assertion messages

### DIFF
--- a/ThermofluidStream/Boundaries/Internal/PartialTank.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialTank.mo
@@ -93,7 +93,6 @@ Real normAcc[3]=Modelica.Math.Vectors.normalize(acceleration.a);
 
 
 protected
-  outer DropOfCommons dropOfCommons;
   outer ThermofluidStream.Boundaries.AccelerationBoundary acceleration;
 
   Medium.AbsolutePressure p_in[N_inlets] = Medium.pressure(inlet.state);

--- a/ThermofluidStream/Boundaries/Internal/PartialTank.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialTank.mo
@@ -1,5 +1,7 @@
 within ThermofluidStream.Boundaries.Internal;
 partial model PartialTank "Partial Tank model for media that are partial gas and incompressible liquid"
+  extends ThermofluidStream.Utilities.DropOfCommonsPlus;
+
   replaceable package Medium =
       ThermofluidStream.Media.additionalMedia.SingleGasAndIncompressible.PartialSingleGasAndIncompressible
     "Medium model" annotation (
@@ -90,7 +92,6 @@ inlets and outlets the volume is connected to.
 Real normAcc[3]=Modelica.Math.Vectors.normalize(acceleration.a);
 
 
-
 protected
   outer DropOfCommons dropOfCommons;
   outer ThermofluidStream.Boundaries.AccelerationBoundary acceleration;
@@ -142,19 +143,19 @@ initial equation
   if initialize_Xi then
     medium.Xi = Xi_0;
   elseif initialize_LiquidMass then
-    assert(V-M_liq_start/liquidDensity > 0,"Initial liquid mass is larger then the tank can contain",level = AssertionLevel.error);
+    assert(V-M_liq_start/liquidDensity > 0,"In \"" + instanceName + "\": Initial liquid mass is larger then the tank can contain",level = AssertionLevel.error);
       medium.Xi={(V-M_liq_start/liquidDensity)*gasDensity/((V-M_liq_start/liquidDensity)*gasDensity+M_liq_start),M_liq_start/((V-M_liq_start/liquidDensity)*gasDensity+M_liq_start)};
   end if;
 
 equation
   for i in 1:N_inlets loop
-    assert(m_flow_in[i] > m_flow_assert, "Negative massflow at tank inlet", dropOfCommons.assertionLevel);
+    assert(m_flow_in[i] > m_flow_assert, "In \"" + instanceName + "\": Negative massflow at tank inlet", dropOfCommons.assertionLevel);
   end for;
     for i in 1:M_outlets loop
-    assert(-m_flow_out[i] > m_flow_assert, "Positive massflow at tank outlet", dropOfCommons.assertionLevel);
+    assert(-m_flow_out[i] > m_flow_assert, "In \"" + instanceName + "\": Positive massflow at tank outlet", dropOfCommons.assertionLevel);
   end for;
 
-  assert(M > 0, "Tanks might not become empty");
+  assert(M > 0, "In \"" + instanceName + "\": Tanks might not become empty");
 
   der(inlet.m_flow)*L = inlet.r - r - r_damping*ones(N_inlets);
   der(outlet.m_flow)*L = outlet.r - r_damping*ones(M_outlets);

--- a/ThermofluidStream/Boundaries/Internal/PartialVolume.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialVolume.mo
@@ -111,9 +111,9 @@ initial equation
   end if;
 
 equation
-  assert(m_flow_in > m_flow_assert, "Negative mass flow rate at Volume inlet", dropOfCommons.assertionLevel);
-  assert(-m_flow_out > m_flow_assert, "Positive mass flow rate at Volume outlet", dropOfCommons.assertionLevel);
-  assert(M > 0, "Negative mass inside the volume");
+  assert(m_flow_in > m_flow_assert, "In \"" + instanceName + "\": Negative mass flow rate at Volume inlet", dropOfCommons.assertionLevel);
+  assert(-m_flow_out > m_flow_assert, "In \"" + instanceName + "\": Positive mass flow rate at Volume outlet", dropOfCommons.assertionLevel);
+  assert(M > 0, "In \"" + instanceName + "\": Negative mass inside the volume");
 
   if considerInertance then
     der(m_flow_in)*L = r_in - r - r_damping;

--- a/ThermofluidStream/Boundaries/Internal/PartialVolumeM.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialVolumeM.mo
@@ -104,11 +104,11 @@ initial equation
   end if;
 
 equation
-  assert(m_flow_in > m_flow_assert, "Negative mass flow rate at volume inlet", dropOfCommons.assertionLevel);
+  assert(m_flow_in > m_flow_assert, "In \"" + instanceName + "\": Negative mass flow rate at volume inlet", dropOfCommons.assertionLevel);
   for i in 1:M_outlets loop
-    assert(-m_flow_out[i] > m_flow_assert, "Positive mass flow rate at volume outlet", dropOfCommons.assertionLevel);
+    assert(-m_flow_out[i] > m_flow_assert, "In \"" + instanceName + "\": Positive mass flow rate at volume outlet", dropOfCommons.assertionLevel);
   end for;
-  assert(M > 0, "Negative mass inside volume");
+  assert(M > 0, "In \"" + instanceName + "\": Negative mass inside volume");
 
   der(inlet.m_flow)*L = inlet.r - r - r_damping;
   der(outlet.m_flow)*L = outlet.r - r_damping*ones(M_outlets);

--- a/ThermofluidStream/Boundaries/Internal/PartialVolumeN.mo
+++ b/ThermofluidStream/Boundaries/Internal/PartialVolumeN.mo
@@ -104,10 +104,10 @@ initial equation
 
 equation
   for i in 1:N loop
-    assert(m_flow_in[i] > m_flow_assert, "Negative mass flow rate at volume inlet", dropOfCommons.assertionLevel);
+   assert(m_flow_in[i] > m_flow_assert, "In \"" + instanceName + "\": Negative mass flow rate at volume inlet", dropOfCommons.assertionLevel);
   end for;
-  assert(-m_flow_out > m_flow_assert, "Positive mass flow rate at volume outlet", dropOfCommons.assertionLevel);
-  assert(M > 0, "Negative mass inside the volume");
+  assert(-m_flow_out > m_flow_assert, "In \"" + instanceName + "\": Positive mass flow rate at volume outlet", dropOfCommons.assertionLevel);
+  assert(M > 0, "In \"" + instanceName + "\": Negative mass inside the volume");
 
   der(inlet.m_flow)*L = inlet.r - r - r_damping*ones(N);
   der(outlet.m_flow)*L = outlet.r - r_damping;

--- a/ThermofluidStream/Boundaries/PhaseSeparator.mo
+++ b/ThermofluidStream/Boundaries/PhaseSeparator.mo
@@ -48,13 +48,13 @@ protected
   Medium.SpecificEnthalpy h_dew = Medium.dewEnthalpy(Medium.setSat_p(medium.p))+1 "Dew Enthalpy of Medium";
 
 initial equation
-  assert(pipe_high > pipe_low, "Upper pipe end must be higher then lower end.", AssertionLevel.error);
+  assert(pipe_high > pipe_low, "In \"" + instanceName + "\": Upper pipe end must be higher then lower end.", AssertionLevel.error);
 
   if init_method == Init.h then
     medium.h = h_0;
   elseif init_method == Init.M then
     x/d_gas+(1-x)/d_liq = V/M_0;
-    assert(x>=0 and x<=1, "Initialization by Mass might be inaccurate outside the two-phase region", AssertionLevel.warning);
+    assert(x>=0 and x<=1, "In \"" + instanceName + "\": Initialization by Mass might be inaccurate outside the two-phase region", AssertionLevel.warning);
   elseif init_method == Init.l then
     x = (d_gas*(1-l_0))/(d_liq*l_0+d_gas*(1-l_0));
   elseif init_method == Init.x then

--- a/ThermofluidStream/Boundaries/PhaseSeparator2.mo
+++ b/ThermofluidStream/Boundaries/PhaseSeparator2.mo
@@ -49,14 +49,14 @@ protected
   Medium.SpecificEnthalpy h_dew = Medium.dewEnthalpy(Medium.setSat_p(medium.p))+1 "Specific dew enthalpy";
 
 initial equation
-  assert(pipe1_high > pipe1_low, "Upper pipe end must be higher then lower end.", AssertionLevel.error);
-  assert(pipe2_high > pipe2_low, "Upper pipe end must be higher then lower end.", AssertionLevel.error);
+  assert(pipe1_high > pipe1_low, "In \"" + instanceName + "\": Upper pipe end must be higher then lower end.", AssertionLevel.error);
+  assert(pipe2_high > pipe2_low, "In \"" + instanceName + "\": Upper pipe end must be higher then lower end.", AssertionLevel.error);
 
   if init_method == Init.h then
     medium.h = h_0;
   elseif init_method == Init.M then
     x/d_gas+(1-x)/d_liq = V/M_0;
-    assert(x>=0 and x<=1, "Initialization by mass might be inaccurate outside the two-phase region", AssertionLevel.warning);
+    assert(x>=0 and x<=1, "In \"" + instanceName + "\": Initialization by mass might be inaccurate outside the two-phase region", AssertionLevel.warning);
   elseif init_method == Init.l then
     x = (d_gas*(1-l_0))/(d_liq*l_0+d_gas*(1-l_0));
   elseif init_method == Init.x then

--- a/ThermofluidStream/Boundaries/Reservoir.mo
+++ b/ThermofluidStream/Boundaries/Reservoir.mo
@@ -30,7 +30,7 @@ initial equation
   height = height_0;
 
 equation
-  assert(height > height_min, "Reservoir fill height must be greater than height_min", dropOfCommons.assertionLevel);
+  assert(height > height_min, "In \"" + instanceName + "\": Reservoir fill height must be greater than height_min", dropOfCommons.assertionLevel);
 
   density_derp_h = 1/(height*g);
 

--- a/ThermofluidStream/Boundaries/TankCuboid.mo
+++ b/ThermofluidStream/Boundaries/TankCuboid.mo
@@ -30,21 +30,21 @@ initial equation
 
   //check that all inlet and outlet positions are within the tank geometry
    for i in 1:N_inlets loop
-   assert(tankCenter[1]-xLength/2<=inletPositions[i,1] and inletPositions[i,1] <= tankCenter[1]+xLength/2, "Inlet outside tank geometry",level = AssertionLevel.error);
-   assert(tankCenter[2]-yLength/2<=inletPositions[i,2] and inletPositions[i,2] <= tankCenter[2]+yLength/2,"Inlet outside tank geometry",level = AssertionLevel.error);
-   assert(tankCenter[3]-zLength/2<=inletPositions[i,3] and inletPositions[i,3] <= tankCenter[3]+zLength/2,"Inlet outside tank geometry",level = AssertionLevel.error);
+   assert(tankCenter[1]-xLength/2<=inletPositions[i,1] and inletPositions[i,1] <= tankCenter[1]+xLength/2, "In \"" + instanceName + "\": Inlet outside tank geometry",level = AssertionLevel.error);
+   assert(tankCenter[2]-yLength/2<=inletPositions[i,2] and inletPositions[i,2] <= tankCenter[2]+yLength/2,"In \"" + instanceName + "\": Inlet outside tank geometry",level = AssertionLevel.error);
+   assert(tankCenter[3]-zLength/2<=inletPositions[i,3] and inletPositions[i,3] <= tankCenter[3]+zLength/2,"In \"" + instanceName + "\": Inlet outside tank geometry",level = AssertionLevel.error);
    end for;
    for i in 1:M_outlets loop
-   assert(tankCenter[1]-xLength/2<=outletPositions[i,1] and outletPositions[i,1] <= tankCenter[1]+xLength/2,"Outlet outside tank geometry",level = AssertionLevel.error);
-   assert(tankCenter[2]-yLength/2<=outletPositions[i,2] and outletPositions[i,2] <= tankCenter[2]+yLength/2,"Outlet outside tank geometry",level = AssertionLevel.error);
-   assert(tankCenter[3]-zLength/2<=outletPositions[i,3] and outletPositions[i,3] <= tankCenter[3]+zLength/2,"Outlet outside tank geometry",level = AssertionLevel.error);
+   assert(tankCenter[1]-xLength/2<=outletPositions[i,1] and outletPositions[i,1] <= tankCenter[1]+xLength/2,"In \"" + instanceName + "\": Outlet outside tank geometry",level = AssertionLevel.error);
+   assert(tankCenter[2]-yLength/2<=outletPositions[i,2] and outletPositions[i,2] <= tankCenter[2]+yLength/2,"In \"" + instanceName + "\": Outlet outside tank geometry",level = AssertionLevel.error);
+   assert(tankCenter[3]-zLength/2<=outletPositions[i,3] and outletPositions[i,3] <= tankCenter[3]+zLength/2,"In \"" + instanceName + "\": Outlet outside tank geometry",level = AssertionLevel.error);
    end for;
 equation
   V_ref =xLength*yLength*zLength;
 
-  assert((Modelica.Math.Vectors.length(normAcc)>0.99 and Modelica.Math.Vectors.length(normAcc)<1.01),"Acceleration vector is not normalized",level = AssertionLevel.error);
-  assert(-eps_geometry <= normAcc[2] and normAcc[2] <= eps_geometry,"Acceleration in y-direction not supported by tankCuboid",level=AssertionLevel.warning);
-  assert(V_liquid<=V_ref,"Trying to fit more liquid into tank than it holds",level=AssertionLevel.warning);
+  assert((Modelica.Math.Vectors.length(normAcc)>0.99 and Modelica.Math.Vectors.length(normAcc)<1.01),"In \"" + instanceName + "\": Acceleration vector is not normalized",level = AssertionLevel.error);
+  assert(-eps_geometry <= normAcc[2] and normAcc[2] <= eps_geometry,"In \"" + instanceName + "\": Acceleration in y-direction not supported by tankCuboid",level=AssertionLevel.warning);
+  assert(V_liquid<=V_ref,"In \"" + instanceName + "\": Trying to fit more liquid into tank than it holds",level=AssertionLevel.warning);
 
   centerOfMass =tankCenter;//constant in first implementation
 

--- a/ThermofluidStream/Boundaries/Volume.mo
+++ b/ThermofluidStream/Boundaries/Volume.mo
@@ -10,7 +10,7 @@ model Volume "Volume of fixed size, closed to the ambient"
     annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
 
 equation
-  assert(abs(density_derp_h) > 1e-12, "The simple Volume model should not be used with (nearly) incompressible media. Consider using the FlexVolume instead.", dropOfCommons.assertionLevel);
+  assert(abs(density_derp_h) > 1e-12, "In \"" + instanceName + "\": the simple Volume model should not be used with " + "(nearly) incompressible media. Consider using FlexVolume instead.", dropOfCommons.assertionLevel);
 
   if density_derp_h_from_media then
     density_derp_h = Medium.density_derp_h(medium.state);

--- a/ThermofluidStream/Boundaries/VolumeMix.mo
+++ b/ThermofluidStream/Boundaries/VolumeMix.mo
@@ -9,7 +9,7 @@ model VolumeMix "Volume of fixed size, closed to the ambient, with N inlets"
     annotation(Dialog(enable = ((k_volume_damping > 0) and not density_derp_h_from_media), tab="Advanced", group="Damping"));
 
 equation
-  assert(abs(density_derp_h) > 1e-12, "The volume should not be used with (nearly) incompressible media. Consider using the FlexVolume instead.", dropOfCommons.assertionLevel);
+  assert(abs(density_derp_h) > 1e-12, "In \"" + instanceName + "\": The volume should not be used with (nearly) incompressible media. Consider using the FlexVolume instead.", dropOfCommons.assertionLevel);
 
   if density_derp_h_from_media then
     density_derp_h = Medium.density_derp_h(medium.state);

--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -35,13 +35,13 @@ initial equation
 
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
-    assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(Kvs > 0, "In \"" + instanceName + "\": Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   elseif flowCoefficient == FlowCoeffType.Cvs_US then
-    assert(Cvs_US > 0, "Invalid coefficient for Cvs_US. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(Cvs_US > 0, "In \"" + instanceName + "\": Invalid coefficient for Cvs_US. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   elseif flowCoefficient == FlowCoeffType.Cvs_UK then
-    assert(Cvs_UK > 0, "Invalid coefficient for Cvs_UK. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(Cvs_UK > 0, "In \"" + instanceName + "\": Invalid coefficient for Cvs_UK. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   else
-    assert(m_flow_ref_set > 0, "Invalid coefficient for m_flow_ref_set. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(m_flow_ref_set > 0, "In \"" + instanceName + "\": Invalid coefficient for m_flow_ref_set. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   end if;
 
   //Calculate reference mass flow rate from reference volume flow rate

--- a/ThermofluidStream/FlowControl/Internal/PartialValve.mo
+++ b/ThermofluidStream/FlowControl/Internal/PartialValve.mo
@@ -28,7 +28,7 @@ protected
 
 equation
   //Inversion of input signal, actuation has to be between 0 and 1
-  assert(u_in <=1 and u_in >=0, "Actuator signal out of valid range [0,1]", level = AssertionLevel.warning);
+  assert(u_in <=1 and u_in >=0, "In \"" + instanceName + "\": Actuator signal out of valid range [0,1]", level = AssertionLevel.warning);
   if invertInput then
       u = max(0, min(1, 1-u_in));
   else

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -49,15 +49,15 @@ protected
 initial equation
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
-    assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(Kvs > 0, "In \"" + instanceName + "\": Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   elseif flowCoefficient == FlowCoeffType.Cvs_US then
-    assert(Cvs_US > 0, "Invalid coefficient for Cvs_US. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(Cvs_US > 0, "In \"" + instanceName + "\": Invalid coefficient for Cvs_US. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   elseif flowCoefficient == FlowCoeffType.Cvs_UK then
-    assert(Cvs_UK > 0, "Invalid coefficient for Cvs_UK. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(Cvs_UK > 0, "In \"" + instanceName + "\": Invalid coefficient for Cvs_UK. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   elseif flowCoefficient == FlowCoeffType.m_flow_set then
-    assert(m_flow_ref_set > 0, "Invalid coefficeint for m_flow_ref_set. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(m_flow_ref_set > 0, "In \"" + instanceName + "\": Invalid coefficient for m_flow_ref_set. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   else
-    assert(d_valve > 0, "Invalid coefficient for d_valve. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
+    assert(d_valve > 0, "In \"" + instanceName + "\": Invalid coefficient for d_valve. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
   end if;
 
   //Calculate reference mass flow rate from reference volume flow rate

--- a/ThermofluidStream/HeatExchangers/Internal/PartialDiscretizedHEX.mo
+++ b/ThermofluidStream/HeatExchangers/Internal/PartialDiscretizedHEX.mo
@@ -96,11 +96,11 @@ public
 equation
   assert(
     inletB.m_flow > m_flow_assert,
-    "Negative mass flow rate at inlet B",
+    "In \"" + instanceName + "\": Negative mass flow rate at inlet B",
     dropOfCommons.assertionLevel);
   assert(
     inletA.m_flow > m_flow_assert,
-    "Negative massflow at inlet A",
+    "In \"" + instanceName + "\": Negative massflow at inlet A",
     dropOfCommons.assertionLevel);
 
   //Summary record

--- a/ThermofluidStream/Idealized/Processes/Adiabatic.mo
+++ b/ThermofluidStream/Idealized/Processes/Adiabatic.mo
@@ -78,7 +78,6 @@ model Adiabatic "Adiabatic process"
     Dialog(tab="Layout", group="Display parameters", enable = displayParameters and etaSpec == ValueSpecification.Fixed), Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter Boolean showPowerDirection = true "= true to show the actual power direction" annotation(
     Dialog(tab="Layout", group="Display parameters", enable=displayParameters), Evaluate=true, HideResult=true, choices(checkBox=true));
-  final parameter String name = getInstanceName() "Instance name";
 
   Modelica.Blocks.Interfaces.RealInput outletSpec_prescribed if specifyOutlet and outletValueSpec == ValueSpecification.Prescribed  "Prescribed outlet specification [SI-units]" annotation(
     Placement(transformation(extent={{-20,-20},{20,20}}, rotation=90, origin={100,-120})));
@@ -162,10 +161,10 @@ equation
     P = m_flow*dh;
   elseif specifyOutlet then // and powerSignal == PowerSignal.Input
     m_flow = P * dh/(dh^2 + eps_dh^2);
-    assert(noEvent(abs(P) < eps_P or abs(dh) > eps_dh), "The power in "+name+" is non zero, but the difference in specific enthalpy is zero, implying that the mass flow rate m_flow := P/dh is infinite.\n The result is regularized.", assertionLevel);
+    assert(noEvent(abs(P) < eps_P or abs(dh) > eps_dh), "The power in "+instanceName+" is non zero, but the difference in specific enthalpy is zero, implying that the mass flow rate m_flow := P/dh is infinite.\n The result is regularized.", assertionLevel);
   else // not specifyOutlet and heatFlowSignal == HeatFlowSignal.Input
     dh = P * m_flow / (m_flow^2 + eps_m_flow^2);
-    assert(noEvent(abs(P) < eps_P or abs(m_flow) > eps_m_flow), "The power in "+name+" is non zero, but the mass flow rate is zero, implying that the difference in specific enthalpy dh := P/m_flow is infinite. \n The result is regularized.", assertionLevel);
+    assert(noEvent(abs(P) < eps_P or abs(m_flow) > eps_m_flow), "The power in "+instanceName+" is non zero, but the mass flow rate is zero, implying that the difference in specific enthalpy dh := P/m_flow is infinite. \n The result is regularized.", assertionLevel);
   end if;
 
   singularityRegime =

--- a/ThermofluidStream/Idealized/Processes/Isenthalpic.mo
+++ b/ThermofluidStream/Idealized/Processes/Isenthalpic.mo
@@ -27,7 +27,6 @@ model Isenthalpic "Isenthalpic process"
     Dialog(group="Warnings", enable = not enforcePressureDrop));
   parameter Boolean showOutletSpecification = true "= true to show the fixed outlet specification value (either dpLoss_fixed, prLoss_fixed or p_out_fixed)" annotation(
     Dialog(tab="Layout", group="Display parameters", enable = displayParameters and outletValueSpec ==ValueSpecification.Fixed),  Evaluate=true, HideResult=true, choices(checkBox=true));
-  final parameter String name = getInstanceName();
 
   Modelica.Blocks.Interfaces.RealInput outletSpec_prescribed if outletValueSpec ==ValueSpecification.Prescribed  "Prescribed outlet specification [SI-units]" annotation(
     Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={100,-120})));
@@ -49,12 +48,11 @@ protected
 equation
   if enforcePressureDrop then
     assert(noEvent(m_flow*dpLoss_set >= -Modelica.Constants.eps),
-      "In \"" + name + "\" the prescribed pressure loss would cause a pressure rise in flow direction and was clipped.",
-      assertionLevel);
+      "In \"" + instanceName + "\" the prescribed pressure loss would cause a pressure rise in flow direction and was clipped.", assertionLevel);
   end if;
   assert(noEvent(m_flow*dpLoss >= -Modelica.Constants.eps),
-    "In \"" + name +"\" the pressure rises in the direction of the flow. \n"
-    + "  An isenthalpic pressure increase however violates the second law of thermodynamics.",
+    "In \"" + instanceName +"\" the pressure rises in the direction of the flow. \n"
+    + " An isenthalpic pressure increase however violates the second law of thermodynamics.",
     assertionLevel);
 
   connect(outletSpec_actual, outletSpec_prescribed);
@@ -114,7 +112,7 @@ equation
           lineThickness=0.5),
         Text(
           extent={{-150,120},{150,80}},
-          textString=if displayInstanceName then "%name" else "",
+          textString=if displayInstanceName then "%instanceName" else "",
           textColor=dropOfCommons.instanceNameColor),
         Text(
           extent={{-30,30},{30,-30}},

--- a/ThermofluidStream/Idealized/Processes/Isobaric.mo
+++ b/ThermofluidStream/Idealized/Processes/Isobaric.mo
@@ -48,7 +48,6 @@ model Isobaric "Isobaric process"
     Dialog(
       enable = systemSpec == ThermofluidStream.Idealized.Types.SystemModel.Cycle),
     HideResult = systemSpec == ThermofluidStream.Idealized.Types.SystemModel.Flow);
-  final parameter String name = getInstanceName() "Instance name";
 
   Modelica.Blocks.Interfaces.RealInput outletSpec_prescribed if specifyOutlet and outletValueSpec == ValueSpecification.Prescribed  "Prescribed outlet specification [SI-units]" annotation(
     Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={100,-120})));
@@ -146,10 +145,10 @@ equation
     Q_flow = m_flow*q;
   elseif specifyOutlet then // and heatFlowSignal == HeatFlowSignal.Input
     m_flow = Q_flow * q/(q^2 + eps_q^2);
-    assert(noEvent(abs(Q_flow) < eps_Q_flow or abs(q) > eps_q), "The heat flow rate in "+name+" is non zero, but the specific heat flow is zero, implying that the mass flow rate m_flow := Q_flow/q is infinite.\n The result is regularized.", assertionLevel);
+    assert(noEvent(abs(Q_flow) < eps_Q_flow or abs(q) > eps_q), "The heat flow rate in "+instanceName+" is non zero, but the specific heat flow is zero, implying that the mass flow rate m_flow := Q_flow/q is infinite.\n The result is regularized.", assertionLevel);
   else // not specifyOutlet and heatFlowSignal == HeatFlowSignal.Input
     q = Q_flow * m_flow / (m_flow^2 + eps_m_flow^2);
-    assert(noEvent(abs(Q_flow) < eps_Q_flow or abs(m_flow) > eps_m_flow), "The heat flow rate in "+name+" is non zero, but the mass flow rate is zero, implying that the specific heat flow q := Q_flow/m_flow is infinite. \n The result is regularized.", assertionLevel);
+    assert(noEvent(abs(Q_flow) < eps_Q_flow or abs(m_flow) > eps_m_flow), "The heat flow rate in "+instanceName+" is non zero, but the mass flow rate is zero, implying that the specific heat flow q := Q_flow/m_flow is infinite. \n The result is regularized.", assertionLevel);
   end if;
 
   singularityRegime =
@@ -195,7 +194,7 @@ equation
           lineThickness=0.5),
         Text(
           extent={{-150,120},{150,80}},
-          textString = if displayInstanceName then "%name" else "",
+          textString = if displayInstanceName then "%instanceName" else "",
           textColor = dropOfCommons.instanceNameColor),
         Text(visible = systemSpec == ThermofluidStream.Idealized.Types.SystemModel.Flow,
           extent={{-30,30},{30,-30}},

--- a/ThermofluidStream/Idealized/Processes/MassFractionModifier.mo
+++ b/ThermofluidStream/Idealized/Processes/MassFractionModifier.mo
@@ -32,9 +32,9 @@ protected
 
 equation
   for i in 1:Medium.nXi loop
-    assert(noEvent(Xi_out[i] >= 0), "Xi_out[i] must not be negative.", AssertionLevel.error);
+  assert(noEvent(Xi_out[i] >= 0), "In \"" + instanceName + "\": Xi_out[i] must not be negative.", AssertionLevel.error);
   end for;
-  assert(noEvent(sum(Xi_out) <= 1), "sum(Xi_out) may not exceed one.", AssertionLevel.error);
+  assert(noEvent(sum(Xi_out) <= 1), "In \"" + instanceName + "\": sum(Xi_out) may not exceed one.", AssertionLevel.error);
 
   connect(outletSpec_actual, outletSpec_prescribed);
   if outletValueSpec == ValueSpecification.Fixed  then

--- a/ThermofluidStream/Processes/Compressor.mo
+++ b/ThermofluidStream/Processes/Compressor.mo
@@ -26,7 +26,7 @@ protected
 
 equation
   // test for ideal gas
-  assert(abs(R_in- R_in)/R_in < max_rel_R, "Medium in compressor is assumed to be ideal gas, but check failed", dropOfCommons.assertionLevel);
+  assert(abs(R_in- R_in)/R_in < max_rel_R, "In \"" + instanceName + "\": Medium in compressor is assumed to be ideal gas, but check failed", dropOfCommons.assertionLevel);
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Line(

--- a/ThermofluidStream/Processes/Fan.mo
+++ b/ThermofluidStream/Processes/Fan.mo
@@ -23,7 +23,7 @@ protected
 
 equation
   // test for ideal gas
-  assert(abs(R_in- R_in)/R_in < max_rel_R, "Medium in fan is assumed to be ideal gas, but check failed", dropOfCommons.assertionLevel);
+  assert(abs(R_in- R_in)/R_in < max_rel_R, "In \"" + instanceName + "\": Medium in fan is assumed to be ideal gas, but check failed", dropOfCommons.assertionLevel);
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Line(

--- a/ThermofluidStream/Processes/Internal/PartialConductionElement.mo
+++ b/ThermofluidStream/Processes/Internal/PartialConductionElement.mo
@@ -53,7 +53,7 @@ initial equation
   end if;
 
 equation
-  assert(noEvent(inlet.m_flow > m_flow_assert), "Negative mass flow rate at inlet", dropOfCommons.assertionLevel);
+  assert(noEvent(inlet.m_flow > m_flow_assert), "In \"" + instanceName + "\": Negative mass flow rate at inlet", dropOfCommons.assertionLevel);
 
   //mass is assumed to be quasisationary-> this violates the conservation of mass since m_flow_in = -m_flow_out. see documentation/information
   M = V*rho;

--- a/ThermofluidStream/Processes/Pump.mo
+++ b/ThermofluidStream/Processes/Pump.mo
@@ -28,7 +28,7 @@ protected
 
 equation
   // test for incompressibility
-  assert(abs(v_in- v_out)/v_in < max_rel_volume, "Medium in pump is assumed to be incompressible, but check failed", dropOfCommons.assertionLevel);
+  assert(abs(v_in- v_out)/v_in < max_rel_volume, "In \"" + instanceName + "\": Medium in pump is assumed to be incompressible, but check failed", dropOfCommons.assertionLevel);
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Line(

--- a/ThermofluidStream/Processes/Turbine.mo
+++ b/ThermofluidStream/Processes/Turbine.mo
@@ -25,7 +25,7 @@ protected
 
 equation
   // test for ideal gas
-  assert(abs(R_in- R_in)/R_in < max_rel_R, "Medium in turbine is assumed to be ideal gas, but check failed", dropOfCommons.assertionLevel);
+  assert(abs(R_in- R_in)/R_in < max_rel_R, "In \"" + instanceName + "\": Medium in turbine is assumed to be ideal gas, but check failed", dropOfCommons.assertionLevel);
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={
         Line(

--- a/ThermofluidStream/Utilities/DropOfCommonsPlus.mo
+++ b/ThermofluidStream/Utilities/DropOfCommonsPlus.mo
@@ -1,8 +1,9 @@
 within ThermofluidStream.Utilities;
-model DropOfCommonsPlus "Extend this to use 'dropOfCommons', 'displayInstanceName' and 'displayParameters'"
+model DropOfCommonsPlus "Extend this to use 'dropOfCommons', 'instanceName', 'displayInstanceName' and 'displayParameters'"
 protected
   outer DropOfCommons dropOfCommons;
 public
+ final parameter String instanceName = getInstanceName() "Instance name" annotation(HideResult=true);
  parameter Boolean displayInstanceName = dropOfCommons.displayInstanceNames "= true, if instance name is displayed" annotation(Dialog(tab="Layout"),Evaluate=true, HideResult=true);
  parameter Boolean displayParameters = dropOfCommons.displayParameters "= true, if displaying parameters is enabled" annotation(Dialog(tab="Layout"),Evaluate=true, HideResult=true);
 


### PR DESCRIPTION
Introduce a shared instanceName parameter in DropOfCommonsPlus and use it in component assertions to identify the source of warnings and errors.

Reuse the inherited instance name in idealized process models and keep the existing assertion conditions and messages otherwise unchanged.

> Tested models and works as expected - regression test also passed 

Closes #339