### PR TITLE
Rename initialization enum literals to PascalCase

### DIFF
--- a/TILMediaWrapper/Tests.mo
+++ b/TILMediaWrapper/Tests.mo
@@ -33,7 +33,7 @@ package Tests
       h0_par=1000) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
     ThermofluidStream.Processes.FlowResistance flowResistance(
       redeclare package Medium = Medium,
-      initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+      initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
       r(displayUnit="mm") = 0.01,
       l=10,
       redeclare function pLoss =
@@ -65,7 +65,7 @@ package Tests
       annotation (Placement(transformation(extent={{-28,60},{-8,80}})));
     ThermofluidStream.Processes.FlowResistance flowResistance1(
       redeclare package Medium = Medium,
-      initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+      initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
       r(displayUnit="mm") = 0.01,
       l=10,
       redeclare function pLoss =

--- a/ThermofluidStream/Boundaries/Tests/DynamicBoundaries.mo
+++ b/ThermofluidStream/Boundaries/Tests/DynamicBoundaries.mo
@@ -18,7 +18,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
   Sink sink(redeclare package Medium=Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{60,-10},{80,10}})));
   Processes.FlowResistance flowResistance(redeclare package Medium=Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     computeL=false,
@@ -38,7 +38,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
   Sink sink1(redeclare package Medium=Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{60,-50},{80,-30}})));
   Processes.FlowResistance flowResistance1(redeclare package Medium=Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-1,
     r(displayUnit="mm") = 0.005,
     l=10,
@@ -76,7 +76,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     annotation (Placement(transformation(extent={{60,50},{80,70}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     computeL=false,
@@ -108,7 +108,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     annotation (Placement(transformation(extent={{60,-70},{80,-50}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-1,
     r(displayUnit="mm") = 0.005,
     l=10,
@@ -133,7 +133,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     annotation (Placement(transformation(extent={{60,-90},{80,-70}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=1,
     r(displayUnit="mm") = 0.005,
     l=10,
@@ -158,7 +158,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     annotation (Placement(transformation(extent={{60,-30},{80,-10}})));
   Processes.FlowResistance flowResistance5(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-1,
     r(displayUnit="mm") = 0.005,
     l=10,

--- a/ThermofluidStream/Boundaries/Tests/PhaseSeperator.mo
+++ b/ThermofluidStream/Boundaries/Tests/PhaseSeperator.mo
@@ -52,7 +52,7 @@ model PhaseSeperator
     startTime=0) annotation (Placement(transformation(extent={{-120,-16},{-100,4}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
@@ -60,7 +60,7 @@ model PhaseSeperator
     annotation (Placement(transformation(extent={{-40,10},{-20,30}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
@@ -68,7 +68,7 @@ model PhaseSeperator
     annotation (Placement(transformation(extent={{-40,-30},{-20,-10}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
@@ -76,7 +76,7 @@ model PhaseSeperator
     annotation (Placement(transformation(extent={{30,10},{50,30}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,

--- a/ThermofluidStream/Boundaries/Tests/Reservoir.mo
+++ b/ThermofluidStream/Boundaries/Tests/Reservoir.mo
@@ -23,7 +23,7 @@ model Reservoir "Test for Reservoir"
     height_0(displayUnit="m") = 0.05)
     annotation (Placement(transformation(extent={{-10,10},{10,30}})));
   Processes.Pump pump(redeclare package Medium=Medium,
-    initM_flow= ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow= ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_from_input=true,
     redeclare function dp_tau_pump =
         Processes.Internal.TurboComponent.dp_tau_nominal_flow (
@@ -62,7 +62,7 @@ model Reservoir "Test for Reservoir"
     annotation (Placement(transformation(extent={{-78,32},{-58,52}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -70,7 +70,7 @@ model Reservoir "Test for Reservoir"
     annotation (Placement(transformation(extent={{-46,-66},{-26,-46}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (

--- a/ThermofluidStream/Boundaries/Tests/Volumes.mo
+++ b/ThermofluidStream/Boundaries/Tests/Volumes.mo
@@ -59,7 +59,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-48,-120},{-28,-100}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -67,7 +67,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{20,-90},{40,-70}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -85,7 +85,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{50,-10},{70,10}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -93,7 +93,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-40,10},{-20,30}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -101,7 +101,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-40,-30},{-20,-10}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -127,7 +127,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{50,60},{70,80}})));
   Processes.FlowResistance flowResistance5(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -135,7 +135,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-40,80},{-20,100}})));
   Processes.FlowResistance flowResistance6(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -143,7 +143,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
   Processes.FlowResistance flowResistance8(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -175,7 +175,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{50,-200},{70,-180}})));
   Processes.FlowResistance flowResistance7(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -183,7 +183,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-40,-160},{-20,-140}})));
   Processes.FlowResistance flowResistance9(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -222,7 +222,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-12,110},{8,130}})));
   Processes.FlowResistance flowResistance10(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -230,7 +230,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{20,110},{40,130}})));
   Processes.FlowResistance flowResistance11(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -256,7 +256,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{50,160},{70,180}})));
   Processes.FlowResistance flowResistance12(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -264,7 +264,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-40,180},{-20,200}})));
   Processes.FlowResistance flowResistance13(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -272,7 +272,7 @@ Medium package used in the Test of the MixVolumes.
     annotation (Placement(transformation(extent={{-40,140},{-20,160}})));
   Processes.FlowResistance flowResistance14(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (

--- a/ThermofluidStream/Examples/EspressoMachine.mo
+++ b/ThermofluidStream/Examples/EspressoMachine.mo
@@ -18,7 +18,7 @@ Medium model for water.
     annotation (Placement(transformation(extent={{-80,-10},{-40,30}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.003,
     l=0.3,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -52,7 +52,7 @@ Medium model for water.
         origin={-30,70})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.003,
     l=0.3,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -94,7 +94,7 @@ Medium model for water.
         origin={-140,-120})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.003,
     l=0.3,
     computeL=true,
@@ -124,7 +124,7 @@ Medium model for water.
         origin={110,-50})));
   FlowControl.TanValve tanValve2(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     relativeLeakiness=1e-7)
     annotation (Placement(transformation(extent={{10,-10},{-10,10}},
         rotation=90,
@@ -172,7 +172,7 @@ Medium model for water.
         origin={-20,-20})));
   Processes.Pump pump(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_from_input=true,
     omegaStateSelect=StateSelect.never,
     redeclare function dp_tau_pump = Processes.Internal.TurboComponent.dp_tau_nominal_flow (
@@ -214,7 +214,7 @@ Medium model for water.
         k_p_input=1e6,
         k_fric_input=0),
     enableOutput=false,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     initPhi=false,
     omegaStateSelect=StateSelect.default,
     omega_from_input=true) annotation (Placement(transformation(
@@ -305,7 +305,7 @@ Medium model for water.
         origin={-88,70})));
   Processes.FlowResistance flowResistance5(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.003,
     l=0.3,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -376,7 +376,7 @@ Medium model for water.
         origin={110,-140})));
   Utilities.CupSink Tasse1(
     redeclare package Medium = Water, flowResistance(
-      initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state))
+      initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState))
     annotation (Placement(transformation(
         extent={{20,-20},{-20,20}},
         rotation=0,

--- a/ThermofluidStream/Examples/HeatPump.mo
+++ b/ThermofluidStream/Examples/HeatPump.mo
@@ -41,12 +41,12 @@ model HeatPump
   Processes.Compressor compressor(
     redeclare package Medium = Medium,
     L=1e6,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     omega_from_input=false,
     enableOutput=true,
     outputQuantity=ThermofluidStream.Sensors.Internal.Types.MassFlowQuantities.m_flow_kgps,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     initPhi=true,
     redeclare function dp_tau_compressor =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
@@ -60,7 +60,7 @@ model HeatPump
   FlowControl.BasicControlValve controlValve(
     redeclare package Medium = Medium,
     L=5000,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=true,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.Kvs,
     Kvs(displayUnit="m3/s") = 0.18,
@@ -108,14 +108,14 @@ model HeatPump
         origin={-40,-120})));
   Processes.Fan fan(
     redeclare package Medium = Air,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_from_input=true,
     redeclare function dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=100))
     annotation (Placement(transformation(extent={{-60,98},{-40,78}})));
   Processes.Fan fan1(
     redeclare package Medium = Air,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_from_input=true,
     redeclare function dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=100)) annotation (

--- a/ThermofluidStream/Examples/ReverseHeatPump.mo
+++ b/ThermofluidStream/Examples/ReverseHeatPump.mo
@@ -20,7 +20,7 @@ model ReverseHeatPump
 
   Processes.Compressor compressor(
     redeclare package Medium = RefrigerantMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.NoInit,
     omega_from_input=true,
     redeclare function dp_tau_compressor =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
@@ -63,7 +63,7 @@ model ReverseHeatPump
 
   FlowControl.BasicControlValve valveCompressorOutletCooling(
     redeclare package Medium = RefrigerantMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.NoInit,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.m_flow_set,
     redeclare function valveCharacteristics =
         FlowControl.Internal.ControlValve.linearCharacteristics,
@@ -72,7 +72,7 @@ model ReverseHeatPump
         origin={-26,40})));
   FlowControl.BasicControlValve valveCompressorOutletHeating(
     redeclare package Medium = RefrigerantMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.NoInit,
     invertInput=true,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.m_flow_set,
     redeclare function valveCharacteristics =
@@ -87,7 +87,7 @@ model ReverseHeatPump
         origin={70,40})));
   FlowControl.BasicControlValve valveCompressorInletHeating(
     redeclare package Medium = RefrigerantMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=true,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.m_flow_set,
     redeclare function valveCharacteristics =
@@ -98,7 +98,7 @@ model ReverseHeatPump
         origin={-70,-6})));
   FlowControl.BasicControlValve valveCompressorInletCooling(
     redeclare package Medium = RefrigerantMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=false,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.m_flow_set,
     redeclare function valveCharacteristics =
@@ -129,7 +129,7 @@ model ReverseHeatPump
         origin={82,144})));
   Undirected.Processes.FlowResistance flowResistance1(
     redeclare package Medium = SecondaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -166,7 +166,7 @@ model ReverseHeatPump
         origin={70,14})));
   Undirected.FlowControl.BasicControlValve TEVcooling(
     redeclare package Medium = RefrigerantMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=false,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.m_flow_set,
     redeclare function valveCharacteristics =
@@ -189,7 +189,7 @@ model ReverseHeatPump
         origin={-70,40})));
   Undirected.FlowControl.BasicControlValve TEVheating(
     redeclare package Medium = RefrigerantMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=false,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.m_flow_set,
     redeclare function valveCharacteristics =
@@ -200,7 +200,7 @@ model ReverseHeatPump
         origin={-40,180})));
   Undirected.Processes.FlowResistance flowResistance(
     redeclare package Medium = SecondaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/Examples/SimpleAirCycle.mo
+++ b/ThermofluidStream/Examples/SimpleAirCycle.mo
@@ -31,7 +31,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
   Boundaries.DynamicPressureInflow dynamicPressure(
     displayInstanceName=false,
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     assumeConstantDensity=false,
     velocityFromInput=false,
@@ -62,10 +62,10 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
   Processes.Turbine turbine(
     redeclare package Medium = Medium,
     L=5e2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     omega_from_input=false,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_0=0,
     initPhi=true,
     phi_0=0,
@@ -145,7 +145,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
   Boundaries.DynamicPressureInflow dynamicPressure1(
     displayInstanceName=false,
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     assumeConstantDensity=false,
     velocityFromInput=false,
@@ -163,10 +163,10 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
   Processes.Turbine turbine1(
     redeclare package Medium = Medium,
     L=5e2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     omega_from_input=false,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_0=0,
     initPhi=true,
     phi_0=0,

--- a/ThermofluidStream/Examples/SimpleCoolingCycle.mo
+++ b/ThermofluidStream/Examples/SimpleCoolingCycle.mo
@@ -26,7 +26,7 @@ extends Modelica.Icons.Example;
     annotation (Placement(transformation(extent={{40,10},{20,30}})));
   ThermofluidStream.Processes.Pump pump(
     redeclare package Medium = Medium_liquid,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
     annotation (Placement(transformation(extent={{-20,10},{-40,30}})));
   ThermofluidStream.Processes.ThermalConvectionPipe thermalConvectionPipe(
@@ -96,7 +96,7 @@ extends Modelica.Icons.Example;
 
   ThermofluidStream.Processes.Fan fan(
     redeclare package Medium = Medium_air,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
       omega_ref=100))

--- a/ThermofluidStream/Examples/SimpleEngine.mo
+++ b/ThermofluidStream/Examples/SimpleEngine.mo
@@ -71,7 +71,7 @@ model SimpleEngine "Simple steam engine"
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Water,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.015,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -80,7 +80,7 @@ model SimpleEngine "Simple steam engine"
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Water,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.015,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -89,7 +89,7 @@ model SimpleEngine "Simple steam engine"
   Processes.FlowResistance flowResistance5(
     redeclare package Medium = Water,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.015,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -98,7 +98,7 @@ model SimpleEngine "Simple steam engine"
   Processes.FlowResistance flowResistance6(
     redeclare package Medium = Water,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.015,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/Examples/SimpleGasTurbine.mo
+++ b/ThermofluidStream/Examples/SimpleGasTurbine.mo
@@ -11,8 +11,8 @@ model SimpleGasTurbine "Simple version of a Gas Turbine"
 
   Processes.Compressor compressor(
     redeclare package Medium=Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_0=100,
     redeclare function dp_tau_compressor =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
@@ -21,7 +21,7 @@ model SimpleGasTurbine "Simple version of a Gas Turbine"
     annotation (Placement(transformation(extent={{-90,-20},{-70,0}})));
   Processes.Turbine turbine(
     redeclare package Medium=Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_turbine =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
       omega_ref=1000,

--- a/ThermofluidStream/Examples/SimpleStream.mo
+++ b/ThermofluidStream/Examples/SimpleStream.mo
@@ -25,14 +25,14 @@ model SimpleStream "Simple pneumatic network"
     annotation (Placement(transformation(extent={{-120,-10},{-100,10}})));
   Processes.FlowResistance pipe1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,10},{40,30}})));
   Processes.FlowResistance pipe2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=100,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)

--- a/ThermofluidStream/Examples/Utilities/Tests/BoilerEspresso.mo
+++ b/ThermofluidStream/Examples/Utilities/Tests/BoilerEspresso.mo
@@ -25,7 +25,7 @@ model BoilerEspresso "Test for the espresso boiler"
         origin={10,-100})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.003,
     l=0.3,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -62,7 +62,7 @@ model BoilerEspresso "Test for the espresso boiler"
         origin={30,100})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.003,
     l=0.3,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -92,7 +92,7 @@ model BoilerEspresso "Test for the espresso boiler"
         origin={-10,100})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Water,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.003,
     l=0.3,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (

--- a/ThermofluidStream/Examples/Utilities/Tests/Piston.mo
+++ b/ThermofluidStream/Examples/Utilities/Tests/Piston.mo
@@ -73,7 +73,7 @@ model Piston "Test for Piston model"
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     computeL=false,
     L_value=1e-3,
     r=0.1,
@@ -84,7 +84,7 @@ model Piston "Test for Piston model"
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     computeL=false,
     L_value=1e-3,
     r=0.1,
@@ -95,7 +95,7 @@ model Piston "Test for Piston model"
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     computeL=false,
     L_value=1e-3,
     r=0.1,
@@ -106,7 +106,7 @@ model Piston "Test for Piston model"
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     computeL=false,
     L_value=1e-3,
     r=0.1,

--- a/ThermofluidStream/Examples/VaporCycle.mo
+++ b/ThermofluidStream/Examples/VaporCycle.mo
@@ -97,7 +97,7 @@ model VaporCycle
     annotation (Placement(transformation(extent={{36,66},{56,86}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = SecondaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (

--- a/ThermofluidStream/Examples/VenturiPump.mo
+++ b/ThermofluidStream/Examples/VenturiPump.mo
@@ -12,7 +12,7 @@ model VenturiPump "Pumping of liquid water using the venturi effect"
 
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=0.25,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -46,7 +46,7 @@ model VenturiPump "Pumping of liquid water using the venturi effect"
         origin={0,80})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=0.1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/Examples/WaterHammer.mo
+++ b/ThermofluidStream/Examples/WaterHammer.mo
@@ -26,7 +26,7 @@ model WaterHammer "Pump water by using dynamic pressures"
 
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.025,
     l=25,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -49,7 +49,7 @@ model WaterHammer "Pump water by using dynamic pressures"
     redeclare package Medium = Medium) annotation (Placement(transformation(extent={{10,-10},{30,10}})));
   ThermofluidStream.FlowControl.CheckValve checkValve(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state)
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)
     annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/FlowControl/Tests/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/BasicControlValve.mo
@@ -20,7 +20,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-116,50},{-96,70}})));
   FlowControl.BasicControlValve valveLinear(
     redeclare package Medium = medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.Kvs,
     Kvs=5,
     redeclare function valveCharacteristics =
@@ -56,7 +56,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-116,-10},{-96,10}})));
   FlowControl.BasicControlValve valveParabolic(
     redeclare package Medium = medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=false,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.Kvs,
     Kvs=5,
@@ -81,7 +81,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-116,-70},{-96,-50}})));
   FlowControl.BasicControlValve valveEqualPercentage(
     redeclare package Medium = medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.Kvs,
     Kvs=5,
     redeclare function valveCharacteristics =

--- a/ThermofluidStream/FlowControl/Tests/CheckValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/CheckValve.mo
@@ -20,7 +20,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{52,-10},{72,10}})));
   ThermofluidStream.FlowControl.CheckValve checkValve(redeclare package Medium=Medium, L=
         1e-4,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state)
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)
     annotation (Placement(transformation(extent={{-22,-10},{-2,10}})));
   Modelica.Blocks.Sources.Pulse pulse(
     amplitude=2e5,

--- a/ThermofluidStream/FlowControl/Tests/MCV.mo
+++ b/ThermofluidStream/FlowControl/Tests/MCV.mo
@@ -21,7 +21,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{50,20},{70,40}})));
   ThermofluidStream.FlowControl.MCV mCV(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     setpointFromInput=true,
     massFlow_set_par=0.1,
@@ -44,7 +44,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{50,-10},{70,10}})));
   ThermofluidStream.FlowControl.MCV mCV1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.volume_flow,
     massFlow_set_par=0.1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
@@ -72,7 +72,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{50,-40},{70,-20}})));
   ThermofluidStream.FlowControl.MCV mCV2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.volume_flow,
     massFlow_set_par=0.1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
@@ -103,7 +103,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{50,-70},{70,-50}})));
   ThermofluidStream.FlowControl.MCV mCV3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     massFlow_set_par=0.1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));
@@ -131,7 +131,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{50,-100},{70,-80}})));
   ThermofluidStream.FlowControl.MCV mCV4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     massFlow_set_par=0.1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{-10,-100},{10,-80}})));
@@ -162,7 +162,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{50,60},{70,80}})));
   ThermofluidStream.FlowControl.MCV mCV5(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.volume_flow,
     setpointFromInput=true,
     massFlow_set_par=0.1,
@@ -202,7 +202,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{52,130},{72,150}})));
   ThermofluidStream.FlowControl.MCV mCV6(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     massFlow_set_par=1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{-8,130},

--- a/ThermofluidStream/FlowControl/Tests/PCV.mo
+++ b/ThermofluidStream/FlowControl/Tests/PCV.mo
@@ -15,7 +15,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{70,-88},{90,-68}})));
   ThermofluidStream.FlowControl.PCV pCV(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=2,
     pressure_set_par(displayUnit="Pa") = 20000) annotation (Placement(transformation(extent={{-20,-20},{0,0}})));
   ThermofluidStream.Boundaries.VolumeFlex
@@ -35,7 +35,7 @@ Medium package used in the Test.
   ThermofluidStream.FlowControl.PCV pCV1(
     redeclare package Medium = Medium,
     L=10,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.PressureControlValveMode.outlet,
     pressure_set_par=150000) annotation (Placement(transformation(extent={{-20,-50},{0,-30}})));
   ThermofluidStream.Boundaries.VolumeFlex
@@ -80,7 +80,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));
   ThermofluidStream.FlowControl.PCV pCV2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=10,
     pressure_set_par(displayUnit="Pa") = 20000) annotation (Placement(transformation(extent={{10,-80},{30,-60}})));
   ThermofluidStream.Boundaries.Source source1(redeclare package Medium = Medium, p0_par=200000)
@@ -97,7 +97,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{10,10},{30,30}})));
   ThermofluidStream.FlowControl.PCV pCV3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=10,
     pressureFromInput=true,
     pressure_set_par(displayUnit="Pa")) annotation (Placement(transformation(extent={{-20,10},{0,30}})));
@@ -115,7 +115,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{10,50},{30,70}})));
   ThermofluidStream.FlowControl.PCV pCV4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=10,
     mode=ThermofluidStream.FlowControl.Internal.Types.PressureControlValveMode.outlet,
     pressureFromInput=true,

--- a/ThermofluidStream/FlowControl/Tests/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/Tests/SpecificValveType.mo
@@ -20,7 +20,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-116,50},{-96,70}})));
   FlowControl.SpecificValveType slideValve(
     redeclare package Medium = medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypes.Kvs,
     redeclare record zetaValueRecord = Internal.Curves.SlideValveZetaCurve,
     Kvs=5) annotation (Placement(transformation(extent={{-10,50},{10,70}})));
@@ -54,7 +54,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-116,-10},{-96,10}})));
   FlowControl.SpecificValveType slideValveInverse(
     redeclare package Medium = medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=true,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypes.Kvs,
     redeclare record zetaValueRecord = Internal.Curves.SlideValveZetaCurve,

--- a/ThermofluidStream/FlowControl/Tests/Switch.mo
+++ b/ThermofluidStream/FlowControl/Tests/Switch.mo
@@ -20,7 +20,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{46,60},{66,80}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -56,7 +56,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-76,-24},{-56,-4}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -72,7 +72,7 @@ Medium package used in the Test.
         origin={46,-26})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/FlowControl/Tests/TanValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/TanValve.mo
@@ -53,7 +53,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-126,20},{-106,40}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -61,7 +61,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{68,26},{88,46}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/HeatExchangers/Tests/Condenser.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/Condenser.mo
@@ -93,7 +93,7 @@ model Condenser
 
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.NoInit,
     m_flow_0=0.3,
     r=0.05,
     l=1,

--- a/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU.mo
@@ -63,7 +63,7 @@ model CounterFlowNTU
     A=10, TC=10) annotation (Placement(transformation(extent={{-10,-8},{10,12}})));
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumB,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -71,7 +71,7 @@ model CounterFlowNTU
     annotation (Placement(transformation(extent={{102,10},{82,30}})));
   Processes.FlowResistance flowResistanceA(
     redeclare package Medium = MediumA,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_parallel.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_parallel.mo
@@ -128,7 +128,7 @@ model CounterFlowNTU_parallel
     annotation (Placement(transformation(extent={{-136,10},{-156,30}})));
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumB,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -136,7 +136,7 @@ model CounterFlowNTU_parallel
     annotation (Placement(transformation(extent={{20,22},{0,42}})));
   Processes.FlowResistance flowResistanceB1(
     redeclare package Medium = MediumB,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -144,7 +144,7 @@ model CounterFlowNTU_parallel
     annotation (Placement(transformation(extent={{12,-2},{-8,18}})));
   Processes.FlowResistance flowResistanceA2(
     redeclare package Medium = MediumA,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -152,7 +152,7 @@ model CounterFlowNTU_parallel
     annotation (Placement(transformation(extent={{-78,34},{-58,54}})));
   Processes.FlowResistance flowResistanceA(
     redeclare package Medium = MediumA,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_serial.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_serial.mo
@@ -82,7 +82,7 @@ model CounterFlowNTU_serial
         origin={0,-14})));
   Processes.FlowResistance flowResistanceA(
     redeclare package Medium = MediumA,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -90,7 +90,7 @@ model CounterFlowNTU_serial
     annotation (Placement(transformation(extent={{-112,-14},{-92,6}})));
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumB,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_zeroMassFlow.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_zeroMassFlow.mo
@@ -73,7 +73,7 @@ model CounterFlowNTU_zeroMassFlow
     annotation (Placement(transformation(extent={{158,-30},{138,-10}})));
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumB,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.005,
     l=0.5,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -81,7 +81,7 @@ model CounterFlowNTU_zeroMassFlow
     annotation (Placement(transformation(extent={{100,10},{80,30}})));
   Processes.FlowResistance flowResistanceA(
     redeclare package Medium = MediumA,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.005,
     l=0.5,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/HeatExchangers/Tests/CrossFlowNTU.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CrossFlowNTU.mo
@@ -75,7 +75,7 @@ model CrossFlowNTU
           annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Processes.FlowResistance flowResistanceA(
     redeclare package Medium = MediumA,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -83,7 +83,7 @@ model CrossFlowNTU
     annotation (Placement(transformation(extent={{-92,-10},{-72,10}})));
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumB,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/HeatExchangers/Tests/CrossFlowNTU_zeroMassFlow.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CrossFlowNTU_zeroMassFlow.mo
@@ -78,7 +78,7 @@ model CrossFlowNTU_zeroMassFlow
     annotation (Placement(transformation(extent={{162,-10},{142,10}})));
   Processes.FlowResistance flowResistanceA(
     redeclare package Medium = MediumA,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.005,
     l=0.5,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -86,7 +86,7 @@ model CrossFlowNTU_zeroMassFlow
     annotation (Placement(transformation(extent={{-102,-10},{-82,10}})));
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumB,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.005,
     l=0.5,
     redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (

--- a/ThermofluidStream/HeatExchangers/Tests/ElementTwoPhase.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/ElementTwoPhase.mo
@@ -22,7 +22,7 @@ model ElementTwoPhase
     annotation (Placement(transformation(extent={{50,70},{70,90}})));
   FlowControl.MCV mCV(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0.1,
     massFlow_set_par=0.1)
     annotation (Placement(transformation(extent={{20,70},{40,90}})));
@@ -50,7 +50,7 @@ model ElementTwoPhase
     annotation (Placement(transformation(extent={{50,-40},{70,-20}})));
   FlowControl.MCV mCV1(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0.1,
     massFlow_set_par=0.1)
     annotation (Placement(transformation(extent={{20,-40},{40,-20}})));
@@ -88,7 +88,7 @@ model ElementTwoPhase
     annotation (Placement(transformation(extent={{50,40},{70,60}})));
   FlowControl.MCV mCV2(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0.1,
     massFlow_set_par=0.1)
     annotation (Placement(transformation(extent={{20,40},{40,60}})));
@@ -116,7 +116,7 @@ model ElementTwoPhase
     annotation (Placement(transformation(extent={{50,-90},{70,-70}})));
   FlowControl.MCV mCV3(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0.1,
     massFlow_set_par=0.1)
     annotation (Placement(transformation(extent={{20,-90},{40,-70}})));
@@ -139,7 +139,7 @@ model ElementTwoPhase
     annotation (Placement(transformation(extent={{-40,70},{-20,90}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
@@ -152,7 +152,7 @@ model ElementTwoPhase
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)

--- a/ThermofluidStream/HeatExchangers/Tests/FlowRes.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/FlowRes.mo
@@ -108,12 +108,12 @@ model FlowRes
     annotation (Placement(transformation(extent={{-98,76},{-78,96}})));
   FlowControl.MCV mCV(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     massFlow_set_par=0.2) annotation (Placement(transformation(extent={{-68,38},{-48,58}})));
   FlowControl.MCV mCV1(
     redeclare package Medium = MediumAir,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     massFlow_set_par=1) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -209,12 +209,12 @@ model FlowRes
     annotation (Placement(transformation(extent={{-96,-26},{-76,-6}})));
   FlowControl.MCV mCV2(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     massFlow_set_par=0.2) annotation (Placement(transformation(extent={{-66,-62},{-46,-42}})));
   FlowControl.MCV mCV3(
     redeclare package Medium = MediumAir,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     massFlow_set_par=1) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -299,7 +299,7 @@ model FlowRes
     annotation (Placement(transformation(extent={{62,32},{82,52}})));
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.NoInit,
     m_flow_0=0.3,
     r=0.05,
     l=1,
@@ -428,7 +428,7 @@ model FlowRes
     annotation (Placement(transformation(extent={{44,-82},{64,-62}})));
   Processes.FlowResistance flowResistanceB1(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.NoInit,
     m_flow_0=0.3,
     r=0.05,
     l=1,

--- a/ThermofluidStream/HeatExchangers/Tests/Recuperator.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/Recuperator.mo
@@ -104,7 +104,7 @@ model Recuperator
     annotation (Placement(transformation(extent={{44,-48},{24,-28}})));
   FlowControl.MCV mCV(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0.2,
     massFlow_set_par=0.2) annotation (Placement(transformation(extent={{-76,-2},{-56,18}})));
 equation

--- a/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step1OpenLoop.mo
+++ b/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step1OpenLoop.mo
@@ -32,7 +32,7 @@ model Step1OpenLoop
     Placement(transformation(extent={{70,-10},{90,10}})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
             0.1e5),
     l=10,

--- a/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step2SaturatedVapor.mo
+++ b/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step2SaturatedVapor.mo
@@ -32,7 +32,7 @@ model Step2SaturatedVapor
     Placement(transformation(extent={{70,-10},{90,10}})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
             0.1e5),
     l=10,

--- a/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step3Superheater.mo
+++ b/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step3Superheater.mo
@@ -31,7 +31,7 @@ model Step3Superheater
     Placement(transformation(extent={{120,-10},{140,10}})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
             0.1e5),
     l=10,

--- a/ThermofluidStream/Idealized/Examples/TUMExercisesThermodynamicCycles/Exercise7MixingPreheater/Inversion.mo
+++ b/ThermofluidStream/Idealized/Examples/TUMExercisesThermodynamicCycles/Exercise7MixingPreheater/Inversion.mo
@@ -57,7 +57,7 @@ model Inversion
   ThermofluidStream.Idealized.Topology.JunctionT2 mixingPreheater(displayInstanceName=true, redeclare package Medium = Medium) annotation (Placement(transformation(extent={{10,-30},{-10,-10}})));
   ThermofluidStream.Idealized.Processes.Adiabatic highPressureTurbineStage(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.NoInit,
     m_flow_0=1,
     eta_fixed=0.889,
     outletSpec=ThermofluidStream.Idealized.Types.OutletSpecification.Adiabatic.OutletPressure,

--- a/ThermofluidStream/Idealized/Examples/TUMExercisesThermodynamicCycles/Exercise7MixingPreheater/PseudoInversion.mo
+++ b/ThermofluidStream/Idealized/Examples/TUMExercisesThermodynamicCycles/Exercise7MixingPreheater/PseudoInversion.mo
@@ -74,7 +74,7 @@ model PseudoInversion
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_K,
     outputValue=true,
     filter_output=true,
-    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.state,
+    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.InitialOutput,
     value_0=273.15 + 130) annotation(
     Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/Idealized/Tests/Topology/JunctionT1Const.mo
+++ b/ThermofluidStream/Idealized/Tests/Topology/JunctionT1Const.mo
@@ -19,7 +19,7 @@ model JunctionT1Const "Example - JunctionT1 with constant mass flow rate sources
     L=1e4)                                                 annotation(Placement(transformation(extent={{-110,40},{-90,60}})));
   ThermofluidStream.Processes.FlowResistance flowResistanceB(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
     l=1,
     r=1) annotation(Placement(transformation(extent={{-160,20},{-140,40}})));
@@ -44,7 +44,7 @@ model JunctionT1Const "Example - JunctionT1 with constant mass flow rate sources
   ThermofluidStream.Processes.FlowResistance
                        flowResistanceA(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
     l=1,
     r=1)                                                                                       annotation(Placement(transformation(extent={{-20,60},{0,80}})));

--- a/ThermofluidStream/Idealized/Tests/Topology/JunctionT2Const.mo
+++ b/ThermofluidStream/Idealized/Tests/Topology/JunctionT2Const.mo
@@ -19,7 +19,7 @@ model JunctionT2Const "Example - JunctionT2 with constant mass flow rate sources
     L=1e4)                                                 annotation(Placement(transformation(extent={{-110,20},{-90,40}})));
   ThermofluidStream.Processes.FlowResistance flowResistanceB(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
     l=1,
     r=1) annotation(Placement(transformation(extent={{-170,20},{-150,40}})));
@@ -44,7 +44,7 @@ model JunctionT2Const "Example - JunctionT2 with constant mass flow rate sources
   ThermofluidStream.Processes.FlowResistance
                        flowResistanceA(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
     l=1,
     r=1)                                                                                       annotation(Placement(transformation(extent={{-20,60},{0,80}})));

--- a/ThermofluidStream/Interfaces/SISOFlow.mo
+++ b/ThermofluidStream/Interfaces/SISOFlow.mo
@@ -15,12 +15,12 @@ partial model SISOFlow "Base Model with basic flow eqautions for SISO"
     Dialog(tab="Advanced", enable = considerInertance), HideResult = not considerInertance);
   parameter StateSelect m_flowStateSelect = StateSelect.default "State selection for mass flow rate"
     annotation(Dialog(tab="Advanced"));
-  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for mass flow rate"
+  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for mass flow rate"
     annotation(Dialog(tab= "Initialization", group="Mass flow rate"));
   parameter SI.MassFlowRate m_flow_0 = 0 "Initial value for mass flow rate"
-    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.state)));
+    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.InitialState)));
   parameter Utilities.Units.MassFlowAcceleration m_acceleration_0 = 0 "Initial value for derivative of mass flow rate"
-    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.derivative)));
+    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   parameter Boolean clip_p_out "= false, if dr_corr=0 (correction of inertial pressure difference)"
     annotation(Dialog(tab="Advanced"));
@@ -50,11 +50,11 @@ partial model SISOFlow "Base Model with basic flow eqautions for SISO"
   Medium.MassFraction Xi_out[Medium.nXi] "Outlet mass fractions";
 
 initial equation
-  if initM_flow == InitializationMethods.state then
+  if initM_flow == InitializationMethods.InitialState then
     m_flow = m_flow_0;
-  elseif initM_flow == InitializationMethods.derivative then
+  elseif initM_flow == InitializationMethods.InitialDerivative then
     der(m_flow) = m_acceleration_0;
-  elseif initM_flow == InitializationMethods.steadyState then
+  elseif initM_flow == InitializationMethods.SteadyState then
     der(m_flow) = 0;
   end if;
 

--- a/ThermofluidStream/Interfaces/Tests/Test_p_out_clipping.mo
+++ b/ThermofluidStream/Interfaces/Tests/Test_p_out_clipping.mo
@@ -20,7 +20,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{50,-10},{70,10}})));
   Processes.FlowResistance flowResistance(redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=100,
     r=1,
     l=1,
@@ -31,9 +31,9 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-10,40},{10,60}})));
   Processes.Fan fan(redeclare package Medium = Medium,
     L=1000,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=100,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_0=1,
     initPhi=true,
     redeclare function dp_tau_fan =
@@ -43,7 +43,7 @@ Medium package used in the Test.
     L=1000,
     m_flowStateSelect=StateSelect.prefer,
     Kvs(displayUnit="m3/s") = 3600,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=10)
     annotation (Placement(transformation(extent={{-10,-20},{10,0}})));
   FlowControl.SpecificValveType specificValveType(redeclare package Medium = Medium,
@@ -51,13 +51,13 @@ Medium package used in the Test.
     m_flowStateSelect=StateSelect.prefer,
     invertInput=true,
     Kvs(displayUnit="m3/s") = 3600,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=100)
     annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
   FlowControl.TanValve tanValve(redeclare package Medium = Medium,
     L=100000,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=1,
     m_flow_ref=1)
     annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
@@ -67,7 +67,7 @@ Medium package used in the Test.
   Processes.Nozzle nozzle(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=100,
     A_out=0.1,
     L_value=100,

--- a/ThermofluidStream/Media/Tests/TestXRGMedia.mo
+++ b/ThermofluidStream/Media/Tests/TestXRGMedia.mo
@@ -80,7 +80,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
         origin={-52,42})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = XRGMedia.CO2_ph,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.002,
     l=50,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
@@ -99,7 +99,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
         origin={76,6})));
   Processes.FlowResistance flowResistance5(
     redeclare package Medium = XRGMedia.R134a_ph,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
@@ -162,7 +162,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     m_flow_ref_set=1)
     annotation (Placement(transformation(extent={{-4,-18},{16,-38}})));
   Processes.ConductionElement conductionElement1(redeclare package Medium =
-        XRGMedia.R245fa_ph, initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state)
+        XRGMedia.R245fa_ph, initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)
     annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=180,
@@ -177,7 +177,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
   Modelica.Blocks.Sources.Constant const(k=6300) annotation (Placement(transformation(extent={{-128,52},{-108,72}})));
   Processes.FlowResistance flowResistance8(
     redeclare package Medium = XRGMedia.R134a_ph,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.02,
     l=1,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)

--- a/ThermofluidStream/Media/additionalMedia/Incompressible/Tests/TestLiqLoopDowcal100.mo
+++ b/ThermofluidStream/Media/additionalMedia/Incompressible/Tests/TestLiqLoopDowcal100.mo
@@ -23,7 +23,7 @@ model TestLiqLoopDowcal100 "Test of medium Dowcal100 for a liquid loop"
 
   ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = TertiaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
@@ -55,7 +55,7 @@ model TestLiqLoopDowcal100 "Test of medium Dowcal100 for a liquid loop"
     annotation (Placement(transformation(extent={{40,80},{60,100}})));
   ThermofluidStream.Processes.FlowResistance flowResistance2(
     redeclare package Medium = SecondaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),

--- a/ThermofluidStream/Media/additionalMedia/Incompressible/Tests/TestLiqLoopJP8.mo
+++ b/ThermofluidStream/Media/additionalMedia/Incompressible/Tests/TestLiqLoopJP8.mo
@@ -23,7 +23,7 @@ model TestLiqLoopJP8 "Test of medium JP8 for a liquid loop"
 
   ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = TertiaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
@@ -55,7 +55,7 @@ model TestLiqLoopJP8 "Test of medium JP8 for a liquid loop"
     annotation (Placement(transformation(extent={{40,80},{60,100}})));
   ThermofluidStream.Processes.FlowResistance flowResistance2(
     redeclare package Medium = SecondaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),

--- a/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestLiqLoopJP8DryAir.mo
+++ b/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestLiqLoopJP8DryAir.mo
@@ -23,7 +23,7 @@ model TestLiqLoopJP8DryAir "Test of medium JP8DryAir for a liquid loop"
 
   ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = TertiaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
@@ -55,7 +55,7 @@ model TestLiqLoopJP8DryAir "Test of medium JP8DryAir for a liquid loop"
     annotation (Placement(transformation(extent={{40,80},{60,100}})));
   ThermofluidStream.Processes.FlowResistance flowResistance2(
     redeclare package Medium = SecondaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),

--- a/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestSimpleLoopJP8DryAir.mo
+++ b/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestSimpleLoopJP8DryAir.mo
@@ -8,7 +8,7 @@ model TestSimpleLoopJP8DryAir "Test of a simple cooling loop using JP8DryAir"
 
   ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = TertiaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),

--- a/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestSimpleLoopWithStaticHeadJP8DryAir.mo
+++ b/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestSimpleLoopWithStaticHeadJP8DryAir.mo
@@ -8,7 +8,7 @@ model TestSimpleLoopWithStaticHeadJP8DryAir "Test of a cooling loop with static 
 
   ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = TertiaryMedium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),

--- a/ThermofluidStream/Processes/Internal/PartialTurboComponent.mo
+++ b/ThermofluidStream/Processes/Internal/PartialTurboComponent.mo
@@ -23,12 +23,12 @@ partial model PartialTurboComponent "Partial model of turbo component"
     annotation(Dialog(tab="Advanced", group="Regularization"));
   parameter StateSelect omegaStateSelect = if omega_from_input then StateSelect.default else StateSelect.prefer "State select for angular velocity"
     annotation(Dialog(tab="Advanced"));
-  parameter InitializationMethods initOmega = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for angular velocity"
+  parameter InitializationMethods initOmega = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for angular velocity"
     annotation(Dialog(tab= "Initialization", group="Angular velocity", enable=not omega_from_input));
   parameter SI.AngularVelocity omega_0 = 0 "Initial value for angular velocity"
-    annotation(Dialog(tab= "Initialization", group="Angular velocity", enable=(initOmega == InitializationMethods.state)));
+    annotation(Dialog(tab= "Initialization", group="Angular velocity", enable=(initOmega == InitializationMethods.InitialState)));
   parameter SI.AngularAcceleration omega_dot_0 = 0 "Initial value for der(omega)"
-    annotation(Dialog(tab= "Initialization", group="Angular velocity", enable=(initOmega == InitializationMethods.derivative)));
+    annotation(Dialog(tab= "Initialization", group="Angular velocity", enable=(initOmega == InitializationMethods.InitialDerivative)));
   parameter Boolean initPhi = false "= true, if angle is initialized"
     annotation(Dialog(tab= "Initialization", group="Angle", enable=not omega_from_input),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Angle phi_0 = 0 "Initial value for angle"
@@ -75,11 +75,11 @@ protected
 
 
 initial equation
-  if initOmega == InitializationMethods.state then
+  if initOmega == InitializationMethods.InitialState then
     omega = omega_0;
-  elseif initM_flow == InitializationMethods.derivative then
+  elseif initM_flow == InitializationMethods.InitialDerivative then
     der(omega) = omega_dot_0;
-  elseif initM_flow == InitializationMethods.steadyState then
+  elseif initM_flow == InitializationMethods.SteadyState then
     der(omega) = 0;
   end if;
 

--- a/ThermofluidStream/Processes/Internal/SISOFlowAdvanced.mo
+++ b/ThermofluidStream/Processes/Internal/SISOFlowAdvanced.mo
@@ -18,14 +18,14 @@ partial model SISOFlowAdvanced "Advanced model for SISOFlow"
   parameter ThermofluidStream.Utilities.Units.Inertance L=dropOfCommons.L "Inertance" annotation (Dialog(tab="Advanced", enable=not setFlow));
   parameter StateSelect m_flowStateSelect = StateSelect.default "State selection for mass flow rate"
     annotation(Dialog(tab="Advanced"));
-  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for mass flow rate"
+  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for mass flow rate"
     annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable= not setFlow));
   parameter SI.MassFlowRate m_flow_0 = 0 "Initial value for mass flow rate"
-    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable= (not setFlow and initM_flow == InitializationMethods.state)));
+    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable= (not setFlow and initM_flow == InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration m_acceleration_0=0 "Initial value for derivative of mass flow rate" annotation (Dialog(
       tab="Initialization",
       group="Mass flow rate",
-      enable=(not setFlow and initM_flow == InitializationMethods.derivative)));
+      enable=(not setFlow and initM_flow == InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   parameter Boolean clip_p_out "= false, if dr_corr=0 (correction of inertial pressure difference)"
     annotation(Dialog(tab="Advanced", enable = not setFlow));
@@ -54,11 +54,11 @@ protected
 
 initial equation
   if not setFlow then
-    if initM_flow == InitializationMethods.state then
+    if initM_flow == InitializationMethods.InitialState then
       m_flow = m_flow_0;
-    elseif initM_flow == InitializationMethods.derivative then
+    elseif initM_flow == InitializationMethods.InitialDerivative then
       der(m_flow) = m_acceleration_0;
-    elseif initM_flow == InitializationMethods.steadyState then
+    elseif initM_flow == InitializationMethods.SteadyState then
       der(m_flow) = 0;
     end if;
   end if;

--- a/ThermofluidStream/Processes/Pipes/CurvedBend.mo
+++ b/ThermofluidStream/Processes/Pipes/CurvedBend.mo
@@ -18,12 +18,12 @@ model CurvedBend "Pressure drop due to curved bend using Modelica.Fluid.Dissipat
   //Initialization
   parameter StateSelect dpStateSelect = StateSelect.default "State select for dp"
     annotation(Dialog(tab = "Advanced"));
-  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for dp"
+  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for dp"
     annotation(Dialog(tab = "Initialization", group = "dp"),choicesAllMatching = true);
   parameter SI.Pressure dp_0 = 0 "Initial value for dp"
-    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.state)));
+    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration dp_acceleraton_0 = 0 "Initial value for der(dp)"
-    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.derivative)));
+    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   parameter ThermofluidStream.Utilities.Units.Inertance L_value = dropOfCommons.L "Inertance"
     annotation(Dialog(tab = "Advanced", enable = not computeL));

--- a/ThermofluidStream/Processes/Pipes/EdgedBend.mo
+++ b/ThermofluidStream/Processes/Pipes/EdgedBend.mo
@@ -16,12 +16,12 @@ model EdgedBend "Pressure drop due to edged bend using Modelica.Fluid.Dissipatio
   //Initialization
   parameter StateSelect dpStateSelect = StateSelect.default "State select for pressure difference dp"
     annotation(Dialog(tab = "Advanced"));
-  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for pressure difference dp"
+  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for pressure difference dp"
     annotation(Dialog(tab = "Initialization", group = "Pressure difference"),choicesAllMatching = true);
   parameter SI.Pressure dp_0 = 0 "Initial value for pressure difference dp"
-    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.state)));
+    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration dp_acceleraton_0 = 0 "Initial value for der(dp)"
-    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.derivative)));
+    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   //Advanced
   parameter ThermofluidStream.Utilities.Units.Inertance L_value = dropOfCommons.L "Inertance"

--- a/ThermofluidStream/Processes/Pipes/EdgedOrifice.mo
+++ b/ThermofluidStream/Processes/Pipes/EdgedOrifice.mo
@@ -13,12 +13,12 @@ model EdgedOrifice "Pressure drop due to sharp edged orifice using Modelica.Flui
 
   // parameter Fluid_HTWG.Types.DarcyFrictionFactor lambda_fric=0.02 "Darcy fricition factor at vena contraction";
   //Initalization
-  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for dp"
+  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for dp"
     annotation(Dialog(tab = "Initialization", group = "dp"),choicesAllMatching = true);
   parameter SI.Pressure dp_0 = 0 "Initial value for dp" annotation (
-    Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.state)));
+    Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration dp_acceleraton_0 = 0 "Initial value for der(dp)"
-    annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.derivative)));
+    annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialDerivative)));
   parameter SI.Pressure dp_smooth = 1 "Start linearisation for decreasing pressure loss"
     annotation(Dialog(tab = "Initialization"));
   //Advanced

--- a/ThermofluidStream/Processes/Pipes/Interfaces/SISOFlowBend.mo
+++ b/ThermofluidStream/Processes/Pipes/Interfaces/SISOFlowBend.mo
@@ -13,12 +13,12 @@ partial model SISOFlowBend "Duplicate of SISOFlow (rotated outlet by 90°)"
     annotation(Dialog(tab="Advanced"));
   parameter StateSelect m_flowStateSelect = StateSelect.default "State selection for mass flow rate"
     annotation(Dialog(tab="Advanced"));
-  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for mass flow rate"
+  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for mass flow rate"
     annotation(Dialog(tab= "Initialization", group="Mass flow rate"));
   parameter SI.MassFlowRate m_flow_0 = 0 "Initial value for mass flow rate"
-    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.state)));
+    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration m_acceleration_0 = 0 "Initial value for derivative of mass flow rate"
-    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.derivative)));
+    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   parameter Boolean clip_p_out "= false, if dr_corr=0 (correction of inertial pressure difference)"
     annotation(Dialog(tab="Advanced"));
@@ -50,11 +50,11 @@ protected
   Medium.MassFraction Xi_out[Medium.nXi] "Outlet mass fractions";
 
 initial equation
-  if initM_flow == InitializationMethods.state then
+  if initM_flow == InitializationMethods.InitialState then
     m_flow = m_flow_0;
-  elseif initM_flow == InitializationMethods.derivative then
+  elseif initM_flow == InitializationMethods.InitialDerivative then
     der(m_flow) = m_acceleration_0;
-  elseif initM_flow == InitializationMethods.steadyState then
+  elseif initM_flow == InitializationMethods.SteadyState then
     der(m_flow) = 0;
   end if;
 

--- a/ThermofluidStream/Processes/Pipes/Interfaces/SISOFlow_nonConstArea.mo
+++ b/ThermofluidStream/Processes/Pipes/Interfaces/SISOFlow_nonConstArea.mo
@@ -15,12 +15,12 @@ partial model SISOFlow_nonConstArea "SISOFlow considering dynamic effects due to
     annotation(Dialog(tab = "Advanced"));
   parameter StateSelect m_flowStateSelect = StateSelect.default "State select for m_flow"
     annotation(Dialog(tab = "Advanced"));
-  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for m_flow"
+  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for m_flow"
     annotation(Dialog(tab = "Initialization", group = "Mass flow"), choicesAllMatching = true);
   parameter SI.MassFlowRate m_flow_0 = 0 "Initial value for m_flow"
-    annotation(Dialog(tab = "Initialization", group = "Mass flow", enable = (initM_flow == InitializationMethods.state)));
+    annotation(Dialog(tab = "Initialization", group = "Mass flow", enable = (initM_flow == InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration m_acceleraton_0 = 0 "Initial value for der(m_flow)"
-    annotation(Dialog(tab = "Initialization", group = "Mass flow", enable = (initM_flow == InitializationMethods.derivative)));
+    annotation(Dialog(tab = "Initialization", group = "Mass flow", enable = (initM_flow == InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   parameter Boolean clip_p_out "If false, set dr_corr to zero"
     annotation(Dialog(tab = "Advanced"));
@@ -49,11 +49,11 @@ protected
   Medium.SpecificEnthalpy h_out "Outlet specific enthaply";
   Medium.MassFraction Xi_out[Medium.nXi] "Outlet mass fractions";
 initial equation
-  if initM_flow == InitializationMethods.state then
+  if initM_flow == InitializationMethods.InitialState then
     m_flow = m_flow_0;
-  elseif initM_flow == InitializationMethods.derivative then
+  elseif initM_flow == InitializationMethods.InitialDerivative then
     der(m_flow) = m_acceleraton_0;
-  elseif initM_flow == InitializationMethods.steadyState then
+  elseif initM_flow == InitializationMethods.SteadyState then
     der(m_flow) = 0;
   end if;
 equation

--- a/ThermofluidStream/Processes/Pipes/Internal/Interfaces/SISOFlowBend.mo
+++ b/ThermofluidStream/Processes/Pipes/Internal/Interfaces/SISOFlowBend.mo
@@ -13,12 +13,12 @@ partial model SISOFlowBend "Duplicate of SISOFlow (rotated outlet by 90°)"
     annotation(Dialog(tab="Advanced"));
   parameter StateSelect m_flowStateSelect = StateSelect.default "State selection for mass flow rate"
     annotation(Dialog(tab="Advanced"));
-  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for mass flow rate"
+  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for mass flow rate"
     annotation(Dialog(tab= "Initialization", group="Mass flow rate"));
   parameter SI.MassFlowRate m_flow_0 = 0 "Initial value for mass flow rate"
-    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.state)));
+    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration m_acceleration_0 = 0 "Initial value for derivative of mass flow rate"
-    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.derivative)));
+    annotation(Dialog(tab= "Initialization", group="Mass flow rate", enable=(initM_flow == InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   parameter Boolean clip_p_out "= false, if dr_corr=0 (correction of inertial pressure difference)"
     annotation(Dialog(tab="Advanced"));
@@ -50,11 +50,11 @@ protected
   Medium.MassFraction Xi_out[Medium.nXi] "Outlet mass fractions";
 
 initial equation
-  if initM_flow == InitializationMethods.state then
+  if initM_flow == InitializationMethods.InitialState then
     m_flow = m_flow_0;
-  elseif initM_flow == InitializationMethods.derivative then
+  elseif initM_flow == InitializationMethods.InitialDerivative then
     der(m_flow) = m_acceleration_0;
-  elseif initM_flow == InitializationMethods.steadyState then
+  elseif initM_flow == InitializationMethods.SteadyState then
     der(m_flow) = 0;
   end if;
 

--- a/ThermofluidStream/Processes/Pipes/Internal/Interfaces/SISOFlow_nonConstArea.mo
+++ b/ThermofluidStream/Processes/Pipes/Internal/Interfaces/SISOFlow_nonConstArea.mo
@@ -15,12 +15,12 @@ partial model SISOFlow_nonConstArea "SISOFlow considering dynamic effects due to
     annotation(Dialog(tab = "Advanced"));
   parameter StateSelect m_flowStateSelect = StateSelect.default "State select for m_flow"
     annotation(Dialog(tab = "Advanced"));
-  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for m_flow"
+  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for m_flow"
     annotation(Dialog(tab = "Initialization", group = "Mass flow"), choicesAllMatching = true);
   parameter SI.MassFlowRate m_flow_0 = 0 "Initial value for m_flow"
-    annotation(Dialog(tab = "Initialization", group = "Mass flow", enable = (initM_flow == InitializationMethods.state)));
+    annotation(Dialog(tab = "Initialization", group = "Mass flow", enable = (initM_flow == InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration m_acceleraton_0 = 0 "Initial value for der(m_flow)"
-    annotation(Dialog(tab = "Initialization", group = "Mass flow", enable = (initM_flow == InitializationMethods.derivative)));
+    annotation(Dialog(tab = "Initialization", group = "Mass flow", enable = (initM_flow == InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   parameter Boolean clip_p_out "If false, set dr_corr to zero"
     annotation(Dialog(tab = "Advanced"));
@@ -49,11 +49,11 @@ protected
   Medium.SpecificEnthalpy h_out "Outlet specific enthaply";
   Medium.MassFraction Xi_out[Medium.nXi] "Outlet mass fractions";
 initial equation
-  if initM_flow == InitializationMethods.state then
+  if initM_flow == InitializationMethods.InitialState then
     m_flow = m_flow_0;
-  elseif initM_flow == InitializationMethods.derivative then
+  elseif initM_flow == InitializationMethods.InitialDerivative then
     der(m_flow) = m_acceleraton_0;
-  elseif initM_flow == InitializationMethods.steadyState then
+  elseif initM_flow == InitializationMethods.SteadyState then
     der(m_flow) = 0;
   end if;
 equation

--- a/ThermofluidStream/Processes/Pipes/SuddenContraction.mo
+++ b/ThermofluidStream/Processes/Pipes/SuddenContraction.mo
@@ -9,12 +9,12 @@ model SuddenContraction "Pressure drop due to contraction using Modelica.Fluid.D
   parameter SI.Length d_2 "Outlet diameter"
     annotation(Dialog(group="Geometry"));
   //Initialization
-  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for pressure difference dp"
+  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for pressure difference dp"
     annotation(Dialog(tab = "Initialization", group = "dp"), choicesAllMatching = true);
   parameter SI.Pressure dp_0 = 0 "Initial value for pressure difference dp"
-    annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.state)));
+    annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration dp_acceleraton_0 = 0 "Initial value for der(dp)"
-    annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.derivative)));
+    annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   //Advanced
   parameter Medium.Density rho_min = dropOfCommons.rho_min "Minimal density"

--- a/ThermofluidStream/Processes/Pipes/SuddenExpansion.mo
+++ b/ThermofluidStream/Processes/Pipes/SuddenExpansion.mo
@@ -9,12 +9,12 @@ model SuddenExpansion "Pressure drop due to expansion using Modelica.Fluid.Dissi
   parameter SI.Length d_2 "Outlet diameter"
     annotation(Dialog(group="Geometry"));
   //Initialization
-  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for pressure difference dp"
+  parameter ThermofluidStream.Utilities.Types.InitializationMethods initdp = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for pressure difference dp"
     annotation(Dialog(tab = "Initialization", group = "Pressure difference"), choicesAllMatching = true);
   parameter SI.Pressure dp_0 = 0 "Initial value for pressure difference dp"
-    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.state)));
+    annotation(Dialog(tab = "Initialization", group = "Pressure difference", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)));
   parameter ThermofluidStream.Utilities.Units.MassFlowAcceleration dp_acceleraton_0 = 0 "Initial value for der(dp)"
-    annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.derivative)));
+    annotation(Dialog(tab = "Initialization", group = "dp", enable = (initdp == ThermofluidStream.Utilities.Types.InitializationMethods.InitialDerivative)));
   // no default value to require the modeler to think about it; use final to suppress this option to user
   //Advanced
   parameter Medium.Density rho_min = dropOfCommons.rho_min "Minimal density"

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_CurvedBend.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_CurvedBend.mo
@@ -21,7 +21,7 @@ model Test_CurvedBend
     T0_par=293.15) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   ThermofluidStream.Processes.Pipes.CurvedBend curvedBend(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     d=1e-2,
     delta=1.5707963267949,
     R=15e-2,

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_Diffusor.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_Diffusor.mo
@@ -14,7 +14,7 @@ model Test_Diffusor
             {40,10}})));
   ThermofluidStream.Processes.Pipes.Diffuser diffuser(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=dropOfCommons.m_flow_reg,
     d_1=0.505,
     d_2=1.009,

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_EdgedBend.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_EdgedBend.mo
@@ -21,7 +21,7 @@ model Test_EdgedBend
     T0_par=293.15) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   ThermofluidStream.Processes.Pipes.EdgedBend edgedBend(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     d=1e-2,
     delta=1.5707963267949,
     ks=1e-6)       annotation (Placement(transformation(extent={{-10,-10},{10,10}})));

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_EdgedOrifice.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_EdgedOrifice.mo
@@ -12,7 +12,7 @@ model Test_EdgedOrifice
 
   ThermofluidStream.Processes.Pipes.EdgedOrifice edgedOrifice(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     d_1=1e-2,
     d_0=0.5e-2,
     l_0=0.1)  annotation (Placement(transformation(extent={{-10,-10},{10,10}})));

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_Junction.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_Junction.mo
@@ -25,7 +25,7 @@ model Test_Junction
     T0_par=293.15) annotation (Placement(transformation(extent={{-74,20},{-54,40}})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=dropOfCommons.m_flow_reg,
     redeclare function pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
@@ -33,7 +33,7 @@ model Test_Junction
     r=1e-2) annotation (Placement(transformation(extent={{20,-10},{40,10}})));
   FlowResistance                             flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     l=1,

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_SplitterY.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_SplitterY.mo
@@ -24,7 +24,7 @@ model Test_SplitterY
     T0_par=293.15) annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     redeclare function pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
@@ -32,7 +32,7 @@ model Test_SplitterY
     r=1e-2) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   FlowResistance                             flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     l=1,

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_SuddenContraction.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_SuddenContraction.mo
@@ -12,7 +12,7 @@ model Test_SuddenContraction
 
   ThermofluidStream.Processes.Pipes.SuddenContraction suddenContraction(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     d_1=1e-2,
     d_2=0.5e-2) annotation (Placement(transformation(extent={{-8,-10},{12,10}})));
   ThermofluidStream.Boundaries.Source source(

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_SuddenExpansion.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_SuddenExpansion.mo
@@ -12,7 +12,7 @@ model Test_SuddenExpansion
 
   ThermofluidStream.Processes.Pipes.SuddenExpansion suddenExpansion(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     d_1=1e-2,
     d_2=2e-2) annotation (Placement(transformation(extent={{-12,-10},{8,10}})));
   ThermofluidStream.Boundaries.Source source(

--- a/ThermofluidStream/Processes/Tests/CentrifugalPump.mo
+++ b/ThermofluidStream/Processes/Tests/CentrifugalPump.mo
@@ -30,7 +30,7 @@ extends Modelica.Icons.Example;
         origin={-90,0})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium_liquid,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.02,
     l=100,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
@@ -129,7 +129,7 @@ extends Modelica.Icons.Example;
   ThermofluidStream.Utilities.Icons.DLRLogo dLRLogo annotation (Placement(transformation(extent={{10,-2},{46,34}})));
   ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium_air,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e5))

--- a/ThermofluidStream/Processes/Tests/CentrifugalPumpCharacteristics.mo
+++ b/ThermofluidStream/Processes/Tests/CentrifugalPumpCharacteristics.mo
@@ -21,7 +21,7 @@ model CentrifugalPumpCharacteristics "Test model for CentrifugalPump"
 
   ThermofluidStream.Processes.CentrifugalPump coefficients(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     dataFromMeasurements=false,
     redeclare ThermofluidStream.Processes.Internal.CentrifugalPump.Coefficients.Wilo.Stratos25slash1to4 coefficients(rho_ref=rho),
     redeclare ThermofluidStream.Processes.Internal.CentrifugalPump.Measurements.Wilo.Stratos25slash1to4 measurements,
@@ -38,7 +38,7 @@ model CentrifugalPumpCharacteristics "Test model for CentrifugalPump"
   Boundaries.Sink  sink1(redeclare package Medium = Medium, pressureFromInput=true) annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
   ThermofluidStream.Processes.CentrifugalPump measurements(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     dataFromMeasurements=true,
     redeclare ThermofluidStream.Processes.Internal.CentrifugalPump.Coefficients.Wilo.Stratos25slash1to4 coefficients(rho_ref=rho),
     redeclare ThermofluidStream.Processes.Internal.CentrifugalPump.Measurements.Wilo.Stratos25slash1to4 measurements(rho_ref=rho),

--- a/ThermofluidStream/Processes/Tests/Compressor.mo
+++ b/ThermofluidStream/Processes/Tests/Compressor.mo
@@ -33,7 +33,7 @@ Medium model for the test. Should be an ideal gas or close to that.
     L=1e6,
     m_flowStateSelect=StateSelect.never,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-1,
     redeclare function dp_tau_compressor = tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
       omega_ref=3000,
@@ -47,8 +47,8 @@ Medium model for the test. Should be an ideal gas or close to that.
     omega_from_input=false,
     J_p=2,
     m_flow_reg=0.001,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_0=-150,
     initPhi=true,
     redeclare function dp_tau_compressor =

--- a/ThermofluidStream/Processes/Tests/ConductionElement.mo
+++ b/ThermofluidStream/Processes/Tests/ConductionElement.mo
@@ -15,7 +15,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Processes.ConductionElement conductionElement(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     V(displayUnit="l") = 0.001,
     A=35,
     U=500,
@@ -41,7 +41,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Processes.ConductionElement conductionElement1(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     V(displayUnit="l") = 0.001,
     enforce_global_energy_conservation=true,
     A=35,
@@ -52,7 +52,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Processes.ConductionElement conductionElement2(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     V(displayUnit="l") = 0.001,
     A=35,
     U=500,
@@ -74,7 +74,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Processes.ConductionElement conductionElement3(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     V(displayUnit="l") = 0.001,
     enforce_global_energy_conservation=true,
     A=35,
@@ -97,7 +97,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Processes.ConductionElement conductionElement4(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     V(displayUnit="l") = 0.001,
     A=35,
     U=500,

--- a/ThermofluidStream/Processes/Tests/ConductionElementVariable.mo
+++ b/ThermofluidStream/Processes/Tests/ConductionElementVariable.mo
@@ -19,7 +19,7 @@ the inlet the source is connected to.
                        p0_par=100000) annotation (Placement(transformation(extent={{-100,40},{-80,60}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
@@ -40,7 +40,7 @@ the inlet the source is connected to.
                                       annotation (Placement(transformation(extent={{-100,-60},{-80,-40}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
@@ -56,7 +56,7 @@ the inlet the source is connected to.
                                       annotation (Placement(transformation(extent={{80,40},{100,60}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
@@ -76,7 +76,7 @@ the inlet the source is connected to.
                                       annotation (Placement(transformation(extent={{80,-40},{100,-60}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
@@ -97,7 +97,7 @@ the inlet the source is connected to.
                                       annotation (Placement(transformation(extent={{260,40},{280,60}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)

--- a/ThermofluidStream/Processes/Tests/ConvectivePipe.mo
+++ b/ThermofluidStream/Processes/Tests/ConvectivePipe.mo
@@ -8,7 +8,7 @@ model ConvectivePipe
 
   ThermalConvectionPipe thermalConvection(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.003,
     l=6.65)
     annotation (Placement(transformation(extent={{-10,10},{10,-10}})));

--- a/ThermofluidStream/Processes/Tests/ConvectivePipe_serial.mo
+++ b/ThermofluidStream/Processes/Tests/ConvectivePipe_serial.mo
@@ -27,7 +27,7 @@ replaceable package Medium = Media.myMedia.Water.ConstantPropertyLiquidWater
         origin={-20,70})));
   FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (

--- a/ThermofluidStream/Processes/Tests/Flow_Resistance.mo
+++ b/ThermofluidStream/Processes/Tests/Flow_Resistance.mo
@@ -25,7 +25,7 @@ Medium model for the test. Can be anything.
   tf.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.steadyState,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.SteadyState,
     computeL=true,
     r=0.1,
     l=100,
@@ -36,7 +36,7 @@ Medium model for the test. Can be anything.
   tf.Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.derivative,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialDerivative,
     m_acceleration_0=1,
     computeL=false,
     L_value=1000,
@@ -49,7 +49,7 @@ Medium model for the test. Can be anything.
   tf.Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     computeL=false,
     L_value=30000,
     r=0.075,
@@ -66,7 +66,7 @@ Medium model for the test. Can be anything.
   tf.Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     computeL=false,
     L_value=30000,
     r=0.075,

--- a/ThermofluidStream/Processes/Tests/Nozzle.mo
+++ b/ThermofluidStream/Processes/Tests/Nozzle.mo
@@ -17,7 +17,7 @@ Medium model for the test. Can be anything.
     A_out=0.01) annotation (Placement(transformation(extent={{10,10},{30,30}})));
   FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=10,
     redeclare function pLoss = Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -33,7 +33,7 @@ Medium model for the test. Can be anything.
     A_out=0.00015) annotation (Placement(transformation(extent={{10,-30},{30,-10}})));
   FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=10,
     redeclare function pLoss =

--- a/ThermofluidStream/Processes/Tests/Pump.mo
+++ b/ThermofluidStream/Processes/Tests/Pump.mo
@@ -33,7 +33,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
     annotation (Placement(transformation(extent={{-10,40},{10,20}})));
 
@@ -43,8 +43,8 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=1000000,
     omega_from_input=false,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     initPhi=true,
     redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
@@ -60,7 +60,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=10000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     enableAccessHeatPort=true,
     redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
           =false, k_p_input=1e7)) annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
@@ -73,8 +73,8 @@ Medium model for the test. Should be incompressible or with low compressibility.
     enableOutput=true,
     outputQuantity=ThermofluidStream.Sensors.Internal.Types.MassFlowQuantities.Cp_flow_JpKs,
     J_p=10,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     initPhi=true,
     phi_0=-1745.3292519943,
     redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (
@@ -93,7 +93,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     enableOutput=true,
     outputQuantity=ThermofluidStream.Sensors.Internal.Types.MassFlowQuantities.V_flow_lpMin,
     J_p=10,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     phi_0=-1745.3292519943,
     redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
           =true, omega_D(displayUnit="rad/s") = 100))

--- a/ThermofluidStream/Processes/Tests/Pump_dp_tau_centrifugal_Characteristics.mo
+++ b/ThermofluidStream/Processes/Tests/Pump_dp_tau_centrifugal_Characteristics.mo
@@ -41,7 +41,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
         useLegacyReynolds=false,
         TDH_D=TDH_D,
@@ -75,7 +75,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,

--- a/ThermofluidStream/Processes/Tests/Pump_dp_tau_centrifugal_DesignPoint.mo
+++ b/ThermofluidStream/Processes/Tests/Pump_dp_tau_centrifugal_DesignPoint.mo
@@ -41,7 +41,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
         useLegacyReynolds=false,
         TDH_D=TDH_D,
@@ -75,7 +75,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         useLegacyReynolds=false,
         TDH_D=TDH_D,
@@ -108,7 +108,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
@@ -138,7 +138,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
@@ -171,7 +171,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         useLegacyReynolds=false,
         TDH_D=TDH_D,
@@ -191,7 +191,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     redeclare package Medium = Medium,
     L=100000,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,

--- a/ThermofluidStream/Processes/Tests/TransportDelay.mo
+++ b/ThermofluidStream/Processes/Tests/TransportDelay.mo
@@ -17,7 +17,7 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{30,30},{50,50}})));
   FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=100,
     l(displayUnit="mm") = 0.008,
     redeclare function pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -54,7 +54,7 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{30,-50},{50,-30}})));
   FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=100,
     l(displayUnit="mm") = 0.008,
     redeclare function pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (

--- a/ThermofluidStream/Processes/Tests/Turbine.mo
+++ b/ThermofluidStream/Processes/Tests/Turbine.mo
@@ -32,7 +32,7 @@ Medium model for the test. Should be an ideal gas or close to that.
     redeclare package Medium = Medium,
     L=1e6,
     omega_from_input=true,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=1e-5,
     redeclare function dp_tau_turbine =
         tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=1e6))
@@ -48,8 +48,8 @@ Medium model for the test. Should be an ideal gas or close to that.
     L=1e5,
     omega_from_input=false,
     J_p=1,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
+    initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     omega_0=-1,
     initPhi=true,
     redeclare function dp_tau_turbine =

--- a/ThermofluidStream/Sensors/DifferenceSensorSelect.mo
+++ b/ThermofluidStream/Sensors/DifferenceSensorSelect.mo
@@ -45,10 +45,10 @@ model DifferenceSensorSelect "Sensor for selectable quantatiy difference"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real value_0(unit=Internal.getUnit(quantity)) = 0 "Start value of sensor output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
   Interfaces.Inlet inletA(redeclare package Medium=MediumA)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
@@ -81,7 +81,7 @@ protected
     "This block computes the selected quantity from state. r and rho_min are needed for the quantities r/p_total and v respectively";
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Sensors/DifferenceSensor_Tp.mo
+++ b/ThermofluidStream/Sensors/DifferenceSensor_Tp.mo
@@ -34,12 +34,12 @@ model DifferenceSensor_Tp "Sensor for Temperature and pressure difference"
     annotation(Dialog(group="Output", enable=outputTemperature or outputPressure),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=(outputTemperature or outputPressure) and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=(outputTemperature or outputPressure) and filter_output));
   parameter Real T_0(final quantity="ThermodynamicTemperature", final unit=temperatureUnit) = 0 "Start value for temperature difference output"
-    annotation(Dialog(group="Output", enable=outputTemperature and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputTemperature and filter_output and init==InitMode.InitialOutput));
   parameter Real p_0(final quantity="Pressure", final unit=pressureUnit) = 0 "Start value for pressure difference output"
-    annotation(Dialog(group="Output", enable=outputPressure and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputPressure and filter_output and init==InitMode.InitialOutput));
 
   Interfaces.Inlet inletA(redeclare package Medium=MediumA)
     annotation (Placement(transformation(extent={{-120,20},{-80,60}})));
@@ -63,7 +63,7 @@ protected
   Real TB; //unit intentional not given to avoid warning
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     p=direct_p;
     T=direct_T;
   elseif filter_output then

--- a/ThermofluidStream/Sensors/DifferenceTwoPhaseSensorSensorSelect.mo
+++ b/ThermofluidStream/Sensors/DifferenceTwoPhaseSensorSensorSelect.mo
@@ -37,10 +37,10 @@ model DifferenceTwoPhaseSensorSensorSelect "Sensor for selectable quantatiy diff
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real value_0(unit=Internal.getTwoPhaseUnit(quantity)) = 0 "Start value of sensor output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
   Interfaces.Inlet inletA(redeclare package Medium=MediumA)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
@@ -67,7 +67,7 @@ protected
       </html>"));
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Sensors/Internal/Types.mo
+++ b/ThermofluidStream/Sensors/Internal/Types.mo
@@ -66,9 +66,9 @@ package Types "Types used in the Sensor Package"
   end MassFlowUnit;
 
   type InitializationModelSensor = enumeration(
-      steadyState
+      SteadyState
       "Steady state initialization (derivatives of states are zero)",
-      state
+      InitialOutput
       "Initialization with initial output state") "Initialization modes for sensor lowpass";
    annotation (Documentation(info="<html>
 <p>

--- a/ThermofluidStream/Sensors/MultiSensor_Tp.mo
+++ b/ThermofluidStream/Sensors/MultiSensor_Tp.mo
@@ -27,12 +27,12 @@ model MultiSensor_Tp "Temperature and pressure sensor"
     annotation(Dialog(group="Output", enable=outputTemperature or outputPressure),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable= (outputTemperature or outputPressure) and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable= (outputTemperature or outputPressure) and filter_output));
   parameter Real T_0(final quantity="ThermodynamicTemperature", final unit=temperatureUnit) = 0 "Start value for temperature output"
-    annotation(Dialog(group="Output", enable=outputTemperature and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputTemperature and filter_output and init==InitMode.InitialOutput));
   parameter Real p_0(final quantity="Pressure", final unit=pressureUnit) = 0 "Start value for pressure output"
-    annotation(Dialog(group="Output", enable=outputPressure and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputPressure and filter_output and init==InitMode.InitialOutput));
 
   Interfaces.Inlet inlet(redeclare package Medium=Medium)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
@@ -47,7 +47,7 @@ model MultiSensor_Tp "Temperature and pressure sensor"
   Real direct_T; //unit intentional not given to avoid warning
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     p=direct_p;
     T=direct_T;
   elseif filter_output then

--- a/ThermofluidStream/Sensors/MultiSensor_Tpm.mo
+++ b/ThermofluidStream/Sensors/MultiSensor_Tpm.mo
@@ -36,14 +36,14 @@ model MultiSensor_Tpm "Sensor for temperature, pressure and mass flow rate"
     annotation(Dialog(group="Output", enable=outputTemperature or outputPressure or outputMassFlowRate),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=(outputTemperature or outputPressure or outputMassFlowRate) and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=(outputTemperature or outputPressure or outputMassFlowRate) and filter_output));
   parameter Real T_0(final quantity="ThermodynamicTemperature", final unit=temperatureUnit) = 0 "Start value for temperature output"
-    annotation(Dialog(group="Output", enable=outputTemperature and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputTemperature and filter_output and init==InitMode.InitialOutput));
   parameter Real p_0(final quantity="Pressure", final unit=pressureUnit) = 0 "Start value for pressure output"
-    annotation(Dialog(group="Output", enable=outputPressure and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputPressure and filter_output and init==InitMode.InitialOutput));
   parameter Real m_flow_0(final quantity="MassFlowRate", final unit=massFlowUnit) = 0 "Start value for mass flow rate output"
-    annotation(Dialog(group="Output", enable=outputMassFlowRate and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputMassFlowRate and filter_output and init==InitMode.InitialOutput));
 
   Interfaces.Inlet inlet(redeclare package Medium=Medium)
     annotation (Placement(transformation(extent={{-120,-120},{-80,-80}})));
@@ -66,7 +66,7 @@ protected
   Real direct_m_flow; //unit intentional not given to avoid warning
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     p=direct_p;
     T=direct_T;
     m_flow=direct_m_flow;

--- a/ThermofluidStream/Sensors/SingleFlowSensor.mo
+++ b/ThermofluidStream/Sensors/SingleFlowSensor.mo
@@ -33,10 +33,10 @@ model SingleFlowSensor "Flow rate sensor"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real value_0(unit=Internal.getFlowUnit(quantity)) = 0 "Start value of sensor output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
   Interfaces.Inlet inlet(redeclare package Medium=Medium)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
@@ -57,7 +57,7 @@ protected
       </html>"));
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Sensors/SingleSensorSelect.mo
+++ b/ThermofluidStream/Sensors/SingleSensorSelect.mo
@@ -42,10 +42,10 @@ model SingleSensorSelect "Selectable sensor"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real value_0(unit=Internal.getUnit(quantity)) = 0 "Start value of sensor output"
-    annotation(Dialog(group="Output", enable= outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable= outputValue and filter_output and init==InitMode.InitialOutput));
 
   Interfaces.Inlet inlet(redeclare package Medium=Medium)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
@@ -66,7 +66,7 @@ protected
     "This block computes the selected quantity from state. r and rho_min are needed for the quantities r/p_total and v respectively";
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Sensors/SingleSensorX.mo
+++ b/ThermofluidStream/Sensors/SingleSensorX.mo
@@ -17,10 +17,10 @@ model SingleSensorX "Sensor for mass fraction"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real[Medium.nX] value_0(each unit="kg/kg") = Medium.X_default "Start value of mass fraction output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
   parameter Integer row(min=1, max=Medium.nX) = 1 "Row of meassured mass fraction";
 
@@ -39,7 +39,7 @@ protected
   Real direct_value[Medium.nX](each unit="kg/kg");
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Sensors/Tests/TestSensors.mo
+++ b/ThermofluidStream/Sensors/Tests/TestSensors.mo
@@ -35,7 +35,7 @@ model TestSensors "Test model for all sensors."
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium1,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.015,
     l=2,
     L_value=1000,
@@ -46,7 +46,7 @@ model TestSensors "Test model for all sensors."
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium2,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.015,
     l=2,
     L_value=100000,
@@ -98,7 +98,7 @@ model TestSensors "Test model for all sensors."
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.v_m3pkg,
     outputValue=true,
     filter_output=true,
-    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.state,
+    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.InitialOutput,
     value_0=1) annotation (Placement(transformation(extent={{-74,8},{-54,28}})));
   SingleSensorSelect singleSensorSelect12(redeclare package Medium = Medium2,
       quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.cv_JpkgK)
@@ -192,7 +192,7 @@ model TestSensors "Test model for all sensors."
     outputValue=true,
     quantity=ThermofluidStream.Sensors.Internal.Types.MassFlowQuantities.V_flow_m3ps,
     filter_output=true,
-    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.state) annotation (Placement(transformation(extent={{44,44},{64,64}})));
+    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.InitialOutput) annotation (Placement(transformation(extent={{44,44},{64,64}})));
   SingleFlowSensor singleFlowSensor4(
     redeclare package Medium = Medium1,
     digits=5,
@@ -267,7 +267,7 @@ model TestSensors "Test model for all sensors."
     temperatureUnit="degC",
     pressureUnit="bar",
     filter_output=true,
-    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.state) annotation (Placement(transformation(extent={{-4,8},{16,28}})));
+    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.InitialOutput) annotation (Placement(transformation(extent={{-4,8},{16,28}})));
   DifferenceSensorSelect differenceSensorSelect3(
     redeclare package MediumA = Medium1,
     redeclare package MediumB = Medium1,
@@ -288,7 +288,7 @@ model TestSensors "Test model for all sensors."
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium3,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.015,
     l=2,
     L_value=100000,

--- a/ThermofluidStream/Sensors/TwoPhaseSensorSelect.mo
+++ b/ThermofluidStream/Sensors/TwoPhaseSensorSelect.mo
@@ -31,10 +31,10 @@ model TwoPhaseSensorSelect "Selectable Sensor for two phase medium"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real value_0(unit=Internal.getTwoPhaseUnit(quantity)) = 0 "Start value of sensor output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
   Interfaces.Inlet inlet(redeclare package Medium=Medium)
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
@@ -52,7 +52,7 @@ protected
       </html>"));
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Topology/Tests/TestDynamicTopology.mo
+++ b/ThermofluidStream/Topology/Tests/TestDynamicTopology.mo
@@ -32,14 +32,14 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{76,10},{96,30}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,60},{-20,80}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
@@ -51,13 +51,13 @@ Medium model for the test. Can be anything.
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,40},{40,60}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,10},{40,30}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,70},{40,90}})));
@@ -102,14 +102,14 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{76,-90},{96,-70}})));
   Processes.FlowResistance flowResistance5(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
   Processes.FlowResistance flowResistance6(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
@@ -122,14 +122,14 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{20,-60},{40,-40}})));
   Processes.FlowResistance flowResistance8(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{20,-90},{40,-70}})));
   Processes.FlowResistance flowResistance9(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)

--- a/ThermofluidStream/Topology/Tests/TestJunctionNM.mo
+++ b/ThermofluidStream/Topology/Tests/TestJunctionNM.mo
@@ -31,14 +31,14 @@ Medium model for the test. Can be anything.
 
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,60},{-20,80}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
@@ -50,13 +50,13 @@ Medium model for the test. Can be anything.
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,40},{40,60}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,10},{40,30}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,70},{40,90}})));
@@ -78,14 +78,14 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{50,-90},{70,-70}})));
   Processes.FlowResistance flowResistance5(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
   Processes.FlowResistance flowResistance6(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
@@ -98,14 +98,14 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{20,-60},{40,-40}})));
   Processes.FlowResistance flowResistance8(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{20,-90},{40,-70}})));
   Processes.FlowResistance flowResistance9(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.005,
     l=10,
     redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)

--- a/ThermofluidStream/Topology/Tests/TestNonPhysical.mo
+++ b/ThermofluidStream/Topology/Tests/TestNonPhysical.mo
@@ -174,7 +174,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{186,34},{166,54}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
@@ -184,7 +184,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{-50,70},{-30,90}})));
   Processes.FlowResistance flowResistance5(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
@@ -194,7 +194,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
   Processes.FlowResistance flowResistance6(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
@@ -204,7 +204,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{-50,-30},{-30,-10}})));
   Processes.FlowResistance flowResistance7(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
@@ -214,7 +214,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{-50,-80},{-30,-60}})));
   Processes.FlowResistance flowResistance8(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
@@ -224,7 +224,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{120,70},{140,90}})));
   Processes.FlowResistance flowResistance9(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
@@ -234,7 +234,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{120,20},{140,40}})));
   Processes.FlowResistance flowResistance10(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
@@ -244,7 +244,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{120,-30},{140,-10}})));
   Processes.FlowResistance flowResistance11(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,

--- a/ThermofluidStream/Undirected/Boundaries/Tests/PhaseSeperator.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/PhaseSeperator.mo
@@ -45,7 +45,7 @@ model PhaseSeperator
     startTime=0) annotation (Placement(transformation(extent={{-154,-10},{-134,10}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
@@ -54,7 +54,7 @@ model PhaseSeperator
     annotation (Placement(transformation(extent={{-60,10},{-40,30}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
@@ -63,7 +63,7 @@ model PhaseSeperator
     annotation (Placement(transformation(extent={{-70,-30},{-50,-10}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
@@ -72,7 +72,7 @@ model PhaseSeperator
     annotation (Placement(transformation(extent={{60,10},{80,30}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,

--- a/ThermofluidStream/Undirected/Boundaries/Tests/Reservoir.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/Reservoir.mo
@@ -26,7 +26,7 @@ model Reservoir "Test for Reservoir"
     annotation (Placement(transformation(extent={{-66,-42},{-46,-22}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss =
@@ -35,7 +35,7 @@ model Reservoir "Test for Reservoir"
     annotation (Placement(transformation(extent={{-30,-80},{-10,-60}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss =
@@ -63,7 +63,7 @@ model Reservoir "Test for Reservoir"
     annotation (Placement(transformation(extent={{-66,58},{-46,78}})));
   ThermofluidStream.Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss =
@@ -72,7 +72,7 @@ model Reservoir "Test for Reservoir"
     annotation (Placement(transformation(extent={{-32,20},{-12,40}})));
   ThermofluidStream.Processes.FlowResistance flowResistance5(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss =

--- a/ThermofluidStream/Undirected/Boundaries/Tests/TestVolumes.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/TestVolumes.mo
@@ -43,7 +43,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-146,-90},{-126,-70}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -51,7 +51,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-80,-60},{-60,-40}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -100,7 +100,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-148,0},{-128,20}})));
   ThermofluidStream.Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -108,7 +108,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-80,30},{-60,50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -142,7 +142,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{142,40},{162,60}})));
   ThermofluidStream.Processes.FlowResistance flowResistance5(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -150,7 +150,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{46,60},{66,80}})));
   ThermofluidStream.Processes.FlowResistance flowResistance6(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -175,7 +175,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{160,-80},{140,-60}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -183,7 +183,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{46,-30},{66,-10}})));
   Processes.FlowResistance flowResistance7(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -191,7 +191,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{46,-70},{66,-50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance8(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -199,7 +199,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{116,40},{136,60}})));
   Processes.FlowResistance flowResistance9(
     redeclare package Medium = MediumMix,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
@@ -217,7 +217,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-110,-100},{-90,-120}})));
   Processes.FlowResistance flowResistance10(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -226,7 +226,7 @@ Medium package used in the Test.
   BoundaryFore boundary_fore2(redeclare package Medium = Medium, p0_par=100000) annotation (Placement(transformation(extent={{-44,-120},{-24,-100}})));
   Processes.FlowResistance flowResistance11(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=10,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/Undirected/FlowControl/Tests/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/BasicControlValve.mo
@@ -20,7 +20,7 @@ Medium package used in the Test.
     T0_par(displayUnit="K") = 300) annotation (Placement(transformation(extent={{-116,50},{-96,70}})));
   FlowControl.BasicControlValve valveLinear(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.Kvs,
     Kvs=5,
     redeclare function valveCharacteristics =
@@ -54,7 +54,7 @@ Medium package used in the Test.
     T0_par(displayUnit="K") = 300) annotation (Placement(transformation(extent={{-116,-10},{-96,10}})));
   FlowControl.BasicControlValve valveParabolic(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=false,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.Kvs,
     Kvs=5,
@@ -77,7 +77,7 @@ Medium package used in the Test.
     T0_par(displayUnit="K") = 300) annotation (Placement(transformation(extent={{-116,-70},{-96,-50}})));
   FlowControl.BasicControlValve valveEqualPercentage(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.Kvs,
     Kvs=5,
     redeclare function valveCharacteristics =

--- a/ThermofluidStream/Undirected/FlowControl/Tests/CheckValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/CheckValve.mo
@@ -20,7 +20,7 @@ Medium package used in the Test.
   Boundaries.BoundaryFore boundary_fore(redeclare package Medium = Medium, p0_par=200000)
     annotation (Placement(transformation(extent={{52,-10},{72,10}})));
   FlowControl.CheckValve checkValve(redeclare package Medium = Medium, L=1e-4,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state)
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState)
     annotation (Placement(transformation(extent={{-22,-10},{-2,10}})));
   Modelica.Blocks.Sources.Pulse pulse(
     amplitude=2e5,

--- a/ThermofluidStream/Undirected/FlowControl/Tests/MCV.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/MCV.mo
@@ -26,7 +26,7 @@ Medium package used in the Test.
   ThermofluidStream.Undirected.FlowControl.MCV
                                     mCV(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     setpointFromInput=true,
     massFlow_set_par=0.1,
@@ -45,7 +45,7 @@ Medium package used in the Test.
   ThermofluidStream.Undirected.FlowControl.MCV
                                     mCV1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.volume_flow,
     massFlow_set_par=0.1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{0,0},{20,
@@ -73,7 +73,7 @@ Medium package used in the Test.
         origin={70,-20})));
   ThermofluidStream.Undirected.FlowControl.MCV mCV2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.volume_flow,
     massFlow_set_par=0.1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{-10,10},
@@ -107,7 +107,7 @@ Medium package used in the Test.
   ThermofluidStream.Undirected.FlowControl.MCV
                                     mCV3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     massFlow_set_par=0.1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{-10,10},
@@ -140,7 +140,7 @@ Medium package used in the Test.
   ThermofluidStream.Undirected.FlowControl.MCV
                                     mCV4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     massFlow_set_par=0.1,
     volumeFlow_set_par=1) annotation (Placement(transformation(extent={{-10,10},
@@ -170,7 +170,7 @@ Medium package used in the Test.
   ThermofluidStream.Undirected.FlowControl.MCV
                                     mCV5(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.volume_flow,
     setpointFromInput=true,
     massFlow_set_par=0.1,
@@ -260,7 +260,7 @@ Medium package used in the Test.
             178}})));
   ThermofluidStream.Undirected.FlowControl.MCV mCV6(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     setpointFromInput=false,
     massFlow_set_par=1,
@@ -284,7 +284,7 @@ Medium package used in the Test.
   ThermofluidStream.Undirected.FlowControl.MCV
                                     mCV7(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     setpointFromInput=false,
     massFlow_set_par=1,
@@ -302,7 +302,7 @@ Medium package used in the Test.
   ThermofluidStream.Undirected.FlowControl.MCV
                                     mCV8(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     setpointFromInput=false,
     massFlow_set_par=1,
@@ -334,7 +334,7 @@ Medium package used in the Test.
   ThermofluidStream.Undirected.FlowControl.MCV
                                     mCV9(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     mode=ThermofluidStream.FlowControl.Internal.Types.MassflowControlValveMode.mass_flow,
     setpointFromInput=false,
     massFlow_set_par=1,

--- a/ThermofluidStream/Undirected/FlowControl/Tests/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/SpecificValveType.mo
@@ -20,7 +20,7 @@ Medium package used in the Test.
     T0_par(displayUnit="K") = 300) annotation (Placement(transformation(extent={{-116,50},{-96,70}})));
   FlowControl.SpecificValveType slideValve(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     redeclare record ZetaValueRecord =
         ThermofluidStream.FlowControl.Internal.Curves.SlideValveZetaCurve,
     flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypes.Kvs,
@@ -53,7 +53,7 @@ Medium package used in the Test.
     T0_par(displayUnit="K") = 300) annotation (Placement(transformation(extent={{-116,-10},{-96,10}})));
   FlowControl.SpecificValveType slideValveInverse(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     invertInput=true,
     redeclare record ZetaValueRecord =
         ThermofluidStream.FlowControl.Internal.Curves.SlideValveZetaCurve,

--- a/ThermofluidStream/Undirected/FlowControl/Tests/TanValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/TanValve.mo
@@ -54,7 +54,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{-12,64},{8,84}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss =ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -62,7 +62,7 @@ Medium package used in the Test.
     annotation (Placement(transformation(extent={{70,26},{90,46}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/Undirected/HeatExchangers/Tests/ConductionElementTwoPhase.mo
+++ b/ThermofluidStream/Undirected/HeatExchangers/Tests/ConductionElementTwoPhase.mo
@@ -25,7 +25,7 @@ model ConductionElementTwoPhase
     h0_par=450e3) annotation (Placement(transformation(extent={{60,-10},{80,10}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.05,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/Undirected/HeatExchangers/Tests/TestDiscretizedHEX.mo
+++ b/ThermofluidStream/Undirected/HeatExchangers/Tests/TestDiscretizedHEX.mo
@@ -50,7 +50,7 @@ model TestDiscretizedHEX
     annotation (Placement(transformation(extent={{18,22},{38,42}})));
   Processes.FlowResistance flowResistanceA(
     redeclare package Medium = MediumAir,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=1,
     r=0.05,
     l=1,
@@ -78,7 +78,7 @@ model TestDiscretizedHEX
         origin={-4,16})));
   Processes.FlowResistance flowResistanceB(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0.3,
     r=0.05,
     l=1,

--- a/ThermofluidStream/Undirected/HeatExchangers/Tests/TestDiscretizedHEXvsDir.mo
+++ b/ThermofluidStream/Undirected/HeatExchangers/Tests/TestDiscretizedHEXvsDir.mo
@@ -379,7 +379,7 @@ model TestDiscretizedHEXvsDir
     annotation (Placement(transformation(extent={{-84,-178},{-64,-158}})));
   ThermofluidStream.Processes.FlowResistance flowResistanceB2(
     redeclare package Medium = MediumRefrigerant,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.NoInit,
     m_flow_0=0.3,
     r=0.05,
     l=1,

--- a/ThermofluidStream/Undirected/Interfaces/SISOBiFlow.mo
+++ b/ThermofluidStream/Undirected/Interfaces/SISOBiFlow.mo
@@ -13,12 +13,12 @@ partial model SISOBiFlow "Base Model with basic flow eqautions for SISO"
     annotation(Dialog(tab="Advanced"));
   parameter StateSelect m_flowStateSelect = StateSelect.default "State select for mass flow rate"
     annotation(Dialog(tab="Advanced"));
-  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.none "Initialization method for mass flow rate"
+  parameter InitializationMethods initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.NoInit "Initialization method for mass flow rate"
     annotation(Dialog(tab= "Initialization"));
   parameter SI.MassFlowRate m_flow_0 = 0 "Initial value for mass flow rate"
-    annotation(Dialog(tab= "Initialization", enable=(initM_flow == InitializationMethods.state)));
+    annotation(Dialog(tab= "Initialization", enable=(initM_flow == InitializationMethods.InitialState)));
   parameter Utilities.Units.MassFlowAcceleration m_acceleration_0 = 0 "Initial value for der(m_flow)"
-    annotation(Dialog(tab= "Initialization", enable=(initM_flow == InitializationMethods.derivative)));
+    annotation(Dialog(tab= "Initialization", enable=(initM_flow == InitializationMethods.InitialDerivative)));
   parameter SI.MassFlowRate m_flow_reg = dropOfCommons.m_flow_reg "Regularization threshold of mass flow rate"
     annotation(Dialog(tab="Advanced", group="Regularization"));
   // no default value to require the modeler to think about it; use final to suppress this option to user
@@ -61,11 +61,11 @@ protected
   Medium.MassFraction Xi_fore_out[Medium.nXi] "Mass fractions of medium exiting";
 
 initial equation
-  if initM_flow == InitializationMethods.state then
+  if initM_flow == InitializationMethods.InitialState then
     m_flow = m_flow_0;
-  elseif initM_flow == InitializationMethods.derivative then
+  elseif initM_flow == InitializationMethods.InitialDerivative then
     der(m_flow) = m_acceleration_0;
-  elseif initM_flow == InitializationMethods.steadyState then
+  elseif initM_flow == InitializationMethods.SteadyState then
     der(m_flow) = 0;
   end if;
 

--- a/ThermofluidStream/Undirected/Interfaces/Tests/Test_p_out_clipping.mo
+++ b/ThermofluidStream/Undirected/Interfaces/Tests/Test_p_out_clipping.mo
@@ -15,7 +15,7 @@ Medium package used in the Test.
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-100,
     r=1,
     l=1,
@@ -29,7 +29,7 @@ Medium package used in the Test.
     L=1000,
     m_flowStateSelect=StateSelect.prefer,
     Kvs(displayUnit="m3/s") = 3600,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=10) annotation (Placement(transformation(extent={{-10,0},{10,20}})));
    FlowControl.SpecificValveType specificValveType(
     redeclare package Medium = Medium,
@@ -37,13 +37,13 @@ Medium package used in the Test.
     m_flowStateSelect=StateSelect.prefer,
     invertInput=true,
     Kvs(displayUnit="m3/s") = 3600,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-100) annotation (Placement(transformation(extent={{-10,-20},{10,0}})));
   FlowControl.TanValve tanValve(
     redeclare package Medium = Medium,
     L=100000,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=1,
     m_flow_ref=1) annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
 
@@ -52,7 +52,7 @@ Medium package used in the Test.
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=100,
     r=1,
     l=1,

--- a/ThermofluidStream/Undirected/Processes/Tests/ConductionElement.mo
+++ b/ThermofluidStream/Undirected/Processes/Tests/ConductionElement.mo
@@ -15,7 +15,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Undirected.Processes.ConductionElement conductionElement(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-1,
     V(displayUnit="l") = 0.001,
     A=35,
@@ -43,7 +43,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Undirected.Processes.ConductionElement conductionElement1(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     V(displayUnit="l") = 0.001,
     A=35,
     U=500,
@@ -69,7 +69,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Undirected.Processes.ConductionElement conductionElement2(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-1,
     V(displayUnit="l") = 0.001,
     enforce_global_energy_conservation=true,
@@ -94,7 +94,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Undirected.Processes.ConductionElement conductionElement3(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-1,
     V(displayUnit="l") = 0.001,
     A=35,
@@ -118,7 +118,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Undirected.Processes.ConductionElement conductionElement4(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=0,
     V(displayUnit="l") = 0.001,
     enforce_global_energy_conservation=true,
@@ -143,7 +143,7 @@ meant for liquids with low compressablility.
   ThermofluidStream.Undirected.Processes.ConductionElement conductionElement5(
     redeclare package Medium = Medium,
     L=0.2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     m_flow_0=-1,
     V(displayUnit="l") = 0.001,
     A=35,

--- a/ThermofluidStream/Undirected/Processes/Tests/TestFlowResistance.mo
+++ b/ThermofluidStream/Undirected/Processes/Tests/TestFlowResistance.mo
@@ -4,7 +4,7 @@ model TestFlowResistance "Test for the undirected flow resistance"
 
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Media.myMedia.Air.SimpleAir,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=1,
     redeclare function pLoss =
@@ -31,7 +31,7 @@ model TestFlowResistance "Test for the undirected flow resistance"
     annotation (Placement(transformation(extent={{60,-6},{48,6}})));
   FlowResistance flowResistance1(
     redeclare package Medium = Media.myMedia.Air.SimpleAir,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=1,
     redeclare function pLoss =

--- a/ThermofluidStream/Undirected/Processes/Tests/TransportDelay.mo
+++ b/ThermofluidStream/Undirected/Processes/Tests/TransportDelay.mo
@@ -17,7 +17,7 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{30,30},{50,50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=100,
     l(displayUnit="mm") = 0.008,
     redeclare function pLoss =
@@ -59,7 +59,7 @@ Medium model for the test. Can be anything.
     annotation (Placement(transformation(extent={{30,-50},{50,-30}})));
   FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=100,
     l(displayUnit="mm") = 0.008,
     redeclare function pLoss =

--- a/ThermofluidStream/Undirected/Sensors/MultiSensor_Tpm.mo
+++ b/ThermofluidStream/Undirected/Sensors/MultiSensor_Tpm.mo
@@ -62,14 +62,14 @@ public
     annotation(Dialog(group="Output", enable=outputTemperature or outputPressure or outputMassFlowRate),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=(outputTemperature or outputPressure or outputMassFlowRate) and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=(outputTemperature or outputPressure or outputMassFlowRate) and filter_output));
   parameter Real T_0(final quantity="ThermodynamicTemperature", final unit=temperatureUnit) = 0 "Start value for temperature output"
-    annotation(Dialog(group="Output", enable=outputTemperature and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputTemperature and filter_output and init==InitMode.InitialOutput));
   parameter Real p_0(final quantity="Pressure", final unit=pressureUnit) = 0 "Start value for pressure output"
-    annotation(Dialog(group="Output", enable=outputPressure and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputPressure and filter_output and init==InitMode.InitialOutput));
   parameter Real m_flow_0(final quantity="MassFlowRate", final unit=massFlowUnit) = 0 "Start value for mass flow rate output"
-    annotation(Dialog(group="Output", enable=outputMassFlowRate and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputMassFlowRate and filter_output and init==InitMode.InitialOutput));
 
 
   Modelica.Blocks.Interfaces.RealOutput T_out(final quantity="ThermodynamicTemperature", final unit=temperatureUnit) = T if outputTemperature "Temperature output connector"
@@ -89,7 +89,7 @@ protected
   Real direct_m_flow; // unit intentionally not set to avoid Warning
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     p=direct_p;
     T=direct_T;
     m_flow=direct_m_flow;

--- a/ThermofluidStream/Undirected/Sensors/SingleFlowSensor.mo
+++ b/ThermofluidStream/Undirected/Sensors/SingleFlowSensor.mo
@@ -26,10 +26,10 @@ model SingleFlowSensor "Flow sensor"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real value_0(unit=ThermofluidStream.Sensors.Internal.getFlowUnit(quantity)) = 0 "Start value of sensor output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
   Modelica.Blocks.Interfaces.RealOutput value_out(unit=ThermofluidStream.Sensors.Internal.getFlowUnit(quantity)) = value if outputValue "Sensor output connector"
     annotation (Placement(transformation(extent={{100,50},{120,70}})));
@@ -46,7 +46,7 @@ protected
         </html>"));
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Undirected/Sensors/SingleSensorSelect.mo
+++ b/ThermofluidStream/Undirected/Sensors/SingleSensorSelect.mo
@@ -36,10 +36,10 @@ model SingleSensorSelect "Selectable sensor"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real value_0(unit=ThermofluidStream.Sensors.Internal.getUnit(quantity)) = 0 "Start value of sensor output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
 
 
@@ -60,7 +60,7 @@ protected
   Real direct_value(unit=ThermofluidStream.Sensors.Internal.getUnit(quantity));
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Undirected/Sensors/SingleSensorX.mo
+++ b/ThermofluidStream/Undirected/Sensors/SingleSensorX.mo
@@ -18,10 +18,10 @@ model SingleSensorX "Mass fractions sensor"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real[Medium.nX] value_0(each unit="kg/kg") = Medium.X_default "Start value of mass fraction output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
   parameter Integer row(min=1, max=Medium.nX) = 1 "Row of mass fraction vector to display";
 
@@ -39,7 +39,7 @@ protected
   function mfk = Utilities.Functions.massFractionK(redeclare package Medium = Medium);
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Undirected/Sensors/Tests/TestSensors.mo
+++ b/ThermofluidStream/Undirected/Sensors/Tests/TestSensors.mo
@@ -18,7 +18,7 @@ model TestSensors "Test for the undirected sensors"
 
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=100,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -65,7 +65,7 @@ model TestSensors "Test for the undirected sensors"
     redeclare package Medium = Medium) annotation (Placement(transformation(extent={{50,-10},{70,10}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=100,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
@@ -100,7 +100,7 @@ model TestSensors "Test for the undirected sensors"
     outputValue=true,
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.p_bar,
     filter_output=true,
-    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.state,
+    init=ThermofluidStream.Sensors.Internal.Types.InitializationModelSensor.InitialOutput,
     value_0=1) annotation (Placement(transformation(extent={{-10,50},{10,70}})));
   SingleFlowSensor singleFlowSensor1(
     redeclare package Medium = Medium,
@@ -140,7 +140,7 @@ model TestSensors "Test for the undirected sensors"
     p0_par=100000) annotation (Placement(transformation(extent={{86,-40},{106,-20}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium2,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.01,
     l=100,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (

--- a/ThermofluidStream/Undirected/Sensors/TwoPhaseSensorSelect.mo
+++ b/ThermofluidStream/Undirected/Sensors/TwoPhaseSensorSelect.mo
@@ -30,10 +30,10 @@ model TwoPhaseSensorSelect "Selectable sensor for two phase medium"
     annotation(Dialog(group="Output", enable=outputValue),Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.Time TC = 0.1 "Time constant of sensor output filter (PT1)"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
-  parameter InitMode init=InitMode.steadyState "Initialization mode for sensor output"
+  parameter InitMode init=InitMode.SteadyState "Initialization mode for sensor output"
     annotation(Dialog(group="Output", enable=outputValue and filter_output));
   parameter Real value_0(unit=ThermofluidStream.Sensors.Internal.getTwoPhaseUnit(quantity)) = 0 "Start value of sensor output"
-    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.state));
+    annotation(Dialog(group="Output", enable=outputValue and filter_output and init==InitMode.InitialOutput));
 
   Modelica.Blocks.Interfaces.RealOutput value_out(unit=ThermofluidStream.Sensors.Internal.getTwoPhaseUnit(quantity)) = value if outputValue "Sensor output connector"
     annotation (Placement(transformation(extent={{100,50},{120,70}})));
@@ -50,7 +50,7 @@ protected
       </html>"));
 
 initial equation
-  if filter_output and init==InitMode.steadyState then
+  if filter_output and init==InitMode.SteadyState then
     value= direct_value;
   elseif filter_output then
     value = value_0;

--- a/ThermofluidStream/Undirected/Topology/Tests/TestConnectors.mo
+++ b/ThermofluidStream/Undirected/Topology/Tests/TestConnectors.mo
@@ -77,7 +77,7 @@ model TestConnectors "Test for the connectors"
     annotation (Placement(transformation(extent={{30,-40},{50,-20}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     computeL=false,
     r=0.01,
     l=1,
@@ -86,7 +86,7 @@ model TestConnectors "Test for the connectors"
     annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     computeL=false,
     r=0.01,
     l=1,
@@ -127,14 +127,14 @@ model TestConnectors "Test for the connectors"
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{-40,-78},{-20,-58}})));
   ThermofluidStream.Processes.FlowResistance flowResistance3(
-    redeclare package Medium = Medium, initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    redeclare package Medium = Medium, initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     l=5,
     redeclare function pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     r(displayUnit="mm") = 0.005)
     annotation (Placement(transformation(extent={{20,-78},{40,-58}})));
   Processes.FlowResistance flowResistance4(
-    redeclare package Medium = Medium, initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    redeclare package Medium = Medium, initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     l=5,
     redeclare function pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,

--- a/ThermofluidStream/Undirected/Topology/Tests/TestJunction.mo
+++ b/ThermofluidStream/Undirected/Topology/Tests/TestJunction.mo
@@ -32,14 +32,14 @@ model TestJunction "Test for the undirected junction"
     annotation (Placement(transformation(extent={{-134,-8},{-114,12}})));
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
     annotation (Placement(transformation(extent={{-46,50},{-26,70}})));
   ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
@@ -52,14 +52,14 @@ model TestJunction "Test for the undirected junction"
     annotation (Placement(transformation(extent={{0,10},{20,30}})));
   ThermofluidStream.Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
     annotation (Placement(transformation(extent={{26,10},{46,30}})));
   ThermofluidStream.Processes.FlowResistance flowResistance5(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
@@ -90,14 +90,14 @@ model TestJunction "Test for the undirected junction"
     annotation (Placement(transformation(extent={{-66,-70},{-46,-50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance8(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
     annotation (Placement(transformation(extent={{-46,-30},{-26,-10}})));
   ThermofluidStream.Processes.FlowResistance flowResistance9(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
@@ -108,14 +108,14 @@ model TestJunction "Test for the undirected junction"
     annotation (Placement(transformation(extent={{0,-70},{20,-50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance10(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
     annotation (Placement(transformation(extent={{26,-70},{46,-50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance11(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
@@ -140,21 +140,21 @@ model TestJunction "Test for the undirected junction"
     annotation (Placement(transformation(extent={{94,-50},{74,-30}})));
   ThermofluidStream.Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
     annotation (Placement(transformation(extent={{-136,30},{-116,50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss = pLoss)
     annotation (Placement(transformation(extent={{-136,-50},{-116,-30}})));
   ThermofluidStream.Processes.FlowResistance flowResistance6(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss =
@@ -163,7 +163,7 @@ model TestJunction "Test for the undirected junction"
     annotation (Placement(transformation(extent={{116,-50},{136,-30}})));
   ThermofluidStream.Processes.FlowResistance flowResistance7(
     redeclare package Medium = Medium,
-    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.InitialState,
     r=0.1,
     l=1,
     redeclare function pLoss =

--- a/ThermofluidStream/Utilities/Types.mo
+++ b/ThermofluidStream/Utilities/Types.mo
@@ -2,13 +2,13 @@ within ThermofluidStream.Utilities;
 package Types "Types that are not units needed."
   extends Modelica.Icons.TypesPackage;
   type InitializationMethods = enumeration(
-      none
+      NoInit
       "No initialization",
-      steadyState
+      SteadyState
       "Steady state initialization (derivatives of states are zero)",
-      state
+      InitialState
       "Initialization with initial states",
-      derivative
+      InitialDerivative
       "Initialization with initial derivatives of states")
     "Choices for initialization of a state."
     annotation (


### PR DESCRIPTION
Rename members of InitializationMethods and InitializationModelSensor and update all references in models, tests, examples, and **_TILMediaWrapper_**.

This is an API-breaking rename with no intended behavioral changes.

Closes #145 