### PR TITLE
Replace replaceable functions with inspectable models

### DIFF
--- a/TILMediaWrapper/Tests.mo
+++ b/TILMediaWrapper/Tests.mo
@@ -36,7 +36,7 @@ package Tests
       initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
       r(displayUnit="mm") = 0.01,
       l=10,
-      redeclare function pLoss =
+      redeclare model pLoss =
           ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (                       k=100, k2=100))
       annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
     Modelica.Blocks.Sources.Ramp ramp(
@@ -68,7 +68,7 @@ package Tests
       initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
       r(displayUnit="mm") = 0.01,
       l=10,
-      redeclare function pLoss =
+      redeclare model pLoss =
           ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (                       k=1000, k2=1000))
       annotation (Placement(transformation(extent={{-12,30},{8,50}})));
     ThermofluidStream.Boundaries.PhaseSeparator phaseSeparator(

--- a/ThermofluidStream/Boundaries/Tests/DynamicBoundaries.mo
+++ b/ThermofluidStream/Boundaries/Tests/DynamicBoundaries.mo
@@ -22,7 +22,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     r(displayUnit="mm") = 0.005,
     l=10,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Source source1(redeclare package Medium=Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{-80,-50},{-60,-30}})));
@@ -44,7 +44,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     l=10,
     L_value=1000,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
 
   Modelica.Blocks.Sources.Ramp ramp(
@@ -80,7 +80,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     r(displayUnit="mm") = 0.005,
     l=10,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,50},{10,70}})));
   Modelica.Blocks.Sources.Ramp ramp2(
     height=1,
@@ -114,7 +114,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     l=10,
     L_value=1000,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));
   Source source4(redeclare package Medium = Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{-80,-90},{-60,-70}})));
@@ -139,7 +139,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     l=10,
     L_value=1000,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-90},{10,-70}})));
   Source source5(redeclare package Medium = Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{-80,-30},{-60,-10}})));
@@ -164,7 +164,7 @@ model DynamicBoundaries "Test for DynamicInflow and Outflow"
     l=10,
     L_value=1000,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-30},{10,-10}})));
 equation
   connect(source.outlet, dynamicPressureInflow.inlet) annotation (Line(

--- a/ThermofluidStream/Boundaries/Tests/PhaseSeperator.mo
+++ b/ThermofluidStream/Boundaries/Tests/PhaseSeperator.mo
@@ -56,7 +56,7 @@ model PhaseSeperator
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss(k=5000))
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss(k=5000))
     annotation (Placement(transformation(extent={{-40,10},{-20,30}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
@@ -64,7 +64,7 @@ model PhaseSeperator
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss(k=5000))
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss(k=5000))
     annotation (Placement(transformation(extent={{-40,-30},{-20,-10}})));
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
@@ -72,7 +72,7 @@ model PhaseSeperator
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss(k=5000))
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss(k=5000))
     annotation (Placement(transformation(extent={{30,10},{50,30}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
@@ -80,7 +80,7 @@ model PhaseSeperator
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss(k=5000))
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss(k=5000))
     annotation (Placement(transformation(extent={{30,-30},{50,-10}})));
   Sensors.TwoPhaseSensorSelect twoPhaseSensorSelect4(
     redeclare package Medium = Medium,

--- a/ThermofluidStream/Boundaries/Tests/Reservoir.mo
+++ b/ThermofluidStream/Boundaries/Tests/Reservoir.mo
@@ -25,7 +25,7 @@ model Reservoir "Test for Reservoir"
   Processes.Pump pump(redeclare package Medium=Medium,
     initM_flow= ThermofluidStream.Utilities.Types.InitializationMethods.state,
     omega_from_input=true,
-    redeclare function dp_tau_pump =
+    redeclare model dp_tau_pump =
         Processes.Internal.TurboComponent.dp_tau_nominal_flow (
         V_r_input(displayUnit="m3") = 0.1,
         k_p_input=500,
@@ -35,7 +35,7 @@ model Reservoir "Test for Reservoir"
     redeclare package Medium=Medium,
     r=0.03,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{10,50},{-10,70}})));
   Source source(redeclare package Medium=Medium, p0_par=101200)
     annotation (Placement(transformation(extent={{-74,-66},{-54,-46}})));
@@ -65,7 +65,7 @@ model Reservoir "Test for Reservoir"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100))
     annotation (Placement(transformation(extent={{-46,-66},{-26,-46}})));
   Processes.FlowResistance flowResistance2(
@@ -73,7 +73,7 @@ model Reservoir "Test for Reservoir"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100))
     annotation (Placement(transformation(extent={{16,-66},{36,-46}})));
 equation

--- a/ThermofluidStream/Boundaries/Tests/TankFillingClosedTank.mo
+++ b/ThermofluidStream/Boundaries/Tests/TankFillingClosedTank.mo
@@ -38,7 +38,7 @@ model TankFillingClosedTank
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -50,7 +50,7 @@ model TankFillingClosedTank
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -86,7 +86,7 @@ model TankFillingClosedTank
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,

--- a/ThermofluidStream/Boundaries/Tests/TankHeating.mo
+++ b/ThermofluidStream/Boundaries/Tests/TankHeating.mo
@@ -45,7 +45,7 @@ model TankHeating
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -57,7 +57,7 @@ model TankHeating
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -69,7 +69,7 @@ model TankHeating
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -103,7 +103,7 @@ model TankHeating
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,

--- a/ThermofluidStream/Boundaries/Tests/TankOverfilling.mo
+++ b/ThermofluidStream/Boundaries/Tests/TankOverfilling.mo
@@ -22,7 +22,7 @@ extends Modelica.Icons.Example;
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=true,
@@ -34,7 +34,7 @@ extends Modelica.Icons.Example;
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=true,
@@ -68,7 +68,7 @@ extends Modelica.Icons.Example;
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=true,

--- a/ThermofluidStream/Boundaries/Tests/TankSelfDraining.mo
+++ b/ThermofluidStream/Boundaries/Tests/TankSelfDraining.mo
@@ -48,7 +48,7 @@ model TankSelfDraining
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -60,7 +60,7 @@ model TankSelfDraining
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -72,7 +72,7 @@ model TankSelfDraining
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03/10,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1))
     annotation (Placement(transformation(extent={{30,-10},{50,10}})));

--- a/ThermofluidStream/Boundaries/Tests/TankSelfDraining2.mo
+++ b/ThermofluidStream/Boundaries/Tests/TankSelfDraining2.mo
@@ -21,7 +21,7 @@ model TankSelfDraining2
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -53,7 +53,7 @@ model TankSelfDraining2
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -65,7 +65,7 @@ model TankSelfDraining2
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -88,7 +88,7 @@ model TankSelfDraining2
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,

--- a/ThermofluidStream/Boundaries/Tests/Volumes.mo
+++ b/ThermofluidStream/Boundaries/Tests/Volumes.mo
@@ -62,7 +62,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{20,-90},{40,-70}})));
   Processes.FlowResistance flowResistance1(
@@ -70,7 +70,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-40,-90},{-20,-70}})));
   VolumeMix volumeMix(
@@ -88,7 +88,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-40,10},{-20,30}})));
   Processes.FlowResistance flowResistance3(
@@ -96,7 +96,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-40,-30},{-20,-10}})));
   Processes.FlowResistance flowResistance4(
@@ -104,7 +104,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{20,-10},{40,10}})));
   VolumeMix volumeMix1(
@@ -130,7 +130,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(extent={{-40,80},{-20,100}})));
   Processes.FlowResistance flowResistance6(
@@ -138,7 +138,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=2e5))
     annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
   Processes.FlowResistance flowResistance8(
@@ -146,7 +146,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e1))
     annotation (Placement(transformation(extent={{20,60},{40,80}})));
   Volume heatportVolume1(
@@ -178,7 +178,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-40,-160},{-20,-140}})));
   Processes.FlowResistance flowResistance9(
@@ -186,7 +186,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{20,-200},{40,-180}})));
   Volume heatportVolume3(
@@ -225,7 +225,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.01,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(extent={{20,110},{40,130}})));
   Processes.FlowResistance flowResistance11(
@@ -233,7 +233,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.01,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(extent={{-40,110},{-20,130}})));
   VolumeMix volumeMix3(
@@ -259,7 +259,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(extent={{-40,180},{-20,200}})));
   Processes.FlowResistance flowResistance13(
@@ -267,7 +267,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=2e5))
     annotation (Placement(transformation(extent={{-40,140},{-20,160}})));
   Processes.FlowResistance flowResistance14(
@@ -275,7 +275,7 @@ Medium package used in the Test of the MixVolumes.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e1))
     annotation (Placement(transformation(extent={{20,160},{40,180}})));
 equation

--- a/ThermofluidStream/Examples/EspressoMachine.mo
+++ b/ThermofluidStream/Examples/EspressoMachine.mo
@@ -21,7 +21,7 @@ Medium model for water.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.003,
     l=0.3,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=3e8,
       k2=0))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
@@ -55,7 +55,7 @@ Medium model for water.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.003,
     l=0.3,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e7,
       k2=0))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
@@ -98,7 +98,7 @@ Medium model for water.
     r(displayUnit="mm") = 0.003,
     l=0.3,
     computeL=true,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e7,
       k2=0))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
@@ -175,7 +175,7 @@ Medium model for water.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     omega_from_input=true,
     omegaStateSelect=StateSelect.never,
-    redeclare function dp_tau_pump = Processes.Internal.TurboComponent.dp_tau_nominal_flow (
+    redeclare model dp_tau_pump = Processes.Internal.TurboComponent.dp_tau_nominal_flow (
       k_fric_input=0))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -207,7 +207,7 @@ Medium model for water.
     pressureUnit="bar") annotation (Placement(transformation(extent={{126,-106},{146,-86}})));
   Processes.Pump pump1(
     J_p=1e-3,redeclare package Medium = Water,
-    redeclare function dp_tau_pump =
+    redeclare model dp_tau_pump =
         Processes.Internal.TurboComponent.dp_tau_nominal_flow (
         parametrizeByDesignPoint=false,
         V_r_input(displayUnit="m3") = 0.1,
@@ -308,7 +308,7 @@ Medium model for water.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.003,
     l=0.3,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e7,
       k2=0))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
@@ -385,7 +385,7 @@ Medium model for water.
     redeclare package Medium = Water,
     r(displayUnit="mm") = 0.003,
     l=0.2,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=180,

--- a/ThermofluidStream/Examples/HeatPump.mo
+++ b/ThermofluidStream/Examples/HeatPump.mo
@@ -48,7 +48,7 @@ model HeatPump
     outputQuantity=ThermofluidStream.Sensors.Internal.Types.MassFlowQuantities.m_flow_kgps,
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     initPhi=true,
-    redeclare function dp_tau_compressor =
+    redeclare model dp_tau_compressor =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=200,
         m_flow_ref=1e-2,
@@ -88,7 +88,7 @@ model HeatPump
     l=0.5,
     L_value=100,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.galvanizedIron))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -100,7 +100,7 @@ model HeatPump
     l=0.5,
     L_value=100,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.galvanizedIron))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -110,14 +110,14 @@ model HeatPump
     redeclare package Medium = Air,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     omega_from_input=true,
-    redeclare function dp_tau_fan =
+    redeclare model dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=100))
     annotation (Placement(transformation(extent={{-60,98},{-40,78}})));
   Processes.Fan fan1(
     redeclare package Medium = Air,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     omega_from_input=true,
-    redeclare function dp_tau_fan =
+    redeclare model dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=100)) annotation (
       Placement(transformation(
         extent={{-10,10},{10,-10}},

--- a/ThermofluidStream/Examples/ReverseHeatPump.mo
+++ b/ThermofluidStream/Examples/ReverseHeatPump.mo
@@ -22,7 +22,7 @@ model ReverseHeatPump
     redeclare package Medium = RefrigerantMedium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.none,
     omega_from_input=true,
-    redeclare function dp_tau_compressor =
+    redeclare model dp_tau_compressor =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         kappaFromMedia=false,
         kappa_fixed=1.13,
@@ -132,7 +132,7 @@ model ReverseHeatPump
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -203,7 +203,7 @@ model ReverseHeatPump
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},

--- a/ThermofluidStream/Examples/SimpleAirCycle.mo
+++ b/ThermofluidStream/Examples/SimpleAirCycle.mo
@@ -49,7 +49,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     omega_from_input=false,
     initPhi=false,
-    redeclare function dp_tau_compressor =
+    redeclare model dp_tau_compressor =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=2500,
         skew=1,
@@ -69,7 +69,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     omega_0=0,
     initPhi=true,
     phi_0=0,
-    redeclare function dp_tau_turbine = Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+    redeclare model dp_tau_turbine = Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=Modelica.Constants.inf,
         m_flow_ref=0.36,
         skew=-0.2,
@@ -100,7 +100,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
         extent={{10,10},{-10,-10}},
         rotation=270,
         origin={-60,-30})));
-  Processes.Fan fan(redeclare package Medium = Medium,     redeclare function dp_tau_fan =
+  Processes.Fan fan(redeclare package Medium = Medium,     redeclare model dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=500,
         skew=1,
@@ -114,7 +114,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     r=r,
     l=20,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (material=
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (material=
             ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{10,-10},{-10,10}},
         rotation=90,
@@ -123,7 +123,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     r=r,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
+    redeclare model pLoss = Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
     computeL=false,
     L_value=0) annotation (Placement(transformation(extent={{-80,-110},{-100,-130}})));
   Boundaries.Source bleedInlet1(
@@ -170,7 +170,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     omega_0=0,
     initPhi=true,
     phi_0=0,
-    redeclare function dp_tau_turbine = Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+    redeclare model dp_tau_turbine = Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=Modelica.Constants.inf,
         m_flow_ref=0.3658,
         skew=-0.2,
@@ -191,7 +191,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
         extent={{-10,10},{10,-10}},
         rotation=270,
         origin={58,0})));
-  Processes.Fan fan1(redeclare package Medium = Medium,     redeclare function dp_tau_fan =
+  Processes.Fan fan1(redeclare package Medium = Medium,     redeclare model dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=1000,
         skew=1,
@@ -204,7 +204,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     r=r,
     l=20,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (material=
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (material=
             ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=270,
@@ -213,7 +213,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     r=r,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
+    redeclare model pLoss = Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
     computeL=false,
     L_value=0) annotation (Placement(transformation(extent={{80,-110},{100,-130}})));
 equation

--- a/ThermofluidStream/Examples/SimpleCoolingCycle.mo
+++ b/ThermofluidStream/Examples/SimpleCoolingCycle.mo
@@ -27,7 +27,7 @@ extends Modelica.Icons.Example;
   ThermofluidStream.Processes.Pump pump(
     redeclare package Medium = Medium_liquid,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
+    redeclare model dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
     annotation (Placement(transformation(extent={{-20,10},{-40,30}})));
   ThermofluidStream.Processes.ThermalConvectionPipe thermalConvectionPipe(
     redeclare package Medium = Medium_liquid,
@@ -40,7 +40,7 @@ extends Modelica.Icons.Example;
     redeclare package Medium = Medium_liquid,
     r=0.05,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(extent={{80,70},{100,90}})));
@@ -97,7 +97,7 @@ extends Modelica.Icons.Example;
   ThermofluidStream.Processes.Fan fan(
     redeclare package Medium = Medium_air,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_fan =
+    redeclare model dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
       omega_ref=100))
     annotation (Placement(transformation(extent={{140,-2},{160,18}})));

--- a/ThermofluidStream/Examples/SimpleEngine.mo
+++ b/ThermofluidStream/Examples/SimpleEngine.mo
@@ -74,7 +74,7 @@ model SimpleEngine "Simple steam engine"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.015,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{10,44},{30,64}})));
   Processes.FlowResistance flowResistance4(
@@ -83,7 +83,7 @@ model SimpleEngine "Simple steam engine"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.015,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-2,24},{18,44}})));
   Processes.FlowResistance flowResistance5(
@@ -92,7 +92,7 @@ model SimpleEngine "Simple steam engine"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.015,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{70,44},{90,64}})));
   Processes.FlowResistance flowResistance6(
@@ -101,7 +101,7 @@ model SimpleEngine "Simple steam engine"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.015,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{88,24},{108,44}})));
   FlowControl.TanValve tanValve(redeclare package Medium = Water, invertInput=false) annotation (Placement(transformation(extent={{100,64},{120,44}})));

--- a/ThermofluidStream/Examples/SimpleGasTurbine.mo
+++ b/ThermofluidStream/Examples/SimpleGasTurbine.mo
@@ -14,7 +14,7 @@ model SimpleGasTurbine "Simple version of a Gas Turbine"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     omega_0=100,
-    redeclare function dp_tau_compressor =
+    redeclare model dp_tau_compressor =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
       omega_ref=100,
       eta=0.8))
@@ -22,7 +22,7 @@ model SimpleGasTurbine "Simple version of a Gas Turbine"
   Processes.Turbine turbine(
     redeclare package Medium=Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_turbine =
+    redeclare model dp_tau_turbine =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
       omega_ref=1000,
       m_flow_ref=1.2,

--- a/ThermofluidStream/Examples/SimpleStream.mo
+++ b/ThermofluidStream/Examples/SimpleStream.mo
@@ -21,27 +21,27 @@ model SimpleStream "Simple pneumatic network"
     redeclare package Medium = Medium,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{-120,-10},{-100,10}})));
   Processes.FlowResistance pipe1(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,10},{40,30}})));
   Processes.FlowResistance pipe2(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=100,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{-30,-30},{-10,-10}})));
   Processes.FlowResistance pipe3(
     redeclare package Medium = Medium,
     r=0.1,
     l=20,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{100,-10},{120,10}})));
   Topology.SplitterT1 splitter(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));

--- a/ThermofluidStream/Examples/Utilities/CoffeeStrainer.mo
+++ b/ThermofluidStream/Examples/Utilities/CoffeeStrainer.mo
@@ -18,7 +18,7 @@ water of some sorts.
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.003,
     l=0.3,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=8e8,
           k2=0)) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/Examples/Utilities/CupSink.mo
+++ b/ThermofluidStream/Examples/Utilities/CupSink.mo
@@ -34,7 +34,7 @@ Medium model in cup.
     redeclare package Medium = Medium,
     r(displayUnit="cm") = 0.05,
     l(displayUnit="cm") = 0.01,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=10))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/Examples/Utilities/Tests/BoilerEspresso.mo
+++ b/ThermofluidStream/Examples/Utilities/Tests/BoilerEspresso.mo
@@ -28,7 +28,7 @@ model BoilerEspresso "Test for the espresso boiler"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.003,
     l=0.3,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e8,
       k2=0))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
@@ -65,7 +65,7 @@ model BoilerEspresso "Test for the espresso boiler"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.003,
     l=0.3,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e7,
       k2=0))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
@@ -95,7 +95,7 @@ model BoilerEspresso "Test for the espresso boiler"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.003,
     l=0.3,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e7,
       k2=0))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/Examples/Utilities/Tests/Piston.mo
+++ b/ThermofluidStream/Examples/Utilities/Tests/Piston.mo
@@ -78,7 +78,7 @@ model Piston "Test for Piston model"
     L_value=1e-3,
     r=0.1,
     l=0.01,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=10))
     annotation (Placement(transformation(extent={{-46,0},{-26,20}})));
   Processes.FlowResistance flowResistance2(
@@ -89,7 +89,7 @@ model Piston "Test for Piston model"
     L_value=1e-3,
     r=0.1,
     l=0.01,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=10))
     annotation (Placement(transformation(extent={{-46,-30},{-26,-10}})));
   Processes.FlowResistance flowResistance1(
@@ -100,7 +100,7 @@ model Piston "Test for Piston model"
     L_value=1e-3,
     r=0.1,
     l=0.01,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=10))
     annotation (Placement(transformation(extent={{34,0},{54,20}})));
   Processes.FlowResistance flowResistance3(
@@ -111,7 +111,7 @@ model Piston "Test for Piston model"
     L_value=1e-3,
     r=0.1,
     l=0.01,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=10))
     annotation (Placement(transformation(extent={{34,-30},{54,-10}})));
   FlowControl.TanValve tanValve(redeclare package Medium = Medium, invertInput=false) annotation (Placement(transformation(extent={{64,20},{84,0}})));

--- a/ThermofluidStream/Examples/VaporCycle.mo
+++ b/ThermofluidStream/Examples/VaporCycle.mo
@@ -87,7 +87,7 @@ model VaporCycle
     redeclare package Medium = SecondaryMedium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{-66,56},{-46,76}})));
   Sensors.MultiSensor_Tpm multiSensor_Tpm(
@@ -100,7 +100,7 @@ model VaporCycle
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{82,-68},{62,-48}})));
   Sensors.MultiSensor_Tpm multiSensor_Tpm1(
@@ -211,7 +211,7 @@ model VaporCycle
   Processes.Compressor compressor(
     redeclare package Medium = RefrigerantMedium,
     omega_from_input=true,
-    redeclare function dp_tau_compressor =
+    redeclare model dp_tau_compressor =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         kappaFromMedia=false,
         kappa_fixed=1.13,

--- a/ThermofluidStream/Examples/VenturiPump.mo
+++ b/ThermofluidStream/Examples/VenturiPump.mo
@@ -15,7 +15,7 @@ model VenturiPump "Pumping of liquid water using the venturi effect"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=0.25,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-30,-70},{-10,-50}})));
   Boundaries.Source source2_1(
@@ -49,7 +49,7 @@ model VenturiPump "Pumping of liquid water using the venturi effect"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=0.1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=270,

--- a/ThermofluidStream/Examples/WaterHammer.mo
+++ b/ThermofluidStream/Examples/WaterHammer.mo
@@ -29,7 +29,7 @@ model WaterHammer "Pump water by using dynamic pressures"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.025,
     l=25,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
   ThermofluidStream.Boundaries.Sink sink1(

--- a/ThermofluidStream/FlowControl/Tests/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/BasicControlValve.mo
@@ -31,7 +31,7 @@ Medium package used in the Test.
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-80,50},{-60,70}})));
   ThermofluidStream.Boundaries.Sink sink1(redeclare package Medium = medium,
@@ -103,35 +103,35 @@ Medium package used in the Test.
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{66,50},{86,70}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{68,-10},{88,10}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-76,-70},{-56,-50}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{60,-70},{80,-50}})));
 equation

--- a/ThermofluidStream/FlowControl/Tests/CheckValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/CheckValve.mo
@@ -30,7 +30,7 @@ Medium package used in the Test.
   Processes.FlowResistance flowResistance(redeclare package Medium=Medium,
     r=0.1,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{14,-10},{34,10}})));
 equation
   connect(checkValve.inlet, source.outlet) annotation (Line(

--- a/ThermofluidStream/FlowControl/Tests/MCV.mo
+++ b/ThermofluidStream/FlowControl/Tests/MCV.mo
@@ -32,7 +32,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,20},{40,40}})));
   ThermofluidStream.Boundaries.Source source1(
@@ -54,7 +54,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,-10},{40,10}})));
   Modelica.Blocks.Sources.Pulse pulse1(
@@ -82,7 +82,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,-40},{40,-20}})));
   Modelica.Blocks.Sources.Trapezoid trapezoid(
@@ -113,7 +113,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,-70},{40,-50}})));
   Modelica.Blocks.Sources.Pulse pulse3(
@@ -141,7 +141,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,-100},{40,-80}})));
   Modelica.Blocks.Sources.Trapezoid trapezoid1(
@@ -173,7 +173,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,60},{40,80}})));
   Modelica.Blocks.Sources.Pulse pulse5(

--- a/ThermofluidStream/FlowControl/Tests/PCV.mo
+++ b/ThermofluidStream/FlowControl/Tests/PCV.mo
@@ -48,7 +48,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.02,
     l=3,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{10,-50},{30,-30}})));
   ThermofluidStream.Boundaries.VolumeFlex
@@ -63,7 +63,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.02,
     l=3,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{10,-20},{30,0}})));
   ThermofluidStream.Boundaries.Source source(redeclare package Medium = Medium, p0_par=100000)
@@ -75,7 +75,7 @@ Medium package used in the Test.
     m_flow_0=10,
     r(displayUnit="mm") = 0.02,
     l=3,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));
   ThermofluidStream.FlowControl.PCV pCV2(
@@ -92,7 +92,7 @@ Medium package used in the Test.
     m_flow_0=10,
     r(displayUnit="mm") = 0.02,
     l=3,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{10,10},{30,30}})));
   ThermofluidStream.FlowControl.PCV pCV3(
@@ -110,7 +110,7 @@ Medium package used in the Test.
     m_flow_0=10,
     r(displayUnit="mm") = 0.02,
     l=3,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{10,50},{30,70}})));
   ThermofluidStream.FlowControl.PCV pCV4(

--- a/ThermofluidStream/FlowControl/Tests/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/Tests/SpecificValveType.mo
@@ -29,7 +29,7 @@ Medium package used in the Test.
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-80,50},{-60,70}})));
   ThermofluidStream.Boundaries.Sink sink1(redeclare package Medium = medium,
@@ -79,21 +79,21 @@ Medium package used in the Test.
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{66,50},{86,70}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{68,-10},{88,10}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
 equation

--- a/ThermofluidStream/FlowControl/Tests/Switch.mo
+++ b/ThermofluidStream/FlowControl/Tests/Switch.mo
@@ -23,7 +23,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-42,60},{-22,80}})));
   Boundaries.Sink sink1(redeclare package Medium = Medium, p0_par=100000)
@@ -35,14 +35,14 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{20,80},{40,100}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{20,60},{40,80}})));
   Modelica.Blocks.Sources.Pulse pulse(period=1)
@@ -59,7 +59,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-44,-24},{-24,-4}})));
   Boundaries.Source source2(
@@ -75,7 +75,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=180,
@@ -86,7 +86,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{18,-24},{38,-4}})));
   Boundaries.Sink sink3(redeclare package Medium = Medium, p0_par=100000)
@@ -97,7 +97,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=180,

--- a/ThermofluidStream/FlowControl/Tests/TanValve.mo
+++ b/ThermofluidStream/FlowControl/Tests/TanValve.mo
@@ -23,7 +23,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-52,-10},{-32,10}})));
   Boundaries.Sink sink1(redeclare package Medium = Medium, p0_par=100000)
@@ -56,7 +56,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{68,26},{88,46}})));
   Processes.FlowResistance flowResistance2(
@@ -64,7 +64,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{64,-10},{84,10}})));
 equation

--- a/ThermofluidStream/HeatExchangers/DiscretizedCounterFlowHEX_FR.mo
+++ b/ThermofluidStream/HeatExchangers/DiscretizedCounterFlowHEX_FR.mo
@@ -17,7 +17,7 @@ model DiscretizedCounterFlowHEX_FR "Discretized Heat Exchanger for single- or tw
     each r=1,
     each l=1,
     each computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       each k=k1_B,
       each k2=k2_B)) annotation (Placement(transformation(extent={{40,50},{60,70}})));
   Processes.FlowResistance flowResistanceA[nCells](
@@ -25,7 +25,7 @@ model DiscretizedCounterFlowHEX_FR "Discretized Heat Exchanger for single- or tw
     each r=1,
     each l=1,
     each computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       each k=k1_A,
       each k2=k2_A)) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/HeatExchangers/DiscretizedCrossFlowHEX.mo
+++ b/ThermofluidStream/HeatExchangers/DiscretizedCrossFlowHEX.mo
@@ -7,7 +7,7 @@ model DiscretizedCrossFlowHEX "Discretized heat exchanger for single- or two-pha
     redeclare package Medium = MediumA,
     each r(each displayUnit="mm") = 0.025,
     each l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       each k=50)) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,

--- a/ThermofluidStream/HeatExchangers/DiscretizedCrossFlowHEX_FR.mo
+++ b/ThermofluidStream/HeatExchangers/DiscretizedCrossFlowHEX_FR.mo
@@ -17,7 +17,7 @@ model DiscretizedCrossFlowHEX_FR "Discretized Heat Exchanger for single- or two-
     each r=1,
     each l=1,
     each computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       each k=k1_A,
       each k2=k2_A)) annotation (Placement(transformation(extent={{-20,-70},{-40,-50}})));
   Processes.FlowResistance flowResistanceB[nCells](
@@ -25,7 +25,7 @@ model DiscretizedCrossFlowHEX_FR "Discretized Heat Exchanger for single- or two-
     each r=1,
     each l=1,
     each computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       each k=k1_B,
       each k2=k2_B)) annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},

--- a/ThermofluidStream/HeatExchangers/Tests/Condenser.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/Condenser.mo
@@ -87,7 +87,7 @@ model Condenser
     m_flow_0=0.5,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-82,0},{-62,20}})));
 
@@ -97,7 +97,7 @@ model Condenser
     m_flow_0=0.3,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU.mo
@@ -66,7 +66,7 @@ model CounterFlowNTU
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{102,10},{82,30}})));
   Processes.FlowResistance flowResistanceA(
@@ -74,7 +74,7 @@ model CounterFlowNTU
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-100,-30},{-80,-10}})));
 

--- a/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_parallel.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_parallel.mo
@@ -123,7 +123,7 @@ model CounterFlowNTU_parallel
     redeclare package Medium = MediumB,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-136,10},{-156,30}})));
   Processes.FlowResistance flowResistanceB(
@@ -131,7 +131,7 @@ model CounterFlowNTU_parallel
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{20,22},{0,42}})));
   Processes.FlowResistance flowResistanceB1(
@@ -139,7 +139,7 @@ model CounterFlowNTU_parallel
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{12,-2},{-8,18}})));
   Processes.FlowResistance flowResistanceA2(
@@ -147,7 +147,7 @@ model CounterFlowNTU_parallel
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-78,34},{-58,54}})));
   Processes.FlowResistance flowResistanceA(
@@ -155,7 +155,7 @@ model CounterFlowNTU_parallel
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-116,-14},{-96,6}})));
   FlowControl.MCV mCV(

--- a/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_serial.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_serial.mo
@@ -85,7 +85,7 @@ model CounterFlowNTU_serial
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-112,-14},{-92,6}})));
   Processes.FlowResistance flowResistanceB(
@@ -93,7 +93,7 @@ model CounterFlowNTU_serial
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{130,-2},{110,18}})));
   FlowControl.MCV mCV(

--- a/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_zeroMassFlow.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CounterFlowNTU_zeroMassFlow.mo
@@ -76,7 +76,7 @@ model CounterFlowNTU_zeroMassFlow
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.005,
     l=0.5,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{100,10},{80,30}})));
   Processes.FlowResistance flowResistanceA(
@@ -84,7 +84,7 @@ model CounterFlowNTU_zeroMassFlow
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.005,
     l=0.5,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-54,-30},{-34,-10}})));
 equation

--- a/ThermofluidStream/HeatExchangers/Tests/CrossFlowNTU.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CrossFlowNTU.mo
@@ -78,7 +78,7 @@ model CrossFlowNTU
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-92,-10},{-72,10}})));
   Processes.FlowResistance flowResistanceB(
@@ -86,7 +86,7 @@ model CrossFlowNTU
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},

--- a/ThermofluidStream/HeatExchangers/Tests/CrossFlowNTU_zeroMassFlow.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/CrossFlowNTU_zeroMassFlow.mo
@@ -81,7 +81,7 @@ model CrossFlowNTU_zeroMassFlow
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.005,
     l=0.5,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(extent={{-102,-10},{-82,10}})));
   Processes.FlowResistance flowResistanceB(
@@ -89,7 +89,7 @@ model CrossFlowNTU_zeroMassFlow
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.005,
     l=0.5,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},

--- a/ThermofluidStream/HeatExchangers/Tests/ElementTwoPhase.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/ElementTwoPhase.mo
@@ -135,27 +135,27 @@ model ElementTwoPhase
     redeclare package Medium = MediumRefrigerant,
     r(displayUnit="mm") = 0.01,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,70},{-20,90}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = MediumRefrigerant,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.01,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-38,40},{-18,60}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = MediumRefrigerant,
     r(displayUnit="mm") = 0.01,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = MediumRefrigerant,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.01,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,-90},{-20,-70}})));
   Modelica.Blocks.Sources.Trapezoid
                                trapezoid2(

--- a/ThermofluidStream/HeatExchangers/Tests/Evaporator.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/Evaporator.mo
@@ -88,7 +88,7 @@ model Evaporator
     m_flow_0=1,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{88,-14},{68,6}})));
 
@@ -97,7 +97,7 @@ model Evaporator
     m_flow_0=0.3,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},

--- a/ThermofluidStream/HeatExchangers/Tests/FlowRes.mo
+++ b/ThermofluidStream/HeatExchangers/Tests/FlowRes.mo
@@ -294,7 +294,7 @@ model FlowRes
     m_flow_0=0.5,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{62,32},{82,52}})));
   Processes.FlowResistance flowResistanceB(
@@ -303,7 +303,7 @@ model FlowRes
     m_flow_0=0.3,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -423,7 +423,7 @@ model FlowRes
     m_flow_0=0.5,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{44,-82},{64,-62}})));
   Processes.FlowResistance flowResistanceB1(
@@ -432,7 +432,7 @@ model FlowRes
     m_flow_0=0.3,
     r=0.05,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step1OpenLoop.mo
+++ b/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step1OpenLoop.mo
@@ -33,7 +33,7 @@ model Step1OpenLoop
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
             0.1e5),
     l=10,
     r=1) annotation(Placement(transformation(extent={{40,-10},{60,10}})));

--- a/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step2SaturatedVapor.mo
+++ b/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step2SaturatedVapor.mo
@@ -33,7 +33,7 @@ model Step2SaturatedVapor
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
             0.1e5),
     l=10,
     r=1) annotation(Placement(transformation(extent={{40,-10},{60,10}})));

--- a/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step3Superheater.mo
+++ b/ThermofluidStream/Idealized/Examples/ClausiusRankine/Step3Superheater.mo
@@ -32,7 +32,7 @@ model Step3Superheater
   ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=
             0.1e5),
     l=10,
     r=1) annotation(Placement(transformation(extent={{90,-10},{110,10}})));

--- a/ThermofluidStream/Idealized/Tests/Topology/JunctionT1Const.mo
+++ b/ThermofluidStream/Idealized/Tests/Topology/JunctionT1Const.mo
@@ -20,7 +20,7 @@ model JunctionT1Const "Example - JunctionT1 with constant mass flow rate sources
   ThermofluidStream.Processes.FlowResistance flowResistanceB(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
     l=1,
     r=1) annotation(Placement(transformation(extent={{-160,20},{-140,40}})));
   ThermofluidStream.Boundaries.Source sourceB(
@@ -45,7 +45,7 @@ model JunctionT1Const "Example - JunctionT1 with constant mass flow rate sources
                        flowResistanceA(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
     l=1,
     r=1)                                                                                       annotation(Placement(transformation(extent={{-20,60},{0,80}})));
   ThermofluidStream.Boundaries.Source sourceA1(

--- a/ThermofluidStream/Idealized/Tests/Topology/JunctionT2Const.mo
+++ b/ThermofluidStream/Idealized/Tests/Topology/JunctionT2Const.mo
@@ -20,7 +20,7 @@ model JunctionT2Const "Example - JunctionT2 with constant mass flow rate sources
   ThermofluidStream.Processes.FlowResistance flowResistanceB(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
     l=1,
     r=1) annotation(Placement(transformation(extent={{-170,20},{-150,40}})));
   ThermofluidStream.Boundaries.Source sourceB(
@@ -45,7 +45,7 @@ model JunctionT2Const "Example - JunctionT2 with constant mass flow rate sources
                        flowResistanceA(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k2=1e5) "Linear-quadratic",
     l=1,
     r=1)                                                                                       annotation(Placement(transformation(extent={{-20,60},{0,80}})));
   ThermofluidStream.Boundaries.Source sourceA1(

--- a/ThermofluidStream/Interfaces/Tests/Test_p_out_clipping.mo
+++ b/ThermofluidStream/Interfaces/Tests/Test_p_out_clipping.mo
@@ -26,7 +26,7 @@ Medium package used in the Test.
     l=1,
     L_value=100,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100, k2=50))
     annotation (Placement(transformation(extent={{-10,40},{10,60}})));
   Processes.Fan fan(redeclare package Medium = Medium,
@@ -36,7 +36,7 @@ Medium package used in the Test.
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     omega_0=1,
     initPhi=true,
-    redeclare function dp_tau_fan =
+    redeclare model dp_tau_fan =
         Processes.Internal.TurboComponent.dp_tau_const_isentrop)
     annotation (Placement(transformation(extent={{-10,20},{10,40}})));
   FlowControl.BasicControlValve basicControlValve(redeclare package Medium = Medium,

--- a/ThermofluidStream/Media/Tests/TestXRGMedia.mo
+++ b/ThermofluidStream/Media/Tests/TestXRGMedia.mo
@@ -64,7 +64,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     redeclare package Medium = XRGMedia.NH3_ph,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
@@ -73,7 +73,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     redeclare package Medium = XRGMedia.CO2_ph,
     r(displayUnit="mm") = 0.005,
     l=15,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
@@ -83,7 +83,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.002,
     l=50,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
@@ -92,7 +92,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     redeclare package Medium = XRGMedia.R134a_ph,
     r(displayUnit="mm") = 0.02,
     l=5,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
@@ -102,7 +102,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
@@ -133,7 +133,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     redeclare package Medium = XRGMedia.R1234yf_ph,
     r(displayUnit="mm") = 0.02,
     l=20,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=500, k2=500))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -145,7 +145,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     redeclare package Medium = XRGMedia.R245fa_ph,
     r(displayUnit="mm") = 0.02,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
@@ -171,7 +171,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
   Processes.Pump pump(
     redeclare package Medium = XRGMedia.R134a_ph,
     omega_from_input=true,
-    redeclare function dp_tau_pump =
+    redeclare model dp_tau_pump =
         Processes.Internal.TurboComponent.dp_tau_nominal_flow)
     annotation (Placement(transformation(extent={{-78,40},{-98,20}})));
   Modelica.Blocks.Sources.Constant const(k=6300) annotation (Placement(transformation(extent={{-128,52},{-108,72}})));
@@ -180,7 +180,7 @@ model TestXRGMedia "Test for five XRG Media with various components"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.02,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,

--- a/ThermofluidStream/Media/additionalMedia/Incompressible/Tests/TestLiqLoopDowcal100.mo
+++ b/ThermofluidStream/Media/additionalMedia/Incompressible/Tests/TestLiqLoopDowcal100.mo
@@ -26,14 +26,14 @@ model TestLiqLoopDowcal100 "Test of medium Dowcal100 for a liquid loop"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
     pressureDropUnit=ThermofluidStream.Types.PressureUnit.kPa,
     pressureDropSignificantDigits=2) annotation (Placement(transformation(extent={{60,56},{40,76}})));
 
   ThermofluidStream.Processes.Pump pump(
     redeclare package Medium = TertiaryMedium,
     omega_from_input=true,
-    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
           useLegacyReynolds=false)) annotation (Placement(transformation(extent={{40,-20},{60,0}})));
 
   ThermofluidStream.Processes.ConductionElement conductionElement(
@@ -58,7 +58,7 @@ model TestLiqLoopDowcal100 "Test of medium Dowcal100 for a liquid loop"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
     pressureDropUnit=ThermofluidStream.Types.PressureUnit.bar,
     pressureDropSignificantDigits=3) annotation (Placement(transformation(extent={{-140,80},{-120,100}})));
 

--- a/ThermofluidStream/Media/additionalMedia/Incompressible/Tests/TestLiqLoopJP8.mo
+++ b/ThermofluidStream/Media/additionalMedia/Incompressible/Tests/TestLiqLoopJP8.mo
@@ -26,14 +26,14 @@ model TestLiqLoopJP8 "Test of medium JP8 for a liquid loop"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
     pressureDropUnit=ThermofluidStream.Types.PressureUnit.kPa,
     pressureDropSignificantDigits=2) annotation (Placement(transformation(extent={{60,56},{40,76}})));
 
   ThermofluidStream.Processes.Pump pump(
     redeclare package Medium = TertiaryMedium,
     omega_from_input=true,
-    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
           useLegacyReynolds=false)) annotation (Placement(transformation(extent={{40,-20},{60,0}})));
 
   ThermofluidStream.Processes.ConductionElement conductionElement(
@@ -58,7 +58,7 @@ model TestLiqLoopJP8 "Test of medium JP8 for a liquid loop"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
     pressureDropUnit=ThermofluidStream.Types.PressureUnit.bar,
     pressureDropSignificantDigits=3) annotation (Placement(transformation(extent={{-140,80},{-120,100}})));
 

--- a/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestLiqLoopJP8DryAir.mo
+++ b/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestLiqLoopJP8DryAir.mo
@@ -26,14 +26,14 @@ model TestLiqLoopJP8DryAir "Test of medium JP8DryAir for a liquid loop"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
     pressureDropUnit=ThermofluidStream.Types.PressureUnit.kPa,
     pressureDropSignificantDigits=2) annotation (Placement(transformation(extent={{60,56},{40,76}})));
 
   ThermofluidStream.Processes.Pump pump(
     redeclare package Medium = TertiaryMedium,
     omega_from_input=true,
-    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
           useLegacyReynolds=false)) annotation (Placement(transformation(extent={{40,-20},{60,0}})));
 
   ThermofluidStream.Processes.ConductionElement conductionElement(
@@ -58,7 +58,7 @@ model TestLiqLoopJP8DryAir "Test of medium JP8DryAir for a liquid loop"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
     pressureDropUnit=ThermofluidStream.Types.PressureUnit.bar,
     pressureDropSignificantDigits=3) annotation (Placement(transformation(extent={{-140,80},{-120,100}})));
 

--- a/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestSimpleLoopJP8DryAir.mo
+++ b/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestSimpleLoopJP8DryAir.mo
@@ -11,14 +11,14 @@ model TestSimpleLoopJP8DryAir "Test of a simple cooling loop using JP8DryAir"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
     pressureDropUnit=ThermofluidStream.Types.PressureUnit.kPa)
     annotation (Placement(transformation(extent={{60,30},{40,50}})));
 
   ThermofluidStream.Processes.Pump pump(
     redeclare package Medium = TertiaryMedium,
     omega_from_input=true,
-    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
           useLegacyReynolds=false)) annotation (Placement(transformation(extent={{60,-20},{80,0}})));
 
   ThermofluidStream.Processes.ConductionElement conductionElement(

--- a/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestSimpleLoopWithStaticHeadJP8DryAir.mo
+++ b/ThermofluidStream/Media/additionalMedia/SingleGasAndIncompressible/Tests/TestSimpleLoopWithStaticHeadJP8DryAir.mo
@@ -11,14 +11,14 @@ model TestSimpleLoopWithStaticHeadJP8DryAir "Test of a cooling loop with static 
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e4),
     pressureDropUnit=ThermofluidStream.Types.PressureUnit.kPa)
     annotation (Placement(transformation(extent={{0,50},{-20,70}})));
 
   ThermofluidStream.Processes.Pump pump(
     redeclare package Medium = TertiaryMedium,
     omega_from_input=true,
-    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
           useLegacyReynolds=false)) annotation (Placement(transformation(extent={{70,-30},{90,-10}})));
 
   ThermofluidStream.Processes.ConductionElement conductionElement(

--- a/ThermofluidStream/Processes/Compressor.mo
+++ b/ThermofluidStream/Processes/Compressor.mo
@@ -1,19 +1,19 @@
 within ThermofluidStream.Processes;
 model Compressor "Compressor using ideal gas assumptions"
 
-  extends Internal.PartialTurboComponent(redeclare function dp_tau =
+  extends Internal.PartialTurboComponent(redeclare model dp_tau =
         dp_tau_compressor);
 
-  replaceable function dp_tau_compressor =
+  replaceable model dp_tau_compressor =
       Internal.TurboComponent.pleaseSelect_dp_tau
     constrainedby Internal.TurboComponent.partial_dp_tau(
       redeclare package Medium = Medium) "Compressor characteristic curve"
     annotation(choices(
-        choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select function",
+        choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select model",
         choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop "Fixed isentropic efficiency"),
       Documentation(info="<html>
 <p>
-Selectable function to choose between different compressor models.
+Selectable model to choose between different compressor models.
 </p>
 </html>"));
 

--- a/ThermofluidStream/Processes/Fan.mo
+++ b/ThermofluidStream/Processes/Fan.mo
@@ -1,16 +1,16 @@
 within ThermofluidStream.Processes;
 model Fan "Fan using ideal gas assumptions"
-  extends Internal.PartialTurboComponent(redeclare function dp_tau=dp_tau_fan);
+  extends Internal.PartialTurboComponent(redeclare model dp_tau=dp_tau_fan);
 
-  replaceable function dp_tau_fan = Internal.TurboComponent.pleaseSelect_dp_tau
+  replaceable model dp_tau_fan = Internal.TurboComponent.pleaseSelect_dp_tau
     constrainedby Internal.TurboComponent.partial_dp_tau(
       redeclare package Medium = Medium) "Fan characteristic curve"
       annotation(choices(
-        choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select function",
+        choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select model",
         choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop "Fixed isentropic efficiency"),
         Documentation(info="<html>
 <p>
-Selectable function to choose between different fan models.
+Selectable model to choose between different fan models.
 </p>
 </html>"));
 

--- a/ThermofluidStream/Processes/FlowResistance.mo
+++ b/ThermofluidStream/Processes/FlowResistance.mo
@@ -7,37 +7,37 @@ model FlowResistance "Flow resistance model"
   import Modelica.Constants.pi "Constant Pi";
   import ThermofluidStream.Processes.Internal.ShapeOfResistance "Shape of cross sectional area";
 
-  replaceable function pLoss = Internal.FlowResistance.pleaseSelectPressureLoss
-    constrainedby Internal.FlowResistance.partialPressureLoss "Pressure loss function"
+  replaceable model pLoss = Internal.FlowResistance.pleaseSelectPressureLoss
+    constrainedby Internal.FlowResistance.partialPressureLoss "Pressure loss model"
     annotation (
       choices(
         choice(
-          redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.pleaseSelectPressureLoss
-          "No function selected"),
+          redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.pleaseSelectPressureLoss
+          "No model selected"),
         choice(
-          redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss
+          redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss
           "Linear-quadratic"),
         choice(
-          redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarPressureLoss
+          redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarPressureLoss
           "Laminar (Hagen-Poiseuille)"),
         choice(
-          redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss
+          redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss
           "Laminar-turbulent (Cheng2008)"),
         choice(
-          redeclare function pLoss =
+          redeclare model pLoss =
             ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland
           "Laminar-turbulent (Haaland1983)"),
         choice(
-          redeclare function pLoss =
+          redeclare model pLoss =
             ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss
           "Fixed pressure loss coefficient"),
         choice(
-          redeclare function pLoss =
+          redeclare model pLoss =
             ThermofluidStream.Processes.Internal.FlowResistance.referencePressureLoss
           "Use reference point (dp, m_flow, d)_ref")),
       Documentation(info="<html>
 <p>
-This function computes the pressure loss of the fluid depending on the massflow,
+This model computes the pressure loss of the fluid depending on the massflow,
 some medium properties and the geometry of the pipe.
 </p>
 </html>"));
@@ -85,12 +85,19 @@ some medium properties and the geometry of the pipe.
   final parameter SI.Area areaHydraulic= pi*D_h*D_h*1/4 "Hydraulic cross-sectional area";
   Real phi(unit = "1", min=0, max=1) "Normalized pressure for coloring the flow resistance";
 
+  pLoss pressureLoss(
+    m_flow=m_flow,
+    rho=rho_in,
+    mu=mu_in,
+    r=D_h/2,
+    l=l);
+
 protected
   Medium.Density rho_in = max(rho_min, Medium.density(inlet.state)) "Inlet density";
   Medium.DynamicViscosity mu_in = Medium.dynamicViscosity(inlet.state) "Inlet dynamic viscosity";
 
 equation
-  dp = -pLoss(m_flow, rho_in, mu_in, D_h/2, l);
+  dp = -pressureLoss.pressureLoss;
   h_out = h_in;
   Xi_out = Xi_in;
   phi = if dropOfCommons.displayColor then
@@ -153,7 +160,7 @@ equation
           textColor={0,0,0},
           textString=DynamicSelect(if true then "dp in bar" else "", "dp = " + String(-dp/1e5, significantDigits=pressureDropSignificantDigits)+ " bar"))}),  Diagram(coordinateSystem(preserveAspectRatio=true)),
     Documentation(info="<html>
-<p>Implementation of a flow resistance pipe with different selectable flow resistance functions (laminar, laminar-turbulent, linear-quadratic). </p>
+<p>Implementation of a flow resistance pipe with different selectable flow resistance models (laminar, laminar-turbulent, linear-quadratic). </p>
 <p>The pressure drop can be displayed with the coloring (<code>displayColor</code> in the <strong>DropOfCommons</strong>). The parameter <code>dp_ref_color</code> can be adjusted depending on expected pressure drop and intensity of coloring. Coloring ranges from 0 to 100 &percnt; red, with 100 &percnt; red at <code>dp = dp_ref_color</code>.</p>
 <p><code>dp_ref_color</code> needs to be defined according to the use case.</p>
 </html>"));

--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarPressureLoss.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.FlowResistance;
-function laminarPressureLoss "Laminar pressure loss function (Hagen-Poiseuille)"
+model laminarPressureLoss "Laminar pressure loss model (Hagen-Poiseuille)"
   extends Internal.FlowResistance.partialPressureLoss;
 
   import Modelica.Constants.pi;

--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLoss.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.FlowResistance;
-function laminarTurbulentPressureLoss "Pressure loss function (Cheng 2008) for laminar, transient and turbulent flow regimes"
+model laminarTurbulentPressureLoss "Pressure loss model (Cheng 2008) for laminar, transient and turbulent flow regimes"
   extends Internal.FlowResistance.partialPressureLoss;
   import Modelica.Constants.pi;
 
@@ -8,7 +8,6 @@ function laminarTurbulentPressureLoss "Pressure loss function (Cheng 2008) for l
   input ThermofluidStream.Processes.Internal.Material material=ThermofluidStream.Processes.Internal.Material.other "Material of pipe"
     annotation (Dialog(enable=true));
 
-protected
   constant SI.ReynoldsNumber R_laminar_DarcyWeisbach_min = 500 "Minimal Reynolds number to use the general equation. Laminar flow before";
   SI.Length ks "Surface roughness";
 

--- a/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/laminarTurbulentPressureLossHaaland.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.FlowResistance;
-function laminarTurbulentPressureLossHaaland "Pressure loss function (Haaland 1983) for laminar, transient and turbulent flow regimes"
+model laminarTurbulentPressureLossHaaland "Pressure loss model (Haaland 1983) for laminar, transient and turbulent flow regimes"
   extends Internal.FlowResistance.partialPressureLoss;
 
   import Modelica.Constants.pi;
@@ -17,7 +17,6 @@ function laminarTurbulentPressureLossHaaland "Pressure loss function (Haaland 19
   input ThermofluidStream.Processes.Internal.Material material = ThermofluidStream.Processes.Internal.Material.other "Material of pipe"
     annotation (Dialog(enable=true));
 
-protected
   SI.Length ks "Surface roughness";
 
   SI.Length diameter=r*2 "Diameter";

--- a/ThermofluidStream/Processes/Internal/FlowResistance/linearQuadraticPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/linearQuadraticPressureLoss.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.FlowResistance;
-function linearQuadraticPressureLoss "Linear-quadratic pressure loss function"
+model linearQuadraticPressureLoss "Linear-quadratic pressure loss model"
   extends Internal.FlowResistance.partialPressureLoss;
 
   input Real k(unit="Pa.s/kg") = 0 "Linear resistance coefficient"

--- a/ThermofluidStream/Processes/Internal/FlowResistance/partialPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/partialPressureLoss.mo
@@ -1,6 +1,5 @@
 within ThermofluidStream.Processes.Internal.FlowResistance;
-partial function partialPressureLoss "Partial pressure loss function"
-  extends Modelica.Icons.Function;
+partial model partialPressureLoss "Partial pressure loss model"
 
   input SI.MassFlowRate m_flow "Mass flow rate";
   input SI.Density rho "Density";
@@ -10,8 +9,7 @@ partial function partialPressureLoss "Partial pressure loss function"
 
   output SI.PressureDifference pressureLoss "pressure loss (dp)";
 
-  annotation(Inline=true, smoothOrder=100,
-    Documentation(info="<html>
+  annotation(Documentation(info="<html>
 <p>Interface definition for a pressure loss in a pipe. Inputs are information about flow condition and the medium as well as the geometry of the pipe, output is the pressure drop.</p>
 </html>"));
 end partialPressureLoss;

--- a/ThermofluidStream/Processes/Internal/FlowResistance/pleaseSelectPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/pleaseSelectPressureLoss.mo
@@ -1,16 +1,16 @@
 within ThermofluidStream.Processes.Internal.FlowResistance;
-function pleaseSelectPressureLoss "Please select pressure loss function"
+model pleaseSelectPressureLoss "Please select pressure loss model"
   extends Internal.FlowResistance.partialPressureLoss;
 
 algorithm
-  assert(false, "Please select pressure loss function");
+  assert(false, "Please select pressure loss model");
 
   pressureLoss :=0;
 
   annotation (Documentation(info="<html>
 <p>
-Pressure loss function without actual equations with an always failing assert to
-output a meaningful error, when the user forgot to select a function. This should
+Pressure loss model without actual equations with an always failing assert to
+output a meaningful error, when the user forgot to select a model. This should
 be used as a default.
 </p>
 </html>"));

--- a/ThermofluidStream/Processes/Internal/FlowResistance/referencePressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/referencePressureLoss.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.FlowResistance;
-function referencePressureLoss "Pressure loss function based on reference values"
+model referencePressureLoss "Pressure loss model based on reference values"
   extends Internal.FlowResistance.partialPressureLoss;
 
   input SI.Pressure dp_ref "Reference pressure loss"
@@ -24,7 +24,7 @@ algorithm
 
   annotation (Documentation(info="<html>
 <p>
-This function calculates the pressure drop according a reference pressure
+This model calculates the pressure drop according a reference pressure
 drop at a reference mass flow rate and reference density.
 </p>
 <blockquote><pre>

--- a/ThermofluidStream/Processes/Internal/FlowResistance/zetaPressureLoss.mo
+++ b/ThermofluidStream/Processes/Internal/FlowResistance/zetaPressureLoss.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.FlowResistance;
-function zetaPressureLoss "Pressure loss coefficient function"
+model zetaPressureLoss "Pressure loss coefficient model"
   extends Internal.FlowResistance.partialPressureLoss;
 
   input Real zeta( unit = "1") "Pressure loss coefficient (dp = zeta*rho/2*v^2)"
@@ -10,7 +10,6 @@ function zetaPressureLoss "Pressure loss coefficient function"
   input SI.Area A = Modelica.Constants.pi*r*r "Cross-sectional area"
     annotation(Dialog(group="Cross-sectional area", enable = not fromGeometry));
 
-protected
   SI.Area A_zeta "Cross-sectional area";
 
 algorithm

--- a/ThermofluidStream/Processes/Internal/PartialTurboComponent.mo
+++ b/ThermofluidStream/Processes/Internal/PartialTurboComponent.mo
@@ -43,12 +43,21 @@ partial model PartialTurboComponent "Partial model of turbo component"
   Modelica.Blocks.Interfaces.RealOutput output_val(unit=Sensors.Internal.getFlowUnit(outputQuantity)) = getQuantity(inlet.state, m_flow, outputQuantity, rho_min) if enableOutput "Quantity output connector"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=270,origin={60,-110})));
 
-  replaceable function dp_tau = TurboComponent.pleaseSelect_dp_tau
+  replaceable model dp_tau = TurboComponent.pleaseSelect_dp_tau
     constrainedby TurboComponent.partial_dp_tau(redeclare package Medium=Medium)  "Component characteristic curve"
       annotation(choicesAllMatching=true,
         Documentation(info="<html>
-<p>This functions computes the pressure difference over the component, as well as the moment that leads to stationary operation in the current state. </p>
+<p>This model computes the pressure difference over the component, as well as the moment that leads to stationary operation in the current state. </p>
 </html>"));
+
+  dp_tau characteristic(
+    redeclare package Medium=Medium,
+    m_flow=m_flow,
+    omega=omega,
+    state_in=inlet.state,
+    m_flow_norm=m_flow_reg,
+    omega_norm=omega_reg,
+    rho_min=rho_min);
 
 function getQuantity = Sensors.Internal.getFlowQuantity (
   redeclare package Medium = Medium) "Function to compute a selectable quantity"
@@ -89,7 +98,7 @@ initial equation
 
 equation
   // Compute pressure difference dp, and steady-state torque tau_st
-  (dp, tau_st) = dp_tau(m_flow, omega, inlet.state, m_flow_reg, omega_reg, rho_min);
+  dp = characteristic.dp; tau_st = characteristic.tau_st;
   h_out = h_in + dh;
   Xi_out = Xi_in;
 

--- a/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_centrifugal.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_centrifugal.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.TurboComponent;
-function dp_tau_centrifugal "Model of a centrifugal pump"
+model dp_tau_centrifugal "Model of a centrifugal pump"
 
 
   extends partial_dp_tau;
@@ -41,7 +41,6 @@ function dp_tau_centrifugal "Model of a centrifugal pump"
   input Real Re_mod_min(unit="1") = 1e2 "Minimum modified Reynolds number"
     annotation(Dialog(tab="Advanced", enable=true));
   input String name = getInstanceName() "Hack to access the instance name";
-protected
   Real alpha(unit="1") = TDH_D/TDH_D_ref "Pressure scaling factor";
   Real beta(unit="1") = omega_D/omega_D_ref "Speed scaling factor";
   Real gamma(unit="1") = V_flow_D/V_flow_D_ref "Flow scaling factor";
@@ -51,7 +50,6 @@ protected
   SI.KinematicViscosity nu_in = mu_in* ( if useLegacyReynolds then 1 else v_in) "Inlet kinematic viscosity";
   SI.SpecificVolume v_ref = 1/rho_ref "Reference specific volume";
 
-  SI.Power W_t "Power (technical work flow rate)";
   SI.Length TDH "Total dynamic head";
   SI.VolumeFlowRate V_flow "Volume flow rate";
 

--- a/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_const_isentrop.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_const_isentrop.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.TurboComponent;
-function dp_tau_const_isentrop "Compressor model with parameter characteristic curve and constant isentropic efficiency"
+model dp_tau_const_isentrop "Compressor model with parameter characteristic curve and constant isentropic efficiency"
   extends partial_dp_tau;
 
   import R_m = Modelica.Constants.R "General gas constant";
@@ -22,7 +22,6 @@ function dp_tau_const_isentrop "Compressor model with parameter characteristic c
     annotation(Dialog(group = "Isentropic exponent", enable = not kappaFromMedia));
 
 
-protected
   Medium.AbsolutePressure p_in = Medium.pressure(state_in) "Inlet pressure";
   SI.Temperature T_in = Medium.temperature(state_in) "Inlet temperature";
   Real kappa(unit="1") = if kappaFromMedia then Medium.isentropicExponent(state_in) else kappa_fixed "Inlet isentropic coefficient";

--- a/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_nominal_flow.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/dp_tau_nominal_flow.mo
@@ -1,5 +1,5 @@
 within ThermofluidStream.Processes.Internal.TurboComponent;
-function dp_tau_nominal_flow "Pump model with the nominal massflow model"
+model dp_tau_nominal_flow "Pump model with the nominal massflow model"
   extends partial_dp_tau;
 
   input Boolean parametrizeByDesignPoint= false "= true, if pump characteristic curve is computed from one design point"
@@ -22,7 +22,6 @@ function dp_tau_nominal_flow "Pump model with the nominal massflow model"
   input Real k_fric_input(unit="N.s/(m2)") = 1e-2 "Linear friction factor"
     annotation(Dialog(group="Direct Parameters", enable=not parametrizeByDesignPoint));
 
-protected
   SI.SpecificVolume v_in = 1/max(rho_min, Medium.density(state_in)) "Inlet specific volume";
 
   SI.VolumeFlowRate V_flow_nominal "Nominal volume flow rate";

--- a/ThermofluidStream/Processes/Internal/TurboComponent/partial_dp_tau.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/partial_dp_tau.mo
@@ -1,7 +1,6 @@
 within ThermofluidStream.Processes.Internal.TurboComponent;
-partial function partial_dp_tau "Compute dp and tau_st of a TurboComponent from the current state"
+partial model partial_dp_tau "Compute dp and tau_st of a TurboComponent from the current state"
 
-  extends Modelica.Icons.Function;
 
   replaceable package Medium = Media.myMedia.Interfaces.PartialMedium "Medium model"
     annotation(choicesAllMatching=true, Documentation(info="<html>
@@ -19,8 +18,8 @@ Medium model needet to compute properties from the inlet_state.
   output SI.Pressure dp "Pressure difference";
   output SI.Torque tau_st "Steady state torque";
 
-  annotation(Inline=true, Documentation(info="<html>
-<p>This function computes the pressure differential and the moment needed for static operation of a partialTurboComponent in its current state. </p>
-<p>By changing this function the partialTurboComponent implements different kinds of turbo components like fans, pumps, compressors, turbines, etc.</p>
+  annotation(Documentation(info="<html>
+<p>This model computes the pressure differential and the moment needed for static operation of a partialTurboComponent in its current state. </p>
+<p>By changing this model the partialTurboComponent implements different kinds of turbo components like fans, pumps, compressors, turbines, etc.</p>
 </html>"));
 end partial_dp_tau;

--- a/ThermofluidStream/Processes/Internal/TurboComponent/pleaseSelect_dp_tau.mo
+++ b/ThermofluidStream/Processes/Internal/TurboComponent/pleaseSelect_dp_tau.mo
@@ -1,14 +1,14 @@
 within ThermofluidStream.Processes.Internal.TurboComponent;
-function pleaseSelect_dp_tau "Please select dp_tau function"
+model pleaseSelect_dp_tau "Please select dp_tau model"
   extends partial_dp_tau;
 
 algorithm
-  assert(false, "please select dp_tau function");
+  assert(false, "please select dp_tau model");
 
   dp := 0;
   tau_st := 0;
 
   annotation (Documentation(info="<html>
-<p>dp-tau function without actual equations with an always failing assert to output a meaningful error, when the user forgot to select a function. This should be used as a default. </p>
+<p>dp-tau model without actual equations with an always failing assert to output a meaningful error, when the user forgot to select a model. This should be used as a default. </p>
 </html>"));
 end pleaseSelect_dp_tau;

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_Junction.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_Junction.mo
@@ -27,7 +27,7 @@ model Test_Junction
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=dropOfCommons.m_flow_reg,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     l=1,
     r=1e-2) annotation (Placement(transformation(extent={{20,-10},{40,10}})));
@@ -35,7 +35,7 @@ model Test_Junction
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=0,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     l=1,
     r=1e-2) annotation (Placement(transformation(extent={{-44,20},{-24,40}})));
 equation

--- a/ThermofluidStream/Processes/Pipes/Tests/Test_SplitterY.mo
+++ b/ThermofluidStream/Processes/Pipes/Tests/Test_SplitterY.mo
@@ -26,7 +26,7 @@ model Test_SplitterY
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=0,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     l=1,
     r=1e-2) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
@@ -34,7 +34,7 @@ model Test_SplitterY
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=0,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     l=1,
     r=1e-2) annotation (Placement(transformation(extent={{20,20},{40,40}})));
 equation

--- a/ThermofluidStream/Processes/Pump.mo
+++ b/ThermofluidStream/Processes/Pump.mo
@@ -1,23 +1,23 @@
 within ThermofluidStream.Processes;
 model Pump "A simple pump model"
 
-  extends Internal.PartialTurboComponent(redeclare function dp_tau =
+  extends Internal.PartialTurboComponent(redeclare model dp_tau =
         dp_tau_pump);
 
   parameter Real max_rel_volume(min=0, max=1, unit="1") = 0.05 "Maximum relative volume change (checking incompressibility approach)"
     annotation(Dialog(tab="Advanced"));
 
-  replaceable function dp_tau_pump =
+  replaceable model dp_tau_pump =
       Internal.TurboComponent.pleaseSelect_dp_tau
     constrainedby Internal.TurboComponent.partial_dp_tau(
       redeclare package Medium = Medium) "Pump characteristic curve"
     annotation(choices(
-       choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select function",
+       choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select model",
        choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal "Centrifugal Pump",
        choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_nominal_flow "Nominal Flow Pump"),
     Documentation(info="<html>
 <p>
-Selectable function to choose between different pump models.
+Selectable model to choose between different pump models.
 </p>
 </html>"));
 
@@ -45,7 +45,7 @@ equation
 <p>It can be chosen between</p>
 <ul>
 <li>Nominal-flow pump, where a nominal flow is computed and the difference between it and the actual flow is linearly producing a pressure</li>
-<li>Centrifugal pump, which implements the equations of a scalable centrifugal pump. Please note that the function uses by default a legacy 
+<li>Centrifugal pump, which implements the equations of a scalable centrifugal pump. Please note that the model uses by default a legacy
 implementation to ensure backward compatibility. The legacy formulation is retained to support existing models but is considered deprecated and 
 its use will trigger a warning at runtime. Users are strongly encouraged to migrate to the updated implementation, as the legacy version will be removed in the next major release.
 Please see <a href=\"modelica://ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal\">dp_tau_centrifugal</a> documentation for more information</li>

--- a/ThermofluidStream/Processes/Tests/CentrifugalPump.mo
+++ b/ThermofluidStream/Processes/Tests/CentrifugalPump.mo
@@ -33,7 +33,7 @@ extends Modelica.Icons.Example;
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.02,
     l=100,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{70,30},{90,50}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm multiSensor_Tpm1(
     displayInstanceName=false,
@@ -132,7 +132,7 @@ extends Modelica.Icons.Example;
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e5))
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e5))
     annotation (Placement(transformation(extent={{130,-52},{150,-32}})));
   Modelica.Blocks.Sources.Sine w_sine(
     amplitude=Modelica.Units.Conversions.from_rpm(400),

--- a/ThermofluidStream/Processes/Tests/Compressor.mo
+++ b/ThermofluidStream/Processes/Tests/Compressor.mo
@@ -35,7 +35,7 @@ Medium model for the test. Should be an ideal gas or close to that.
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=-1,
-    redeclare function dp_tau_compressor = tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+    redeclare model dp_tau_compressor = tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
       omega_ref=3000,
       skew=1,
       m_flow_ref=1))
@@ -51,7 +51,7 @@ Medium model for the test. Should be an ideal gas or close to that.
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     omega_0=-150,
     initPhi=true,
-    redeclare function dp_tau_compressor =
+    redeclare model dp_tau_compressor =
         tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
   omega_ref=500,
         skew=1,

--- a/ThermofluidStream/Processes/Tests/ConductionElement.mo
+++ b/ThermofluidStream/Processes/Tests/ConductionElement.mo
@@ -119,7 +119,7 @@ meant for liquids with low compressablility.
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.003,
     l=10,
-    redeclare function pLoss =
+    redeclare model pLoss =
         Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{20,-100},{40,-80}})));
 equation

--- a/ThermofluidStream/Processes/Tests/ConductionElementVariable.mo
+++ b/ThermofluidStream/Processes/Tests/ConductionElementVariable.mo
@@ -20,7 +20,7 @@ the inlet the source is connected to.
   Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
          annotation (Placement(transformation(extent={{-200,40},{-180,60}})));
@@ -41,7 +41,7 @@ the inlet the source is connected to.
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
          annotation (Placement(transformation(extent={{-200,-60},{-180,-40}})));
@@ -57,7 +57,7 @@ the inlet the source is connected to.
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
          annotation (Placement(transformation(extent={{-20,40},{0,60}})));
@@ -77,7 +77,7 @@ the inlet the source is connected to.
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
          annotation (Placement(transformation(extent={{-20,-40},{0,-60}})));
@@ -98,7 +98,7 @@ the inlet the source is connected to.
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=0, k2=1e5) "Linear-quadratic",
     l=10,
     r=0.01)
          annotation (Placement(transformation(extent={{160,40},{180,60}})));

--- a/ThermofluidStream/Processes/Tests/ConvectivePipe.mo
+++ b/ThermofluidStream/Processes/Tests/ConvectivePipe.mo
@@ -30,7 +30,7 @@ model ConvectivePipe
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
   Modelica.Thermal.HeatTransfer.Components.HeatCapacitor heatCapacitor(C=0.0001, T(fixed=true))

--- a/ThermofluidStream/Processes/Tests/ConvectivePipe_serial.mo
+++ b/ThermofluidStream/Processes/Tests/ConvectivePipe_serial.mo
@@ -30,7 +30,7 @@ replaceable package Medium = Media.myMedia.Water.ConstantPropertyLiquidWater
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{-84,-10},{-64,10}})));
   Modelica.Thermal.HeatTransfer.Components.HeatCapacitor heatCapacitor(C=100, T(fixed=true))

--- a/ThermofluidStream/Processes/Tests/Flow_Resistance.mo
+++ b/ThermofluidStream/Processes/Tests/Flow_Resistance.mo
@@ -29,7 +29,7 @@ Medium model for the test. Can be anything.
     computeL=true,
     r=0.1,
     l=100,
-    redeclare function pLoss = tf.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = tf.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1000,
       k2=100))
     annotation (Placement(transformation(extent={{-10,20},{10,40}})));
@@ -42,7 +42,7 @@ Medium model for the test. Can be anything.
     L_value=1000,
     r=0.02,
     l=100,
-    redeclare function pLoss =
+    redeclare model pLoss =
         tf.Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 
@@ -54,7 +54,7 @@ Medium model for the test. Can be anything.
     L_value=30000,
     r=0.075,
     l=10,
-    redeclare function pLoss = tf.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = tf.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
 
@@ -71,7 +71,7 @@ Medium model for the test. Can be anything.
     L_value=30000,
     r=0.075,
     l=10,
-    redeclare function pLoss =
+    redeclare model pLoss =
         tf.Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));

--- a/ThermofluidStream/Processes/Tests/Nozzle.mo
+++ b/ThermofluidStream/Processes/Tests/Nozzle.mo
@@ -20,7 +20,7 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.01,
     l=10,
-    redeclare function pLoss = Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-30,10},{-10,30}})));
   Boundaries.Source source(redeclare package Medium = Medium, p0_par=110000)
@@ -36,7 +36,7 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.01,
     l=10,
-    redeclare function pLoss =
+    redeclare model pLoss =
       Internal.FlowResistance.laminarTurbulentPressureLoss (
         material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-30,-30},{-10,-10}})));

--- a/ThermofluidStream/Processes/Tests/Pump.mo
+++ b/ThermofluidStream/Processes/Tests/Pump.mo
@@ -34,7 +34,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
+    redeclare model dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
     annotation (Placement(transformation(extent={{-10,40},{10,20}})));
 
   Modelica.Blocks.Sources.Constant pump_speed_rad_s(k=800)
@@ -46,7 +46,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     initPhi=true,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
+    redeclare model dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   tf.Processes.Tests.Power powerSource1(P=8000, tau_max=150)
     annotation (Placement(transformation(extent={{-40,-30},{-20,-10}})));
@@ -62,7 +62,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     enableAccessHeatPort=true,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
+    redeclare model dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
           =false, k_p_input=1e7)) annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
   Modelica.Blocks.Sources.Constant pump2_speed_rad_s(k=3200)
     annotation (Placement(transformation(extent={{40,-70},{20,-50}})));
@@ -77,7 +77,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     initPhi=true,
     phi_0=-1745.3292519943,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (
+    redeclare model dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (
         parametrizeByDesignPoint=false,
         V_r_input=0.0006,
         k_p_input=1e8)) annotation (Placement(transformation(extent={{-10,-100},{10,-80}})));
@@ -95,7 +95,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     J_p=10,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     phi_0=-1745.3292519943,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
+    redeclare model dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
           =true, omega_D(displayUnit="rad/s") = 100))
     "Design point: V_flow=100L/min at 100rad/s with a pressure increase of 5 bar"
     annotation (Placement(transformation(extent={{-10,90},{10,70}})));

--- a/ThermofluidStream/Processes/Tests/Pump_dp_tau_centrifugal_Characteristics.mo
+++ b/ThermofluidStream/Processes/Tests/Pump_dp_tau_centrifugal_Characteristics.mo
@@ -42,7 +42,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
         useLegacyReynolds=false,
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
@@ -76,7 +76,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
         omega_D=omega_D)) annotation (Placement(transformation(extent={{-70,-30},{-50,-50}})));

--- a/ThermofluidStream/Processes/Tests/Pump_dp_tau_centrifugal_DesignPoint.mo
+++ b/ThermofluidStream/Processes/Tests/Pump_dp_tau_centrifugal_DesignPoint.mo
@@ -42,7 +42,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (
         useLegacyReynolds=false,
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
@@ -76,7 +76,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         useLegacyReynolds=false,
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
@@ -109,7 +109,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
         omega_D=omega_D)) annotation (Placement(transformation(extent={{-240,-20},{-220,-40}})));
@@ -139,7 +139,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
         omega_D=omega_D)) annotation (Placement(transformation(extent={{0,-40},{20,-20}})));
@@ -172,7 +172,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         useLegacyReynolds=false,
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
@@ -192,7 +192,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
+    redeclare model dp_tau_pump = Internal.TurboComponent.dp_tau_centrifugal (
         TDH_D=TDH_D,
         V_flow_D=V_flow_D,
         omega_D=omega_D)) annotation (Placement(transformation(extent={{250,-20},{270,-40}})));

--- a/ThermofluidStream/Processes/Tests/TransportDelay.mo
+++ b/ThermofluidStream/Processes/Tests/TransportDelay.mo
@@ -20,7 +20,7 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=100,
     l(displayUnit="mm") = 0.008,
-    redeclare function pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{-10,30},{10,50}})));
   Boundaries.Sink sink(redeclare package Medium = Medium, p0_par=100000)
@@ -57,7 +57,7 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=100,
     l(displayUnit="mm") = 0.008,
-    redeclare function pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
   Boundaries.Sink sink1(redeclare package Medium = Medium, p0_par=100000)

--- a/ThermofluidStream/Processes/Tests/Turbine.mo
+++ b/ThermofluidStream/Processes/Tests/Turbine.mo
@@ -34,7 +34,7 @@ Medium model for the test. Should be an ideal gas or close to that.
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=1e-5,
-    redeclare function dp_tau_turbine =
+    redeclare model dp_tau_turbine =
         tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=1e6))
     annotation (Placement(transformation(extent={{-6,10},{14,30}})));
   Modelica.Blocks.Sources.Constant const(k=1000)
@@ -52,7 +52,7 @@ Medium model for the test. Should be an ideal gas or close to that.
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     omega_0=-1,
     initPhi=true,
-    redeclare function dp_tau_turbine =
+    redeclare model dp_tau_turbine =
         tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=1e6, eta=1))
     annotation (Placement(transformation(extent={{-8,-38},{12,-18}})));
   Modelica.Mechanics.Rotational.Sources.LinearSpeedDependentTorque

--- a/ThermofluidStream/Processes/Turbine.mo
+++ b/ThermofluidStream/Processes/Turbine.mo
@@ -1,18 +1,18 @@
 within ThermofluidStream.Processes;
 model Turbine "Turbine using ideal gas assumptions"
-  extends Internal.PartialTurboComponent(redeclare function dp_tau =
+  extends Internal.PartialTurboComponent(redeclare model dp_tau =
         dp_tau_turbine);
 
-  replaceable function dp_tau_turbine =
+  replaceable model dp_tau_turbine =
       Internal.TurboComponent.pleaseSelect_dp_tau
     constrainedby Internal.TurboComponent.partial_dp_tau(
       redeclare package Medium = Medium) "Turbine characteristic curve"
     annotation(choices(
-        choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select function",
+        choice=ThermofluidStream.Processes.Internal.TurboComponent.pleaseSelect_dp_tau "Please select model",
         choice=ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop(omega_ref=1e6) "Fixed isentropic efficiency"),
       Documentation(info="<html>
 <p>
-Selectable function to choose between different turbine models.
+Selectable model to choose between different turbine models.
 </p>
 </html>"));
 

--- a/ThermofluidStream/Sensors/Tests/TestSensors.mo
+++ b/ThermofluidStream/Sensors/Tests/TestSensors.mo
@@ -40,7 +40,7 @@ model TestSensors "Test model for all sensors."
     l=2,
     L_value=1000,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.galvanizedIron))
     annotation (Placement(transformation(extent={{-10,64},{10,84}})));
   Processes.FlowResistance flowResistance1(
@@ -51,7 +51,7 @@ model TestSensors "Test model for all sensors."
     l=2,
     L_value=100000,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.galvanizedIron))
     annotation (Placement(transformation(extent={{-40,-24},{-20,-4}})));
   SingleSensorSelect singleSensorSelect(redeclare package Medium = Medium1,
@@ -293,7 +293,7 @@ model TestSensors "Test model for all sensors."
     l=2,
     L_value=100000,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.galvanizedIron))
     annotation (Placement(transformation(extent={{50,-110},{70,-90}})));
   Boundaries.Sink sink2(redeclare package Medium = Medium3)

--- a/ThermofluidStream/Topology/Tests/TestDynamicTopology.mo
+++ b/ThermofluidStream/Topology/Tests/TestDynamicTopology.mo
@@ -35,32 +35,32 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,60},{-20,80}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,20},{-20,40}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,40},{40,60}})));
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,40},{40,60}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,10},{40,30}})));
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,10},{40,30}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,70},{40,90}})));
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,70},{40,90}})));
   Boundaries.DynamicPressureInflow dynamicPressureInflow(
     redeclare package Medium = Medium,
     A_par(displayUnit="cm2") = 0.0001,
@@ -105,34 +105,34 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
   Processes.FlowResistance flowResistance6(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,-80},{-20,-60}})));
   Processes.FlowResistance flowResistance7(
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{20,-60},{40,-40}})));
   Processes.FlowResistance flowResistance8(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{20,-90},{40,-70}})));
   Processes.FlowResistance flowResistance9(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{20,-30},{40,-10}})));
   Boundaries.DynamicPressureInflow dynamicPressureInflow2(
     redeclare package Medium = Medium,

--- a/ThermofluidStream/Topology/Tests/TestJunctionNM.mo
+++ b/ThermofluidStream/Topology/Tests/TestJunctionNM.mo
@@ -34,32 +34,32 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,60},{-20,80}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,20},{-20,40}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,40},{40,60}})));
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,40},{40,60}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,10},{40,30}})));
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,10},{40,30}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,70},{40,90}})));
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss) annotation (Placement(transformation(extent={{20,70},{40,90}})));
   JunctionNM junctionNM1(
     redeclare package Medium = Medium,
     N=2,
@@ -81,34 +81,34 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
   Processes.FlowResistance flowResistance6(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-40,-80},{-20,-60}})));
   Processes.FlowResistance flowResistance7(
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{20,-60},{40,-40}})));
   Processes.FlowResistance flowResistance8(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{20,-90},{40,-70}})));
   Processes.FlowResistance flowResistance9(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r(displayUnit="mm") = 0.005,
     l=10,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
+    redeclare model pLoss = Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{20,-30},{40,-10}})));
   inner DropOfCommons dropOfCommons annotation (
     Placement(visible = true, transformation(origin = {-2, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/ThermofluidStream/Topology/Tests/TestNonPhysical.mo
+++ b/ThermofluidStream/Topology/Tests/TestNonPhysical.mo
@@ -58,7 +58,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{-100,50},{-80,70}})));
@@ -67,7 +67,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
       Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
@@ -77,7 +77,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
       Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
@@ -86,7 +86,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
       Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
@@ -142,7 +142,7 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{150,-80},{170,-60}})));
   Processes.Pump pump(redeclare package Medium = Medium,
     omega_from_input=true,
-    redeclare function dp_tau_pump =
+    redeclare model dp_tau_pump =
         Processes.Internal.TurboComponent.dp_tau_nominal_flow (
         parametrizeByDesignPoint=true,
         dp_D=1000,
@@ -150,19 +150,19 @@ model TestNonPhysical
     annotation (Placement(transformation(extent={{70,50},{90,70}})));
   Processes.Pump pump2(redeclare package Medium = Medium,
     omega_from_input=true,
-    redeclare function dp_tau_pump =
+    redeclare model dp_tau_pump =
         Processes.Internal.TurboComponent.dp_tau_nominal_flow (
           parametrizeByDesignPoint=true, dp_D=1000))
     annotation (Placement(transformation(extent={{70,0},{90,20}})));
   Processes.Pump pump3(redeclare package Medium = Medium,
     omega_from_input=true,
-    redeclare function dp_tau_pump =
+    redeclare model dp_tau_pump =
         Processes.Internal.TurboComponent.dp_tau_nominal_flow (
           parametrizeByDesignPoint=true, dp_D=1000))
     annotation (Placement(transformation(extent={{70,-50},{90,-30}})));
   Processes.Pump pump1(redeclare package Medium = Medium,
     omega_from_input=true,
-    redeclare function dp_tau_pump =
+    redeclare model dp_tau_pump =
         Processes.Internal.TurboComponent.dp_tau_nominal_flow (
           parametrizeByDesignPoint=true, dp_D=1000))
     annotation (Placement(transformation(extent={{70,-100},{90,-80}})));
@@ -178,7 +178,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{-50,70},{-30,90}})));
@@ -188,7 +188,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
@@ -198,7 +198,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{-50,-30},{-30,-10}})));
@@ -208,7 +208,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{-50,-80},{-30,-60}})));
@@ -218,7 +218,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{120,70},{140,90}})));
@@ -228,7 +228,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{120,20},{140,40}})));
@@ -238,7 +238,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{120,-30},{140,-10}})));
@@ -248,7 +248,7 @@ model TestNonPhysical
     r(displayUnit="mm") = 0.01,
     l=1,
     computeL=false,
-    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=100))
     annotation (Placement(transformation(extent={{120,-80},{140,-60}})));

--- a/ThermofluidStream/Undirected/Boundaries/Tests/PhaseSeperator.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/PhaseSeperator.mo
@@ -49,7 +49,7 @@ model PhaseSeperator
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=5000))
     annotation (Placement(transformation(extent={{-60,10},{-40,30}})));
   Processes.FlowResistance flowResistance2(
@@ -58,7 +58,7 @@ model PhaseSeperator
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=5000))
     annotation (Placement(transformation(extent={{-70,-30},{-50,-10}})));
   Processes.FlowResistance flowResistance(
@@ -67,7 +67,7 @@ model PhaseSeperator
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=5000))
     annotation (Placement(transformation(extent={{60,10},{80,30}})));
   Processes.FlowResistance flowResistance3(
@@ -76,7 +76,7 @@ model PhaseSeperator
     r(displayUnit="cm") = 0.05,
     l=1,
     computeL=false,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=5000))
     annotation (Placement(transformation(extent={{72,-30},{92,-10}})));
   ThermofluidStream.Sensors.TwoPhaseSensorSelect twoPhaseSensorSelect4(

--- a/ThermofluidStream/Undirected/Boundaries/Tests/Reservoir.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/Reservoir.mo
@@ -29,7 +29,7 @@ model Reservoir "Test for Reservoir"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
          k=100))
     annotation (Placement(transformation(extent={{-30,-80},{-10,-60}})));
@@ -38,7 +38,7 @@ model Reservoir "Test for Reservoir"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
          k=100))
     annotation (Placement(transformation(extent={{30,-80},{50,-60}})));
@@ -66,7 +66,7 @@ model Reservoir "Test for Reservoir"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
          k=100))
     annotation (Placement(transformation(extent={{-32,20},{-12,40}})));
@@ -75,7 +75,7 @@ model Reservoir "Test for Reservoir"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
          k=100))
     annotation (Placement(transformation(extent={{30,20},{50,40}})));

--- a/ThermofluidStream/Undirected/Boundaries/Tests/Tank_fillingClosedTank.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/Tank_fillingClosedTank.mo
@@ -40,7 +40,7 @@ model Tank_fillingClosedTank
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=false,
@@ -72,7 +72,7 @@ model Tank_fillingClosedTank
   Processes.FlowResistance flowResistance3(redeclare package Medium = Medium,
     r=0.03,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1))
     annotation (Placement(transformation(extent={{34,-10},{54,10}})));

--- a/ThermofluidStream/Undirected/Boundaries/Tests/Tank_overfilling.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/Tank_overfilling.mo
@@ -22,7 +22,7 @@ extends Modelica.Icons.Example;
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=true,
@@ -34,7 +34,7 @@ extends Modelica.Icons.Example;
     l=1,
     shape=ThermofluidStream.Processes.Internal.ShapeOfResistance.circular,
     r=0.03,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
         zeta=1,
         fromGeometry=true,
@@ -89,7 +89,7 @@ extends Modelica.Icons.Example;
     redeclare package Medium = Medium,
     r=0.03/1.4,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1))
     annotation (Placement(transformation(extent={{-46,-24},{-66,-4}})));

--- a/ThermofluidStream/Undirected/Boundaries/Tests/Tank_selfDraining.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/Tank_selfDraining.mo
@@ -38,7 +38,7 @@ model Tank_selfDraining
   Processes.FlowResistance flowResistance3(redeclare package Medium = Medium,
     r=0.03,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1))
     annotation (Placement(transformation(extent={{-56,10},{-36,30}})));
@@ -51,7 +51,7 @@ model Tank_selfDraining
     redeclare package Medium = Medium,
     r=0.03,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1))
     annotation (Placement(transformation(extent={{-52,-22},{-32,-2}})));
@@ -59,7 +59,7 @@ model Tank_selfDraining
     redeclare package Medium = Medium,
     r=0.03,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1))
     annotation (Placement(transformation(extent={{30,-54},{50,-34}})));
@@ -67,7 +67,7 @@ model Tank_selfDraining
     redeclare package Medium = Medium,
     r=0.03,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1))
     annotation (Placement(transformation(extent={{26,-34},{46,-14}})));

--- a/ThermofluidStream/Undirected/Boundaries/Tests/Tank_upsideDownBottle.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/Tank_upsideDownBottle.mo
@@ -54,7 +54,7 @@ model Tank_upsideDownBottle
   redeclare package Medium = Medium,
     r=0.03,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1))
     annotation (Placement(transformation(extent={{0,-80},{-20,-60}})));
@@ -62,7 +62,7 @@ model Tank_upsideDownBottle
   redeclare package Medium = Medium,
     r=0.01,
     l=0.02,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (
           zeta=1)) annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},

--- a/ThermofluidStream/Undirected/Boundaries/Tests/TestVolumes.mo
+++ b/ThermofluidStream/Undirected/Boundaries/Tests/TestVolumes.mo
@@ -46,7 +46,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-80,-60},{-60,-40}})));
   Processes.FlowResistance flowResistance1(
@@ -54,7 +54,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-140,-60},{-120,-40}})));
   ThermofluidStream.Boundaries.Source
@@ -103,7 +103,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-80,30},{-60,50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance3(
@@ -111,7 +111,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-140,30},{-120,50}})));
   BoundaryFore boundary_fore(redeclare package Medium = Medium, p0_par=100000) annotation (Placement(transformation(extent={{-44,-60},{-24,-40}})));
@@ -145,7 +145,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(extent={{46,60},{66,80}})));
   ThermofluidStream.Processes.FlowResistance flowResistance6(
@@ -153,7 +153,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=2e5))
     annotation (Placement(transformation(extent={{46,20},{66,40}})));
   VolumeMix volumeMix2(
@@ -178,7 +178,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e5))
     annotation (Placement(transformation(extent={{46,-30},{66,-10}})));
   Processes.FlowResistance flowResistance7(
@@ -186,7 +186,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=2e5))
     annotation (Placement(transformation(extent={{46,-70},{66,-50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance8(
@@ -194,7 +194,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{116,40},{136,60}})));
   Processes.FlowResistance flowResistance9(
@@ -202,7 +202,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{120,-80},{100,-60}})));
   Volume heatportVolume2(
@@ -220,7 +220,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{-80,-120},{-60,-100}})));
   BoundaryFore boundary_fore2(redeclare package Medium = Medium, p0_par=100000) annotation (Placement(transformation(extent={{-44,-120},{-24,-100}})));
@@ -229,7 +229,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=10,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.wood))
     annotation (Placement(transformation(extent={{40,-120},{60,-100}})));
   BoundaryRear boundary_rear5(redeclare package Medium = Medium, p0_par=200000) annotation (Placement(transformation(extent={{10,-120},{30,-100}})));

--- a/ThermofluidStream/Undirected/FlowControl/Tests/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/BasicControlValve.mo
@@ -31,7 +31,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-80,50},{-60,70}})));
   Boundaries.BoundaryFore boundary_fore1(redeclare package Medium = Medium, p0_par=100000)
@@ -101,35 +101,35 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{60,50},{80,70}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{60,-10},{80,10}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
   Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-80,-70},{-60,-50}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{60,-70},{80,-50}})));
 equation

--- a/ThermofluidStream/Undirected/FlowControl/Tests/CheckValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/CheckValve.mo
@@ -31,7 +31,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.1,
     l=10,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{14,-10},{34,10}})));
 equation

--- a/ThermofluidStream/Undirected/FlowControl/Tests/MCV.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/MCV.mo
@@ -198,7 +198,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{28,70},{48,90}})));
   Processes.FlowResistance flowResistance(
@@ -207,7 +207,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{30,30},{50,50}})));
   Processes.FlowResistance flowResistance1(
@@ -216,7 +216,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{28,0},{48,20}})));
   Processes.FlowResistance flowResistance2(
@@ -225,7 +225,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=180,
@@ -236,7 +236,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=180,
@@ -247,7 +247,7 @@ Medium package used in the Test.
     l=10,
     L_value=0.01,
     computeL=false,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=180,

--- a/ThermofluidStream/Undirected/FlowControl/Tests/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/SpecificValveType.mo
@@ -30,7 +30,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-80,50},{-60,70}})));
   Boundaries.BoundaryFore boundary_fore1(redeclare package Medium = Medium, p0_par=100000)
@@ -76,21 +76,21 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{60,50},{80,70}})));
   Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{60,-10},{80,10}})));
   Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e3))
     annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
   Modelica.Blocks.Sources.Pulse pulse(

--- a/ThermofluidStream/Undirected/FlowControl/Tests/TanValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/TanValve.mo
@@ -25,7 +25,7 @@ Medium package used in the Test.
     redeclare package Medium = Medium,
     r=0.05,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
       ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
         material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
@@ -57,7 +57,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss =ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss =ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{70,26},{90,46}})));
   Processes.FlowResistance flowResistance2(
@@ -65,7 +65,7 @@ Medium package used in the Test.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{70,-10},{90,10}})));
   Modelica.Blocks.Sources.Pulse pulse(

--- a/ThermofluidStream/Undirected/HeatExchangers/DiscretizedCrossFlowHEX.mo
+++ b/ThermofluidStream/Undirected/HeatExchangers/DiscretizedCrossFlowHEX.mo
@@ -7,7 +7,7 @@ model DiscretizedCrossFlowHEX "Discretized heat exchanger for single- or two-pha
     redeclare package Medium = MediumA,
     each r(each displayUnit="mm") = 0.025,
     each l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (each k=50)) annotation (Placement(transformation(extent={{-20,-70},{-40,-50}})));
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (each k=50)) annotation (Placement(transformation(extent={{-20,-70},{-40,-50}})));
   Topology.JunctionMN junctionMN(
     redeclare package Medium = MediumA,
     N=1,

--- a/ThermofluidStream/Undirected/HeatExchangers/Tests/ConductionElementTwoPhase.mo
+++ b/ThermofluidStream/Undirected/HeatExchangers/Tests/ConductionElementTwoPhase.mo
@@ -28,7 +28,7 @@ model ConductionElementTwoPhase
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-44,-10},{-24,10}})));
   Sensors.MultiSensor_Tpm multiSensor_Tpm(

--- a/ThermofluidStream/Undirected/HeatExchangers/Tests/TestDiscretizedHEX.mo
+++ b/ThermofluidStream/Undirected/HeatExchangers/Tests/TestDiscretizedHEX.mo
@@ -54,7 +54,7 @@ model TestDiscretizedHEX
     m_flow_0=1,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-62,12},{-42,32}})));
   inner DropOfCommons dropOfCommons annotation (Placement(transformation(extent={{74,74},{94,94}})));
@@ -82,7 +82,7 @@ model TestDiscretizedHEX
     m_flow_0=0.3,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-42,-20},{-62,0}})));
   Modelica.Blocks.Continuous.PI PI1(

--- a/ThermofluidStream/Undirected/HeatExchangers/Tests/TestDiscretizedHEXvsDir.mo
+++ b/ThermofluidStream/Undirected/HeatExchangers/Tests/TestDiscretizedHEXvsDir.mo
@@ -53,7 +53,7 @@ model TestDiscretizedHEXvsDir
     m_flow_0=0,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-86,210},{-66,230}})));
   Modelica.Blocks.Sources.Ramp rampPressure(
@@ -87,7 +87,7 @@ model TestDiscretizedHEXvsDir
     m_flow_0=0,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-66,184},{-86,204}})));
   Modelica.Blocks.Continuous.PI PI1(
@@ -237,7 +237,7 @@ model TestDiscretizedHEXvsDir
     m_flow_0=1,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{90,-72},{70,-52}})));
   ThermofluidStream.Processes.FlowResistance flowResistanceB1(
@@ -245,7 +245,7 @@ model TestDiscretizedHEXvsDir
     m_flow_0=0.3,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
@@ -374,7 +374,7 @@ model TestDiscretizedHEXvsDir
     m_flow_0=0.5,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-84,-178},{-64,-158}})));
   ThermofluidStream.Processes.FlowResistance flowResistanceB2(
@@ -383,7 +383,7 @@ model TestDiscretizedHEXvsDir
     m_flow_0=0.3,
     r=0.05,
     l=1,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/ThermofluidStream/Undirected/Interfaces/Tests/Test_p_out_clipping.mo
+++ b/ThermofluidStream/Undirected/Interfaces/Tests/Test_p_out_clipping.mo
@@ -21,7 +21,7 @@ Medium package used in the Test.
     l=1,
     L_value=100,
     computeL=false,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100, k2=50))
     annotation (Placement(transformation(extent={{-10,20},{10,40}})));
   FlowControl.BasicControlValve basicControlValve(
@@ -58,7 +58,7 @@ Medium package used in the Test.
     l=1,
     L_value=100,
     computeL=false,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=100,
       k2=50))
     annotation (Placement(transformation(extent={{-10,40},{10,60}})));

--- a/ThermofluidStream/Undirected/Processes/FlowResistance.mo
+++ b/ThermofluidStream/Undirected/Processes/FlowResistance.mo
@@ -6,11 +6,11 @@ model FlowResistance "Flow resistance model"
 
   parameter SI.Radius r(min=0) "Radius";
   parameter SI.Length l(min=0) "Length";
-  replaceable function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.pleaseSelectPressureLoss
+  replaceable model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.pleaseSelectPressureLoss
     constrainedby ThermofluidStream.Processes.Internal.FlowResistance.partialPressureLoss
-    "Pressure loss function"
+    "Pressure loss model"
     annotation(choicesAllMatching=true, Documentation(info="<html>
-<p>Pressure loss function used in the flow resistance.</p>
+<p>Pressure loss model used in the flow resistance.</p>
 </html>"));
 
   parameter Boolean computeL = true "= true, if inertance L is computed from the geometry"
@@ -19,6 +19,19 @@ model FlowResistance "Flow resistance model"
     annotation(Dialog(tab="Advanced",group="Inertance", enable=not computeL));
   parameter Medium.Density rho_min = dropOfCommons.rho_min "Minium inlet density"
     annotation(Dialog(tab="Advanced"));
+
+  pLoss pressureLoss_fore(
+    m_flow=m_flow,
+    rho=rho_rear_in,
+    mu=mu_rear_in,
+    r=r,
+    l=l);
+  pLoss pressureLoss_rear(
+    m_flow=-m_flow,
+    rho=rho_fore_in,
+    mu=mu_fore_in,
+    r=r,
+    l=l);
 
 protected
   Medium.Density rho_rear_in = max(rho_min, Medium.density(rear.state_forwards)) "Inlet density of rear port";
@@ -29,12 +42,12 @@ protected
 
 equation
   //Forwards model
-  dp_fore = -pLoss(m_flow, rho_rear_in, mu_rear_in, r, l);
+  dp_fore = -pressureLoss_fore.pressureLoss;
   h_fore_out = h_rear_in;
   Xi_fore_out = Xi_rear_in;
 
   //Rearwards model
-  dp_rear = -pLoss(-m_flow, rho_fore_in, mu_fore_in, r, l);
+  dp_rear = -pressureLoss_rear.pressureLoss;
   h_rear_out = h_fore_in;
   Xi_rear_out = Xi_fore_in;
 
@@ -79,6 +92,6 @@ equation
           origin={0,25},
           rotation=180)}), Diagram(coordinateSystem(preserveAspectRatio=true)),
     Documentation(info="<html>
-<p>Undirected implementation of the FlowResistance with different selectable flow resistance functions (laminar, laminar-turbulent, linear-quadratic). The output pressure can be clipped to a certain value.</p>
+<p>Undirected implementation of the FlowResistance with different selectable flow resistance models (laminar, laminar-turbulent, linear-quadratic). The output pressure can be clipped to a certain value.</p>
 </html>"));
 end FlowResistance;

--- a/ThermofluidStream/Undirected/Processes/Tests/TestFlowResistance.mo
+++ b/ThermofluidStream/Undirected/Processes/Tests/TestFlowResistance.mo
@@ -7,7 +7,7 @@ model TestFlowResistance "Test for the undirected flow resistance"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         .ThermofluidStream.Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Boundaries.BoundaryRear boundary_rear(
@@ -34,7 +34,7 @@ model TestFlowResistance "Test for the undirected flow resistance"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
   Boundaries.BoundaryRear boundary_rear1(

--- a/ThermofluidStream/Undirected/Processes/Tests/TransportDelay.mo
+++ b/ThermofluidStream/Undirected/Processes/Tests/TransportDelay.mo
@@ -20,7 +20,7 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=100,
     l(displayUnit="mm") = 0.008,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{-10,30},{10,50}})));
@@ -62,7 +62,7 @@ Medium model for the test. Can be anything.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=100,
     l(displayUnit="mm") = 0.008,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1e4))
     annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));

--- a/ThermofluidStream/Undirected/Sensors/Tests/TestSensors.mo
+++ b/ThermofluidStream/Undirected/Sensors/Tests/TestSensors.mo
@@ -21,7 +21,7 @@ model TestSensors "Test for the undirected sensors"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=100,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   Boundaries.BoundaryRear boundary_rear(
@@ -68,7 +68,7 @@ model TestSensors "Test for the undirected sensors"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=100,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-40,50},{-20,70}})));
   Boundaries.BoundaryRear boundary_rear1(
@@ -143,7 +143,7 @@ model TestSensors "Test for the undirected sensors"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.01,
     l=100,
-    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
   SingleSensorX singleSensorX(redeclare package Medium = Medium2) annotation (Placement(transformation(extent={{-100,-40},{-80,-20}})));

--- a/ThermofluidStream/Undirected/Topology/Tests/TestConnectors.mo
+++ b/ThermofluidStream/Undirected/Topology/Tests/TestConnectors.mo
@@ -81,7 +81,7 @@ model TestConnectors "Test for the connectors"
     computeL=false,
     r=0.01,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         .ThermofluidStream.Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
   Processes.FlowResistance flowResistance2(
@@ -90,7 +90,7 @@ model TestConnectors "Test for the connectors"
     computeL=false,
     r=0.01,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         .ThermofluidStream.Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
   Boundaries.BoundaryRear boundary_rear4(redeclare package Medium = Medium, p0_par=100000)
@@ -123,20 +123,20 @@ model TestConnectors "Test for the connectors"
     redeclare package Medium = Medium,
     r(displayUnit="mm") = 0.005,
     l=5,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss)
     annotation (Placement(transformation(extent={{-40,-78},{-20,-58}})));
   ThermofluidStream.Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium, initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.state,
     l=5,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
     r(displayUnit="mm") = 0.005)
     annotation (Placement(transformation(extent={{20,-78},{40,-58}})));
   Processes.FlowResistance flowResistance4(
     redeclare package Medium = Medium, initM_flow = ThermofluidStream.Utilities.Types.InitializationMethods.state,
     l=5,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss,
   r(displayUnit="mm") = 0.005)
     annotation (Placement(transformation(

--- a/ThermofluidStream/Undirected/Topology/Tests/TestJunction.mo
+++ b/ThermofluidStream/Undirected/Topology/Tests/TestJunction.mo
@@ -8,12 +8,12 @@ model TestJunction "Test for the undirected junction"
 <p>This is the replaceable package that determines the medium of the Test. </p>
 </html>"));
 
-  replaceable function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+  replaceable model pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
     material=ThermofluidStream.Processes.Internal.Material.wood)
     constrainedby ThermofluidStream.Processes.Internal.FlowResistance.partialPressureLoss
-    "Pressure loss function for all Flow resistances"
+    "Pressure loss model for all Flow resistances"
     annotation(choicesAllMatching = true, Documentation(info="<html>
-<p>This is the pressure loss function used for all resistances except the two on the outlets of the right two cases.</p>
+<p>This is the pressure loss model used for all resistances except the two on the outlets of the right two cases.</p>
 </html>"));
 
   ThermofluidStream.Boundaries.Source source(redeclare package Medium=Medium,
@@ -35,14 +35,14 @@ model TestJunction "Test for the undirected junction"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{-46,50},{-26,70}})));
   ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{-46,10},{-26,30}})));
   ThermofluidStream.Boundaries.Source source2(
     redeclare package Medium = Medium, p0_par=2000000)
@@ -55,14 +55,14 @@ model TestJunction "Test for the undirected junction"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{26,10},{46,30}})));
   ThermofluidStream.Processes.FlowResistance flowResistance5(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{26,50},{46,70}})));
   ThermofluidStream.Topology.JunctionT1 junctionT1_1(redeclare package Medium=Medium,
     assumeConstantDensity=false,
@@ -93,14 +93,14 @@ model TestJunction "Test for the undirected junction"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{-46,-30},{-26,-10}})));
   ThermofluidStream.Processes.FlowResistance flowResistance9(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{-46,-70},{-26,-50}})));
   ThermofluidStream.Boundaries.Source source7(redeclare package Medium = Medium, p0_par=2000000)
     annotation (Placement(transformation(extent={{0,-30},{20,-10}})));
@@ -111,14 +111,14 @@ model TestJunction "Test for the undirected junction"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{26,-70},{46,-50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance11(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{26,-30},{46,-10}})));
   ThermofluidStream.Boundaries.Sink sink8(redeclare package Medium = Medium,
       p0_par=100000)
@@ -143,21 +143,21 @@ model TestJunction "Test for the undirected junction"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{-136,30},{-116,50}})));
   ThermofluidStream.Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss = pLoss)
+    redeclare model pLoss = pLoss)
     annotation (Placement(transformation(extent={{-136,-50},{-116,-30}})));
   ThermofluidStream.Processes.FlowResistance flowResistance6(
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
          k=1000))
     annotation (Placement(transformation(extent={{116,-50},{136,-30}})));
@@ -166,7 +166,7 @@ model TestJunction "Test for the undirected junction"
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     r=0.1,
     l=1,
-    redeclare function pLoss =
+    redeclare model pLoss =
         ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
          k=1000))
     annotation (Placement(transformation(extent={{116,30},{136,50}})));


### PR DESCRIPTION
Replace the replaceable pressure-loss and turbo characteristic functions with replaceable model classes.

Instantiate the selected models in FlowResistance and PartialTurboComponent so internal variables such as Reynolds number, friction factor, pressure ratio and specific work are available in simulation results.

Update all dependent redeclarations in tests and examples and add separate pressure-loss model instances for both flow directions in the undirected FlowResistance.

Closes #47 