### PR TITLE
remove tf=import ThermofluidStream

### DIFF
--- a/ThermofluidStream/Processes/Tests/Compressor.mo
+++ b/ThermofluidStream/Processes/Tests/Compressor.mo
@@ -2,8 +2,6 @@ within ThermofluidStream.Processes.Tests;
 model Compressor "Test for compressors"
   extends Modelica.Icons.Example;
 
-  import tf = ThermofluidStream;
-
   replaceable package Medium = ThermofluidStream.Media.myMedia.CompressibleLiquids.LinearWater_pT_Ambient "Medium model"
     annotation (Documentation(info="<html>
 <p>
@@ -12,37 +10,37 @@ Medium model for the test. Should be an ideal gas or close to that.
 </html>"));  // ThermofluidStream.myMedia.Air.SimpleAir;
 
 
-  tf.Boundaries.Source source(
+  ThermofluidStream.Boundaries.Source source(
     redeclare package Medium = Medium,
     T0_par=300,
     p0_par=100000)
     annotation (Placement(transformation(extent={{-100,6},{-80,26}})));
-  tf.Boundaries.Sink sink(
+  ThermofluidStream.Boundaries.Sink sink(
     redeclare package Medium = Medium,
     pressureFromInput=false,
     p0_par=300000)
     annotation (Placement(transformation(extent={{86,6},{106,26}})));
 
-  inner tf.DropOfCommons dropOfCommons(L=1, assertionLevel = AssertionLevel.warning)
+  inner ThermofluidStream.DropOfCommons dropOfCommons(L=1, assertionLevel = AssertionLevel.warning)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=0,
         origin={68,-78})));
 
-  tf.Processes.Compressor compressor(
+  ThermofluidStream.Processes.Compressor compressor(
     redeclare package Medium = Medium,
     L=1e6,
     m_flowStateSelect=StateSelect.never,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=-1,
-    redeclare function dp_tau_compressor = tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+    redeclare function dp_tau_compressor = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
       omega_ref=3000,
       skew=1,
       m_flow_ref=1))
     annotation (Placement(transformation(extent={{-6,10},{14,30}})));
   Modelica.Blocks.Sources.Constant const(k=6000)
     annotation (Placement(transformation(extent={{-28,-10},{-8,10}})));
-  tf.Processes.Compressor compressor1(
+  ThermofluidStream.Processes.Compressor compressor1(
     redeclare package Medium = Medium,
     omega_from_input=false,
     J_p=2,
@@ -52,7 +50,7 @@ Medium model for the test. Should be an ideal gas or close to that.
     omega_0=-150,
     initPhi=true,
     redeclare function dp_tau_compressor =
-        tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+        ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
   omega_ref=500,
         skew=1,
         m_flow_ref=0.01,
@@ -60,9 +58,9 @@ Medium model for the test. Should be an ideal gas or close to that.
         V_ref=0.0001)) annotation (Placement(transformation(extent={{-6,-30},{14,-10}})));
   Power power1(P=50000, tau_max=300)
     annotation (Placement(transformation(extent={{-28,-50},{-8,-30}})));
-  tf.Topology.SplitterN splitterN(N=2, redeclare package Medium = Medium)
+  ThermofluidStream.Topology.SplitterN splitterN(N=2, redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-74,6},{-54,26}})));
-  tf.Topology.JunctionN junctionN(N=2, redeclare package Medium = Medium)
+  ThermofluidStream.Topology.JunctionN junctionN(N=2, redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{60,6},{80,26}})));
 
 equation

--- a/ThermofluidStream/Processes/Tests/Flow_Resistance.mo
+++ b/ThermofluidStream/Processes/Tests/Flow_Resistance.mo
@@ -2,38 +2,37 @@ within ThermofluidStream.Processes.Tests;
 model Flow_Resistance "Test for flow resistance"
   extends Modelica.Icons.Example;
 
-  import tf = ThermofluidStream;
-  replaceable package Medium = tf.Media.myMedia.Air.SimpleAir "Medium model"
+  replaceable package Medium = ThermofluidStream.Media.myMedia.Air.SimpleAir "Medium model"
     annotation (Documentation(info="<html>
 <p>
 Medium model for the test. Can be anything.
 </p>
 </html>"));
 
-  tf.Boundaries.Source source(
+  ThermofluidStream.Boundaries.Source source(
     redeclare package Medium = Medium,
     T0_par(displayUnit="K") = 300,
     p0_par=300000)
     annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
-  tf.Boundaries.Sink sink(redeclare package Medium = Medium, p0_par=100000)
+  ThermofluidStream.Boundaries.Sink sink(redeclare package Medium = Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{20,-10},{40,10}})));
 
-  inner tf.DropOfCommons dropOfCommons(L=1, assertionLevel = AssertionLevel.warning,
+  inner ThermofluidStream.DropOfCommons dropOfCommons(L=1, assertionLevel = AssertionLevel.warning,
     displayColor=true)
     annotation (Placement(transformation(extent={{60,60},{80,80}})));
 
-  tf.Processes.FlowResistance flowResistance(
+  ThermofluidStream.Processes.FlowResistance flowResistance(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.steadyState,
     computeL=true,
     r=0.1,
     l=100,
-    redeclare function pLoss = tf.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
       k=1000,
       k2=100))
     annotation (Placement(transformation(extent={{-10,20},{10,40}})));
-  tf.Processes.FlowResistance flowResistance1(
+  ThermofluidStream.Processes.FlowResistance flowResistance1(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.derivative,
@@ -43,10 +42,10 @@ Medium model for the test. Can be anything.
     r=0.02,
     l=100,
     redeclare function pLoss =
-        tf.Processes.Internal.FlowResistance.laminarPressureLoss)
+        ThermofluidStream.Processes.Internal.FlowResistance.laminarPressureLoss)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 
-  tf.Processes.FlowResistance flowResistance2(
+  ThermofluidStream.Processes.FlowResistance flowResistance2(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
@@ -54,16 +53,16 @@ Medium model for the test. Can be anything.
     L_value=30000,
     r=0.075,
     l=10,
-    redeclare function pLoss = tf.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
+    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
 
-  tf.Boundaries.Source source1(
+  ThermofluidStream.Boundaries.Source source1(
     redeclare package Medium = Medium,
     T0_par(displayUnit="K") = 300,
     p0_par=300000)
     annotation (Placement(transformation(extent={{-40,-70},{-20,-50}})));
-  tf.Processes.FlowResistance flowResistance3(
+  ThermofluidStream.Processes.FlowResistance flowResistance3(
     redeclare package Medium = Medium,
     m_flowStateSelect=StateSelect.prefer,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
@@ -72,25 +71,25 @@ Medium model for the test. Can be anything.
     r=0.075,
     l=10,
     redeclare function pLoss =
-        tf.Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland (
+        ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland (
       material=ThermofluidStream.Processes.Internal.Material.steel))
     annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));
 
-  tf.Boundaries.Sink sink1(redeclare package Medium = Medium, p0_par=100000)
+  ThermofluidStream.Boundaries.Sink sink1(redeclare package Medium = Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{20,-70},{40,-50}})));
-  tf.Boundaries.Source source2(
+  ThermofluidStream.Boundaries.Source source2(
     redeclare package Medium = Medium,
     T0_par(displayUnit="K") = 300,
     p0_par=300000)
     annotation (Placement(transformation(extent={{-40,20},{-20,40}})));
-  tf.Boundaries.Sink sink2(redeclare package Medium = Medium, p0_par=100000)
+  ThermofluidStream.Boundaries.Sink sink2(redeclare package Medium = Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{20,20},{40,40}})));
-  tf.Boundaries.Source source3(
+  ThermofluidStream.Boundaries.Source source3(
     redeclare package Medium = Medium,
     T0_par(displayUnit="K") = 300,
     p0_par=300000)
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
-  tf.Boundaries.Sink sink3(redeclare package Medium = Medium, p0_par=100000)
+  ThermofluidStream.Boundaries.Sink sink3(redeclare package Medium = Medium, p0_par=100000)
     annotation (Placement(transformation(extent={{20,-40},{40,-20}})));
 equation
   connect(source1.outlet, flowResistance3.inlet) annotation (Line(

--- a/ThermofluidStream/Processes/Tests/Pump.mo
+++ b/ThermofluidStream/Processes/Tests/Pump.mo
@@ -2,9 +2,8 @@ within ThermofluidStream.Processes.Tests;
 model Pump "Test for pumps"
   extends Modelica.Icons.Example;
 
-  import tf = ThermofluidStream;
-  replaceable package Medium = tf.Media.myMedia.CompressibleLiquids.LinearWater_pT_Ambient
-    constrainedby tf.Media.myMedia.Interfaces.PartialMedium "Medium model"
+  replaceable package Medium = ThermofluidStream.Media.myMedia.CompressibleLiquids.LinearWater_pT_Ambient
+    constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium "Medium model"
     annotation (
       choicesAllMatching=true,
       Documentation(info="<html>
@@ -13,18 +12,18 @@ Medium model for the test. Should be incompressible or with low compressibility.
 </p>
 </html>"));
 
-  tf.Boundaries.Source source(
+  ThermofluidStream.Boundaries.Source source(
     redeclare package Medium = Medium,
     T0_par=300,
     p0_par=100000)
     annotation (Placement(transformation(extent={{-100,20},{-80,40}})));
-  tf.Boundaries.Sink sink(
+  ThermofluidStream.Boundaries.Sink sink(
     redeclare package Medium = Medium,
     pressureFromInput=false,
     p0_par=350000)
     annotation (Placement(transformation(extent={{96,20},{116,40}})));
 
-  inner tf.DropOfCommons dropOfCommons(L=1)
+  inner ThermofluidStream.DropOfCommons dropOfCommons(L=1)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=0,
         origin={-90,-50})));
@@ -34,7 +33,7 @@ Medium model for the test. Should be incompressible or with low compressibility.
     L=100000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
+    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
     annotation (Placement(transformation(extent={{-10,40},{10,20}})));
 
   Modelica.Blocks.Sources.Constant pump_speed_rad_s(k=800)
@@ -46,27 +45,27 @@ Medium model for the test. Should be incompressible or with low compressibility.
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     initPhi=true,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
+    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_centrifugal (useLegacyReynolds=false))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-  tf.Processes.Tests.Power powerSource1(P=8000, tau_max=150)
+  ThermofluidStream.Processes.Tests.Power powerSource1(P=8000, tau_max=150)
     annotation (Placement(transformation(extent={{-40,-30},{-20,-10}})));
-  tf.Topology.SplitterN splitterN(N=4, redeclare package Medium = Medium,
+  ThermofluidStream.Topology.SplitterN splitterN(N=4, redeclare package Medium = Medium,
     L=0)
     annotation (Placement(transformation(extent={{-72,20},{-52,40}})));
-  tf.Topology.JunctionN junctionN(N=4, redeclare package Medium = Medium,
+  ThermofluidStream.Topology.JunctionN junctionN(N=4, redeclare package Medium = Medium,
     L=0)
     annotation (Placement(transformation(extent={{60,20},{80,40}})));
-  tf.Processes.Pump pump_directParamWithHeatPort(
+  ThermofluidStream.Processes.Pump pump_directParamWithHeatPort(
     redeclare package Medium = Medium,
     L=10000,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     enableAccessHeatPort=true,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
+    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
           =false, k_p_input=1e7)) annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
   Modelica.Blocks.Sources.Constant pump2_speed_rad_s(k=3200)
     annotation (Placement(transformation(extent={{40,-70},{20,-50}})));
-  tf.Processes.Pump pump_directParamPowerIn(
+  ThermofluidStream.Processes.Pump pump_directParamPowerIn(
     redeclare package Medium = Medium,
     L=10000,
     omega_from_input=false,
@@ -77,16 +76,16 @@ Medium model for the test. Should be incompressible or with low compressibility.
     initOmega=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     initPhi=true,
     phi_0=-1745.3292519943,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (
+    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_nominal_flow (
         parametrizeByDesignPoint=false,
         V_r_input=0.0006,
         k_p_input=1e8)) annotation (Placement(transformation(extent={{-10,-100},{10,-80}})));
-  tf.Processes.Tests.Power powerSource2(P=5000, tau_max=150)
+  ThermofluidStream.Processes.Tests.Power powerSource2(P=5000, tau_max=150)
     annotation (Placement(transformation(extent={{-40,-120},{-20,-100}})));
 
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature fixedTemperature(T=
         283.15) annotation (Placement(transformation(extent={{-40,-70},{-20,-50}})));
-  tf.Processes.Pump pump_designPointOmega100(
+  ThermofluidStream.Processes.Pump pump_designPointOmega100(
     redeclare package Medium = Medium,
     L=10000,
     omega_from_input=true,
@@ -95,18 +94,18 @@ Medium model for the test. Should be incompressible or with low compressibility.
     J_p=10,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     phi_0=-1745.3292519943,
-    redeclare function dp_tau_pump = tf.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
+    redeclare function dp_tau_pump = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_nominal_flow (parametrizeByDesignPoint
           =true, omega_D(displayUnit="rad/s") = 100))
     "Design point: V_flow=100L/min at 100rad/s with a pressure increase of 5 bar"
     annotation (Placement(transformation(extent={{-10,90},{10,70}})));
   Modelica.Blocks.Sources.Constant pump4_speed_rad_s(k=100)
     annotation (Placement(transformation(extent={{-40,90},{-20,110}})));
-  tf.Boundaries.Source source1(
+  ThermofluidStream.Boundaries.Source source1(
     redeclare package Medium = Medium,
     T0_par=300,
     p0_par=100000)
     annotation (Placement(transformation(extent={{-100,70},{-80,90}})));
-  tf.Boundaries.Sink sink1(
+  ThermofluidStream.Boundaries.Sink sink1(
     redeclare package Medium = Medium,
     pressureFromInput=false,
     p0_par=600000)

--- a/ThermofluidStream/Processes/Tests/Turbine.mo
+++ b/ThermofluidStream/Processes/Tests/Turbine.mo
@@ -2,8 +2,6 @@ within ThermofluidStream.Processes.Tests;
 model Turbine "Test for turbines"
   extends Modelica.Icons.Example;
 
-  import tf = ThermofluidStream;
-
   replaceable package Medium = ThermofluidStream.Media.myMedia.Air.SimpleAir "Medium model"
     annotation (Documentation(info="<html>
 <p>
@@ -11,39 +9,39 @@ Medium model for the test. Should be an ideal gas or close to that.
 </p>
 </html>"));
 
-  tf.Boundaries.Source source(
+  ThermofluidStream.Boundaries.Source source(
     redeclare package Medium = Medium,
     T0_par=300,
     p0_par=300000)
     annotation (Placement(transformation(extent={{-100,6},{-80,26}})));
-  tf.Boundaries.Sink sink(
+  ThermofluidStream.Boundaries.Sink sink(
     redeclare package Medium = Medium,
     pressureFromInput=false,
     p0_par=100000)
     annotation (Placement(transformation(extent={{86,6},{106,26}})));
 
-  inner tf.DropOfCommons dropOfCommons(L=1, assertionLevel = AssertionLevel.warning,
+  inner ThermofluidStream.DropOfCommons dropOfCommons(L=1, assertionLevel = AssertionLevel.warning,
     displayParameters=true)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=0,
         origin={68,-78})));
 
-  tf.Processes.Turbine turbine(
+  ThermofluidStream.Processes.Turbine turbine(
     redeclare package Medium = Medium,
     L=1e6,
     omega_from_input=true,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=1e-5,
     redeclare function dp_tau_turbine =
-        tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=1e6))
+        ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=1e6))
     annotation (Placement(transformation(extent={{-6,10},{14,30}})));
   Modelica.Blocks.Sources.Constant const(k=1000)
     annotation (Placement(transformation(extent={{-28,-10},{-8,10}})));
-  tf.Topology.SplitterN splitterN(N=2, redeclare package Medium = Medium)
+  ThermofluidStream.Topology.SplitterN splitterN(N=2, redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-66,6},{-46,26}})));
-  tf.Topology.JunctionN junctionN(N=2, redeclare package Medium = Medium)
+  ThermofluidStream.Topology.JunctionN junctionN(N=2, redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{46,6},{66,26}})));
-  tf.Processes.Turbine turbine1(
+  ThermofluidStream.Processes.Turbine turbine1(
     redeclare package Medium = Medium,
     L=1e5,
     omega_from_input=false,
@@ -53,7 +51,7 @@ Medium model for the test. Should be an ideal gas or close to that.
     omega_0=-1,
     initPhi=true,
     redeclare function dp_tau_turbine =
-        tf.Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=1e6, eta=1))
+        ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (omega_ref=1e6, eta=1))
     annotation (Placement(transformation(extent={{-8,-38},{12,-18}})));
   Modelica.Mechanics.Rotational.Sources.LinearSpeedDependentTorque
     linearSpeedDependentTorque(


### PR DESCRIPTION
`import tf = ThermofluidStream` was removed from the test models where it was used.

Closes #307 