### PR TITLE
Fix display name for isenthalpic and isobaric

### DIFF
--- a/ThermofluidStream/Idealized/Processes/Isenthalpic.mo
+++ b/ThermofluidStream/Idealized/Processes/Isenthalpic.mo
@@ -112,7 +112,7 @@ equation
           lineThickness=0.5),
         Text(
           extent={{-150,120},{150,80}},
-          textString=if displayInstanceName then "%instanceName" else "",
+          textString=if displayInstanceName then "%name" else "",
           textColor=dropOfCommons.instanceNameColor),
         Text(
           extent={{-30,30},{30,-30}},

--- a/ThermofluidStream/Idealized/Processes/Isobaric.mo
+++ b/ThermofluidStream/Idealized/Processes/Isobaric.mo
@@ -194,7 +194,7 @@ equation
           lineThickness=0.5),
         Text(
           extent={{-150,120},{150,80}},
-          textString = if displayInstanceName then "%instanceName" else "",
+          textString = if displayInstanceName then "%name" else "",
           textColor = dropOfCommons.instanceNameColor),
         Text(visible = systemSpec == ThermofluidStream.Idealized.Types.SystemModel.Flow,
           extent={{-30,30},{30,-30}},


### PR DESCRIPTION
The name of isenthalpic and isobaric idealized components can now be displayed correctly. Replace `"%instanceName"` by `"%name"`

Closes #357 