### PR TITLE
Depreciate Cvs_UK

### DIFF
--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -19,7 +19,7 @@ model BasicControlValve "Basic valve model with optional flow characteristics fo
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Kvs)));
   parameter Real Cvs_US =  0 "Cvs-value (US [gal/min]) from data sheet (valve fully open)"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_US)));
-  parameter Real Cvs_UK =  0 "Cvs-value (UK [gal/min]) from data sheet (valve fully open)"
+  parameter Real Cvs_UK =  0 "Cvs-value (UK [gal/min]) from data sheet (valve fully open, deprecated; use Kvs or Cvs_US instead)"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_UK)));
   parameter SI.MassFlowRate m_flow_ref_set =  0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
@@ -32,7 +32,7 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow";
 
 initial equation
-
+  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "In \"" + instanceName + "\": Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);

--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -113,18 +113,5 @@ equation
 <p>The three standard curve characteristics (linear, parabolic, equal-percentage) are implemented and can be chosen.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
-
-<h5>Reference values for standardized flow coefficients</h5>
-<p>
-When using <code>Kvs</code>, <code>Cvs_US</code>, or
-<code>Cvs_UK</code>, the default values
-<code>dp_ref = 1 bar</code> and
-<code>rho_ref = 1000 kg/m3</code> must not be modified.
-</p>
-<p>
-Changing these reference values currently leads to incorrect model
-behavior. The assertion level can be configured using
-<code>assertionLevel</code>. To test this behavior, a test model has been setup in Tests.ValveReferenceValues.
-</p>
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -32,7 +32,18 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow";
 
 initial equation
-  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
+  assert(
+  flowCoefficient <> FlowCoeffType.Cvs_UK,
+  "\n"
+  + "===============================================================================\n"
+  + "             ThermoFluidStream WARNING - DEPRECATED PARAMETERIZATION\n"
+  + "===============================================================================\n"
+  + "The flow coefficient type Cvs_UK is selected.\n"
+  + "This option is DEPRECATED and will be REMOVED in ThermoFluidStream 2.0.\n"
+  + "Action required: Use Kvs or Cvs_US instead.\n"
+  + "Component: " + getInstanceName() + "\n"
+  + "===============================================================================\n",
+  level=AssertionLevel.warning);
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "In \"" + instanceName + "\": Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
@@ -102,5 +113,18 @@ equation
 <p>The three standard curve characteristics (linear, parabolic, equal-percentage) are implemented and can be chosen.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>. To test this behavior, a test model has been setup in Tests.ValveReferenceValues.
+</p>
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/FlowControl/Internal/Types/FlowCoefficientTypes.mo
+++ b/ThermofluidStream/FlowControl/Internal/Types/FlowCoefficientTypes.mo
@@ -2,6 +2,6 @@ within ThermofluidStream.FlowControl.Internal.Types;
 type FlowCoefficientTypes = enumeration(
     Kvs "Kvs (metric)",
     Cvs_US "Cvs (US)",
-    Cvs_UK "Cvs (UK)",
+    Cvs_UK "Cvs (UK, deprecated; use Kvs or Cvs_US instead; scheduled for removal in TFS 2.0)",
     m_flow_set "Reference mass flow",
     flowDiameter "Flow diameter");

--- a/ThermofluidStream/FlowControl/Internal/Types/FlowCoefficientTypesBasic.mo
+++ b/ThermofluidStream/FlowControl/Internal/Types/FlowCoefficientTypesBasic.mo
@@ -2,5 +2,5 @@ within ThermofluidStream.FlowControl.Internal.Types;
 type FlowCoefficientTypesBasic = enumeration(
     Kvs "Kvs (metric)",
     Cvs_US "Cvs (US)",
-    Cvs_UK "Cvs (UK)",
+    Cvs_UK "Cvs (UK, deprecated; use Kvs or Cvs_US instead; scheduled for removal in TFS 2.0)",
     m_flow_set "Reference mass flow");

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -47,7 +47,18 @@ protected
 
 
 initial equation
-  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
+  assert(
+  flowCoefficient <> FlowCoeffType.Cvs_UK,
+  "\n"
+  + "===============================================================================\n"
+  + "             ThermoFluidStream WARNING - DEPRECATED PARAMETERIZATION\n"
+  + "===============================================================================\n"
+  + "The flow coefficient type Cvs_UK is selected.\n"
+  + "This option is DEPRECATED and will be REMOVED in ThermoFluidStream 2.0.\n"
+  + "Action required: Use Kvs or Cvs_US instead.\n"
+  + "Component: " + getInstanceName() + "\n"
+  + "===============================================================================\n",
+  level=AssertionLevel.warning);
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "In \"" + instanceName + "\": Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
@@ -114,5 +125,18 @@ equation
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>. To test this behavior, a test model has been setup in Tests.ValveReferenceValues.
+</p>
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -16,7 +16,7 @@ model SpecificValveType "Specific technical valve types"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Kvs)));
   parameter Real Cvs_US = 0 "Cvs-value (US [gal/min]) from data sheet (valve fully open)"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_US)));
-  parameter Real Cvs_UK = 0 "Cvs-value (UK [gal/min]) from data sheet (valve fully open)"
+  parameter Real Cvs_UK = 0 "Cvs-value (UK [gal/min]) from data sheet (valve fully open, deprecated; use Kvs or Cvs_US instead)"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_UK)));
   parameter SI.MassFlowRate m_flow_ref_set = 0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
@@ -47,6 +47,7 @@ protected
 
 
 initial equation
+  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "In \"" + instanceName + "\": Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -125,18 +125,5 @@ equation
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
-
-<h5>Reference values for standardized flow coefficients</h5>
-<p>
-When using <code>Kvs</code>, <code>Cvs_US</code>, or
-<code>Cvs_UK</code>, the default values
-<code>dp_ref = 1 bar</code> and
-<code>rho_ref = 1000 kg/m3</code> must not be modified.
-</p>
-<p>
-Changing these reference values currently leads to incorrect model
-behavior. The assertion level can be configured using
-<code>assertionLevel</code>. To test this behavior, a test model has been setup in Tests.ValveReferenceValues.
-</p>
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
@@ -27,6 +27,8 @@ model BasicControlValve "Basic valve model with optional flow characteristics fo
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_UK)));
   parameter SI.MassFlowRate m_flow_ref_set = 0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
+  parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
+    annotation(Dialog(tab="Advanced"));
 
 protected
   final parameter SI.VolumeFlowRate V_flow_ref=
@@ -36,7 +38,36 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow rate";
 
 initial equation
-  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
+    assert(
+    flowCoefficient <> FlowCoeffType.Cvs_UK,
+    "\n"
+    + "===============================================================================\n"
+    + "              ThermoFluidStream WARNING - DEPRECATED BEHAVIOR\n"
+    + "===============================================================================\n"
+    + "The flow coefficient type Cvs_UK is selected.\n"
+    + "This parameterization is DEPRECATED and will be REMOVED in v2.0.\n"
+    + "Action required: Use Kvs or Cvs_US instead.\n"
+    + "Component: " + getInstanceName() + "\n"
+    + "===============================================================================\n",
+    level=AssertionLevel.warning);
+
+  if flowCoefficient <> FlowCoeffType.m_flow_set then
+    assert(
+      abs(dp_ref/1e5 - 1) <= Modelica.Constants.eps,
+      "In \"" + getInstanceName()
+      + "\": dp_ref must remain at its default value of 1 bar when "
+      + "m_flow_ref_set is not used. Modifying dp_ref leads to incorrect "
+      + "model behavior. Remove the dp_ref modifier.",
+      level=assertionLevel);
+
+    assert(
+      abs(rho_ref/1000 - 1) <= Modelica.Constants.eps,
+      "In \"" + getInstanceName()
+      + "\": rho_ref must remain at its default value of 1000 kg/m3 when "
+      + "m_flow_ref_set is not used. Modifying rho_ref leads to incorrect "
+      + "model behavior. Remove the rho_ref modifier.",
+      level=assertionLevel);
+  end if;
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);

--- a/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
@@ -49,23 +49,6 @@ initial equation
     + "===============================================================================\n",
     level=AssertionLevel.warning);
 
-  if flowCoefficient <> FlowCoeffType.m_flow_set then
-    assert(
-      abs(dp_ref/1e5 - 1) <= Modelica.Constants.eps,
-      "In \"" + getInstanceName()
-      + "\": dp_ref must remain at its default value of 1 bar when "
-      + "m_flow_ref_set is not used. Modifying dp_ref leads to incorrect "
-      + "model behavior. Remove the dp_ref modifier.",
-      level=assertionLevel);
-
-    assert(
-      abs(rho_ref/1000 - 1) <= Modelica.Constants.eps,
-      "In \"" + getInstanceName()
-      + "\": rho_ref must remain at its default value of 1000 kg/m3 when "
-      + "m_flow_ref_set is not used. Modifying rho_ref leads to incorrect "
-      + "model behavior. Remove the rho_ref modifier.",
-      level=assertionLevel);
-  end if;
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);

--- a/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
@@ -23,7 +23,7 @@ model BasicControlValve "Basic valve model with optional flow characteristics fo
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Kvs)));
   parameter Real Cvs_US = 0 "Cvs-value (US [gal/min]) from data sheet (valve fully open)"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_US)));
-  parameter Real Cvs_UK = 0 "Cvs-value (UK [gal/min]) from data sheet (valve fully open)"
+  parameter Real Cvs_UK = 0 "Cvs-value (UK [gal/min]) from data sheet (valve fully open, deprecated; use Kvs or Cvs_US instead)"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_UK)));
   parameter SI.MassFlowRate m_flow_ref_set = 0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
@@ -36,6 +36,7 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow rate";
 
 initial equation
+  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);

--- a/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
@@ -27,8 +27,6 @@ model BasicControlValve "Basic valve model with optional flow characteristics fo
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_UK)));
   parameter SI.MassFlowRate m_flow_ref_set = 0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
-  parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
-    annotation(Dialog(tab="Advanced"));
 
 protected
   final parameter SI.VolumeFlowRate V_flow_ref=
@@ -127,17 +125,5 @@ equation
 <p>The three standard curve characteristics (linear, parabolic, equal-percentage) are implemented and can be chosen.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
-<h5>Reference values for standardized flow coefficients</h5>
-<p>
-When using <code>Kvs</code>, <code>Cvs_US</code>, or
-<code>Cvs_UK</code>, the default values
-<code>dp_ref = 1 bar</code> and
-<code>rho_ref = 1000 kg/m3</code> must not be modified.
-</p>
-<p>
-Changing these reference values currently leads to incorrect model
-behavior. The assertion level can be configured using
-<code>assertionLevel</code>. To test this behavior, a test model has been setup in Tests.ValveReferenceValues.
-</p>
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
@@ -127,5 +127,17 @@ equation
 <p>The three standard curve characteristics (linear, parabolic, equal-percentage) are implemented and can be chosen.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>. To test this behavior, a test model has been setup in Tests.ValveReferenceValues.
+</p>
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -61,25 +61,6 @@ initial equation
     + "===============================================================================\n",
     level=AssertionLevel.warning);
 
-  if flowCoefficient == FlowCoeffType.Kvs or
-     flowCoefficient == FlowCoeffType.Cvs_US or
-     flowCoefficient == FlowCoeffType.Cvs_UK then
-    assert(
-      abs(dp_ref/1e5 - 1) <= Modelica.Constants.eps,
-      "In \"" + getInstanceName()
-      + "\": dp_ref must remain at its default value of 1 bar when using "
-      + "Kvs, Cvs_US, or Cvs_UK. Modifying dp_ref leads to incorrect "
-      + "model behavior. Remove the dp_ref modifier.",
-      level=assertionLevel);
-
-    assert(
-      abs(rho_ref/1000 - 1) <= Modelica.Constants.eps,
-      "In \"" + getInstanceName()
-      + "\": rho_ref must remain at its default value of 1000 kg/m3 when "
-      + "using Kvs, Cvs_US, or Cvs_UK. Modifying rho_ref leads to incorrect "
-      + "model behavior. Remove the rho_ref modifier.",
-      level=assertionLevel);
-  end if;
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 shall not be used", level=AssertionLevel.error);

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -17,7 +17,7 @@ model SpecificValveType "Specific technical valve types"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Kvs)));
   parameter Real Cvs_US = 0 "Cvs-value (US [gal/min]) from data sheet (valve fully open)"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_US)));
-  parameter Real Cvs_UK = 0 "Cvs-value (UK [gal/min]) from data sheet (valve fully open)"
+  parameter Real Cvs_UK = 0 "Cvs-value (UK [gal/min]) from data sheet (valve fully open, deprecated; use Kvs or Cvs_US instead)"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_UK)));
   parameter SI.MassFlowRate m_flow_ref_set = 0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
@@ -48,6 +48,7 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow rate";
 
 initial equation
+  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 shall not be used", level=AssertionLevel.error);

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -149,5 +149,17 @@ equation
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>. To test this behavior, a test model has been setup in Tests.ValveReferenceValues.
+</p> 
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -24,6 +24,8 @@ model SpecificValveType "Specific technical valve types"
   //Set valve data as parameter
   parameter SI.Diameter d_valve = 0 "Flow diameter"
     annotation (Dialog(group="Valve parameters", enable=(flowCoefficient== FlowCoeffType.flowDiameter)));
+  parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
+    annotation(Dialog(tab="Advanced"));
 
 protected
   constant ZetaValueRecord valveData;
@@ -48,7 +50,38 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow rate";
 
 initial equation
-  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
+  assert(
+    flowCoefficient <> FlowCoeffType.Cvs_UK,
+    "\n"
+    + "===============================================================================\n"
+    + "              ThermoFluidStream WARNING - DEPRECATED BEHAVIOR\n"
+    + "===============================================================================\n"
+    + "The flow coefficient type Cvs_UK is selected.\n"
+    + "This parameterization is DEPRECATED and will be REMOVED in v2.0.\n"
+    + "Action required: Use Kvs or Cvs_US instead.\n"
+    + "Component: " + getInstanceName() + "\n"
+    + "===============================================================================\n",
+    level=AssertionLevel.warning);
+
+  if flowCoefficient == FlowCoeffType.Kvs or
+     flowCoefficient == FlowCoeffType.Cvs_US or
+     flowCoefficient == FlowCoeffType.Cvs_UK then
+    assert(
+      abs(dp_ref/1e5 - 1) <= Modelica.Constants.eps,
+      "In \"" + getInstanceName()
+      + "\": dp_ref must remain at its default value of 1 bar when using "
+      + "Kvs, Cvs_US, or Cvs_UK. Modifying dp_ref leads to incorrect "
+      + "model behavior. Remove the dp_ref modifier.",
+      level=assertionLevel);
+
+    assert(
+      abs(rho_ref/1000 - 1) <= Modelica.Constants.eps,
+      "In \"" + getInstanceName()
+      + "\": rho_ref must remain at its default value of 1000 kg/m3 when "
+      + "using Kvs, Cvs_US, or Cvs_UK. Modifying rho_ref leads to incorrect "
+      + "model behavior. Remove the rho_ref modifier.",
+      level=assertionLevel);
+  end if;
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 shall not be used", level=AssertionLevel.error);

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -24,8 +24,6 @@ model SpecificValveType "Specific technical valve types"
   //Set valve data as parameter
   parameter SI.Diameter d_valve = 0 "Flow diameter"
     annotation (Dialog(group="Valve parameters", enable=(flowCoefficient== FlowCoeffType.flowDiameter)));
-  parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
-    annotation(Dialog(tab="Advanced"));
 
 protected
   constant ZetaValueRecord valveData;
@@ -149,17 +147,5 @@ equation
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
-<h5>Reference values for standardized flow coefficients</h5>
-<p>
-When using <code>Kvs</code>, <code>Cvs_US</code>, or
-<code>Cvs_UK</code>, the default values
-<code>dp_ref = 1 bar</code> and
-<code>rho_ref = 1000 kg/m3</code> must not be modified.
-</p>
-<p>
-Changing these reference values currently leads to incorrect model
-behavior. The assertion level can be configured using
-<code>assertionLevel</code>. To test this behavior, a test model has been setup in Tests.ValveReferenceValues.
-</p> 
 </html>"));
 end SpecificValveType;


### PR DESCRIPTION
## Changes

- Marked `Cvs_UK` as deprecated in both flow coefficient enumerations.
- Added deprecation notes to the `Cvs_UK` parameter descriptions in all directed and undirected valve models.
- Added warning assertions when `Cvs_UK` is selected.
- Kept the existing `Cvs_UK` conversion and parameter validation unchanged.
- No physical equations or numerical behavior were modified.

Closes #341