### PR TITLE
Dp_ref_rho assert

### DIFF
--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -116,9 +116,9 @@ When using <code>Kvs</code>, <code>Cvs_US</code>, or
 <code>dp_ref = 1 bar</code> and
 <code>rho_ref = 1000 kg/m3</code> must not be modified.
 </p>
-<p>
 Changing these reference values currently leads to incorrect model
 behavior. The assertion level can be configured using
 <code>assertionLevel</code>. To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.FlowControl.Tests.ValveReferenceValues\">ValveReferenceValues</a>.
+</p>
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -119,6 +119,5 @@ When using <code>Kvs</code>, <code>Cvs_US</code>, or
 Changing these reference values currently leads to incorrect model
 behavior. The assertion level can be configured using
 <code>assertionLevel</code>. To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.FlowControl.Tests.ValveReferenceValues\">ValveReferenceValues</a>.
-</p>
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -34,8 +34,6 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow";
 
 initial equation
-
-  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
   if flowCoefficient == FlowCoeffType.Kvs or
      flowCoefficient == FlowCoeffType.Cvs_US or
      flowCoefficient == FlowCoeffType.Cvs_UK then

--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -23,6 +23,8 @@ model BasicControlValve "Basic valve model with optional flow characteristics fo
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_UK)));
   parameter SI.MassFlowRate m_flow_ref_set =  0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
+  parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
+    annotation(Dialog(tab="Advanced"));
 
 protected
   final parameter SI.VolumeFlowRate V_flow_ref=
@@ -33,6 +35,13 @@ protected
 
 initial equation
 
+  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
+  if flowCoefficient == FlowCoeffType.Kvs or
+     flowCoefficient == FlowCoeffType.Cvs_US or
+     flowCoefficient == FlowCoeffType.Cvs_UK then
+     assert(abs(dp_ref/1e5 - 1) <= Modelica.Constants.eps, "In \"" + instanceName + "\": dp_ref must remain at its default value of 1 bar when using Kvs, Cvs_US, or Cvs_UK. Remove the dp_ref modifier.", level=assertionLevel);
+     assert(abs(rho_ref/1000 - 1) <= Modelica.Constants.eps, "In \"" + instanceName + "\": rho_ref must remain at its default value of 1000 kg/m3 when using Kvs, Cvs_US, or Cvs_UK. Remove the rho_ref modifier.", level=assertionLevel);
+  end if;
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "In \"" + instanceName + "\": Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
@@ -102,5 +111,17 @@ equation
 <p>The three standard curve characteristics (linear, parabolic, equal-percentage) are implemented and can be chosen.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>.
+</p>
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.FlowControl;
 model BasicControlValve "Basic valve model with optional flow characteristics for incompressible fluids"
 
-  extends ThermofluidStream.FlowControl.Internal.PartialValve;
+  extends ThermofluidStream.FlowControl.Internal.PartialValve (final enable_dp_rho_ref = flowCoefficient==FlowCoeffType.m_flow_set);
 
   import FlowCoeffType = ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic;
 
@@ -24,7 +24,7 @@ model BasicControlValve "Basic valve model with optional flow characteristics fo
   parameter SI.MassFlowRate m_flow_ref_set =  0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
   parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
-    annotation(Dialog(tab="Advanced"));
+    annotation(Dialog(tab="Advanced"), HideResult=true);
 
 protected
   final parameter SI.VolumeFlowRate V_flow_ref=
@@ -108,6 +108,17 @@ equation
 <p><br>The modeler has the ability to choose between different valve characteristics and flow coefficients.</p>
 <p>The three standard curve characteristics (linear, parabolic, equal-percentage) are implemented and can be chosen.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate can be set. </p>
-<p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+<p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p> 
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>. To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.FlowControl.Tests.ValveReferenceValues\">ValveReferenceValues</a>.
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/FlowControl/BasicControlValve.mo
@@ -111,17 +111,5 @@ equation
 <p>The three standard curve characteristics (linear, parabolic, equal-percentage) are implemented and can be chosen.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
-<h5>Reference values for standardized flow coefficients</h5>
-<p>
-When using <code>Kvs</code>, <code>Cvs_US</code>, or
-<code>Cvs_UK</code>, the default values
-<code>dp_ref = 1 bar</code> and
-<code>rho_ref = 1000 kg/m3</code> must not be modified.
-</p>
-<p>
-Changing these reference values currently leads to incorrect model
-behavior. The assertion level can be configured using
-<code>assertionLevel</code>.
-</p>
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/FlowControl/Internal/PartialValve.mo
+++ b/ThermofluidStream/FlowControl/Internal/PartialValve.mo
@@ -5,6 +5,8 @@ partial model PartialValve "Partial implementation of a physical valve"
 
   parameter Boolean invertInput = false "= true, if input u_in is inverted"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
+  parameter Boolean enable_dp_rho_ref "Enables/ hides showing dp_ref and rho_ref"
+    annotation (HideResult=true);
   parameter Real k_min(unit="1", min = 1e-5, max = 1) = 0.03 "Remaining flow at actuation signal u = 0";
 
   Modelica.Blocks.Interfaces.RealInput u_in(unit="1") "Valve control input signal []"
@@ -13,9 +15,9 @@ partial model PartialValve "Partial implementation of a physical valve"
   Real u(unit="1") "Actuation input for flow calculation";
   parameter SI.PressureDifference dp_ref=1e5
     "Reference pressure difference"
-    annotation (Dialog(tab="Advanced", group="Reference values"));
+    annotation (Dialog(tab="Advanced", group="Reference values", enable = enable_dp_rho_ref));
   parameter Medium.Density rho_ref=1000 "Reference density"
-    annotation (Dialog(tab="Advanced", group="Reference values"));
+    annotation (Dialog(tab="Advanced", group="Reference values", enable = enable_dp_rho_ref));
 
 protected
   final constant Real secondsPerHour(final unit="s/h") = 3600 "Unit conversion parameter";

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -131,6 +131,5 @@ When using <code>Kvs</code>, <code>Cvs_US</code>, or
 Changing these reference values currently leads to incorrect model
 behavior. The assertion level can be configured using
 <code>assertionLevel</code>.To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.FlowControl.Tests.ValveReferenceValues\">ValveReferenceValues</a>.
-</p>
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.FlowControl;
 model SpecificValveType "Specific technical valve types"
 
-  extends ThermofluidStream.FlowControl.Internal.PartialValve;
+  extends ThermofluidStream.FlowControl.Internal.PartialValve (final enable_dp_rho_ref = flowCoefficient==FlowCoeffType.m_flow_set);
 
   import FlowCoeffType = ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypes;
 

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -24,7 +24,7 @@ model SpecificValveType "Specific technical valve types"
   parameter SI.Diameter d_valve = 0 "Flow diameter"
     annotation (Dialog(group="Valve parameters", enable=(flowCoefficient== FlowCoeffType.flowDiameter)));
   parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
-   annotation(Dialog(tab="Advanced"));
+    annotation(Dialog(tab="Advanced"), HideResult=true);
 
 protected
   final parameter SI.Area A_valve=0.25*Modelica.Constants.pi*d_valve^2 "Cross-sectional area";
@@ -120,6 +120,17 @@ equation
 <p>This valve models the behavior of specific valve types.</p>
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
-<p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+<p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p> 
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>.To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.FlowControl.Tests.ValveReferenceValues\">ValveReferenceValues</a>.
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -49,8 +49,6 @@ protected
 
 
 initial equation
-
-  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
   if flowCoefficient == FlowCoeffType.Kvs or
      flowCoefficient == FlowCoeffType.Cvs_US or
      flowCoefficient == FlowCoeffType.Cvs_UK then

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -128,9 +128,9 @@ When using <code>Kvs</code>, <code>Cvs_US</code>, or
 <code>dp_ref = 1 bar</code> and
 <code>rho_ref = 1000 kg/m3</code> must not be modified.
 </p>
-<p>
 Changing these reference values currently leads to incorrect model
 behavior. The assertion level can be configured using
 <code>assertionLevel</code>.To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.FlowControl.Tests.ValveReferenceValues\">ValveReferenceValues</a>.
+</p>
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -123,17 +123,5 @@ equation
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
-<h5>Reference values for standardized flow coefficients</h5>
-<p>
-When using <code>Kvs</code>, <code>Cvs_US</code>, or
-<code>Cvs_UK</code>, the default values
-<code>dp_ref = 1 bar</code> and
-<code>rho_ref = 1000 kg/m3</code> must not be modified.
-</p>
-<p>
-Changing these reference values currently leads to incorrect model
-behavior. The assertion level can be configured using
-<code>assertionLevel</code>.
-</p>
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/FlowControl/SpecificValveType.mo
@@ -23,6 +23,8 @@ model SpecificValveType "Specific technical valve types"
   //Set valve data as parameter
   parameter SI.Diameter d_valve = 0 "Flow diameter"
     annotation (Dialog(group="Valve parameters", enable=(flowCoefficient== FlowCoeffType.flowDiameter)));
+  parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
+   annotation(Dialog(tab="Advanced"));
 
 protected
   final parameter SI.Area A_valve=0.25*Modelica.Constants.pi*d_valve^2 "Cross-sectional area";
@@ -47,6 +49,14 @@ protected
 
 
 initial equation
+
+  assert(flowCoefficient <> FlowCoeffType.Cvs_UK, "Cvs_UK is deprecated and will be removed in TFS 2.0. Use Kvs or Cvs_US instead.", level=AssertionLevel.warning);
+  if flowCoefficient == FlowCoeffType.Kvs or
+     flowCoefficient == FlowCoeffType.Cvs_US or
+     flowCoefficient == FlowCoeffType.Cvs_UK then
+     assert(abs(dp_ref/1e5 - 1) <= Modelica.Constants.eps, "In \"" + instanceName + "\": dp_ref must remain at its default value of 1 bar when using Kvs, Cvs_US, or Cvs_UK. Remove the dp_ref modifier.", level=assertionLevel);
+     assert(abs(rho_ref/1000 - 1) <= Modelica.Constants.eps, "In \"" + instanceName + "\": rho_ref must remain at its default value of 1000 kg/m3 when using Kvs, Cvs_US, or Cvs_UK. Remove the rho_ref modifier.", level=assertionLevel);
+  end if;
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "In \"" + instanceName + "\": Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
@@ -113,5 +123,17 @@ equation
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>.
+</p>
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/FlowControl/Tests/ValveReferenceValues.mo
+++ b/ThermofluidStream/FlowControl/Tests/ValveReferenceValues.mo
@@ -1,0 +1,427 @@
+within ThermofluidStream.FlowControl.Tests;
+model ValveReferenceValues
+  "Test for Reference Values in Basic and Specific Valve"
+  extends Modelica.Icons.Example;
+
+  replaceable package medium = ThermofluidStream.Media.myMedia.Water.ConstantPropertyLiquidWater
+    constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium
+    "Medium package"
+    annotation (choicesAllMatching=true, Documentation(info="<html>
+<p>
+Medium package used in the Test.
+</p>
+</html>"));
+
+  inner ThermofluidStream.DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-12,10},{8,30}})));
+  ThermofluidStream.Boundaries.Source source(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,170},{-96,190}})));
+  FlowControl.BasicControlValve reference(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    redeclare function valveCharacteristics =
+        ThermofluidStream.FlowControl.Internal.ControlValve.linearCharacteristics,
+    Kvs=5) annotation (Placement(transformation(extent={{-10,170},{10,190}})));
+
+  ThermofluidStream.Processes.FlowResistance flowResistance(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+      k=1e3))
+    annotation (Placement(transformation(extent={{-80,170},{-60,190}})));
+  ThermofluidStream.Boundaries.Sink sink1(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,170},{116,190}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm multiSensor_Tpm2(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{-40,180},{-20,200}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm multiSensor_Tpm3(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{26,180},{46,200}})));
+  Modelica.Blocks.Sources.Ramp ramp(
+    height=1,
+    duration=10,
+    offset=0,
+    startTime=5)
+    annotation (Placement(transformation(extent={{180,-8},{160,12}})));
+  ThermofluidStream.Boundaries.Source source1(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,110},{-96,130}})));
+  FlowControl.BasicControlValve dp_ref(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    invertInput=false,
+    dp_ref=200000,
+    rho_ref(displayUnit="kg/m3"),
+    Kvs=5,
+    redeclare function valveCharacteristics =
+        Internal.ControlValve.parabolicCharacteristics,
+    m_flow_ref_set=0.1,
+    assertionLevel=AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-10,110},{10,130}})));
+
+  ThermofluidStream.Boundaries.Sink sink2(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,110},{116,130}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm multiSensor_Tpm4(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{-40,120},{-20,140}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm multiSensor_Tpm5(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{26,120},{46,140}})));
+  ThermofluidStream.Boundaries.Source source2(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,50},{-96,70}})));
+  FlowControl.BasicControlValve rho_ref(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    rho_ref=10000,
+    Kvs=5,
+    redeclare function valveCharacteristics =
+        Internal.ControlValve.equalPercentageCharacteristics,
+    assertionLevel=AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-10,50},{10,70}})));
+
+  ThermofluidStream.Boundaries.Sink sink3(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,50},{116,70}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm multiSensor_Tpm7(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{-40,60},{-20,80}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm multiSensor_Tpm8(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{26,60},{46,80}})));
+  Modelica.Blocks.Sources.Constant const2(k=1.1e5)
+    annotation (Placement(transformation(extent={{-184,-4},{-164,16}})));
+  Processes.FlowResistance flowResistance6(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+      k=1e3))
+    annotation (Placement(transformation(extent={{66,170},{86,190}})));
+  Processes.FlowResistance flowResistance1(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+      k=1e3))
+    annotation (Placement(transformation(extent={{68,110},{88,130}})));
+  Processes.FlowResistance flowResistance2(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+      k=1e3))
+    annotation (Placement(transformation(extent={{-80,110},{-60,130}})));
+  Processes.FlowResistance flowResistance3(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+      k=1e3))
+    annotation (Placement(transformation(extent={{-80,50},{-60,70}})));
+  Processes.FlowResistance flowResistance4(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss = Processes.Internal.FlowResistance.linearQuadraticPressureLoss (
+      k=1e3))
+    annotation (Placement(transformation(extent={{60,50},{80,70}})));
+  Boundaries.Source                   source3(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,-50},{-96,-30}})));
+  ThermofluidStream.FlowControl.SpecificValveType reference1(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    Kvs=5) annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
+  Processes.FlowResistance                   flowResistance5(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss =
+        Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e3))
+    annotation (Placement(transformation(extent={{-80,-50},{-60,-30}})));
+  Boundaries.Sink                   sink4(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,-50},{116,-30}})));
+  Sensors.MultiSensor_Tpm                   multiSensor_Tpm1(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
+  Sensors.MultiSensor_Tpm                   multiSensor_Tpm6(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{26,-40},{46,-20}})));
+  Boundaries.Source                   source4(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,-110},{-96,-90}})));
+  ThermofluidStream.FlowControl.SpecificValveType dp_ref1(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    invertInput=false,
+    dp_ref=200000,
+    rho_ref(displayUnit="kg/m3"),
+    Kvs=5,
+    m_flow_ref_set=0.1,
+    assertionLevel=AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
+  Boundaries.Sink                   sink5(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,-110},{116,-90}})));
+  Sensors.MultiSensor_Tpm                   multiSensor_Tpm9(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{-40,-100},{-20,-80}})));
+  Sensors.MultiSensor_Tpm                   multiSensor_Tpm10(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{26,-100},{46,-80}})));
+  Boundaries.Source                   source5(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,-170},{-96,-150}})));
+  ThermofluidStream.FlowControl.SpecificValveType rho_ref1(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    rho_ref=10000,
+    Kvs=5,
+    assertionLevel=AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-10,-170},{10,-150}})));
+  Boundaries.Sink                   sink6(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,-170},{116,-150}})));
+  Sensors.MultiSensor_Tpm                   multiSensor_Tpm11(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{-40,-160},{-20,-140}})));
+  Sensors.MultiSensor_Tpm                   multiSensor_Tpm12(redeclare package
+      Medium = medium)
+    annotation (Placement(transformation(extent={{26,-160},{46,-140}})));
+  Processes.FlowResistance flowResistance7(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss =
+        Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e3))
+    annotation (Placement(transformation(extent={{66,-50},{86,-30}})));
+  Processes.FlowResistance flowResistance8(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss =
+        Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e3))
+    annotation (Placement(transformation(extent={{68,-110},{88,-90}})));
+  Processes.FlowResistance flowResistance9(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss =
+        Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e3))
+    annotation (Placement(transformation(extent={{-80,-110},{-60,-90}})));
+  Processes.FlowResistance flowResistance10(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss =
+        Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e3))
+    annotation (Placement(transformation(extent={{-80,-170},{-60,-150}})));
+  Processes.FlowResistance flowResistance11(
+    redeclare package Medium = medium,
+    r=0.05,
+    l=1,
+    redeclare function pLoss =
+        Processes.Internal.FlowResistance.linearQuadraticPressureLoss (k=1e3))
+    annotation (Placement(transformation(extent={{60,-170},{80,-150}})));
+equation
+  connect(reference.inlet, multiSensor_Tpm2.outlet) annotation (Line(
+      points={{-10,180},{-20,180}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm3.inlet, reference.outlet) annotation (Line(
+      points={{26,180},{10,180}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(flowResistance.outlet, multiSensor_Tpm2.inlet) annotation (Line(
+      points={{-60,180},{-40,180}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(dp_ref.inlet, multiSensor_Tpm4.outlet) annotation (Line(
+      points={{-10,120},{-20,120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm5.inlet, dp_ref.outlet) annotation (Line(
+      points={{26,120},{10,120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(rho_ref.inlet, multiSensor_Tpm7.outlet) annotation (Line(
+      points={{-10,60},{-20,60}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm8.inlet, rho_ref.outlet) annotation (Line(
+      points={{26,60},{10,60}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(source2.p0_var, const2.y) annotation (Line(points={{-108,66},{-158,66},
+          {-158,6},{-163,6}},   color={0,0,127}));
+  connect(ramp.y, dp_ref.u_in) annotation (Line(points={{159,2},{124,2},{124,
+          148},{0,148},{0,128}}, color={0,0,127}));
+  connect(ramp.y, rho_ref.u_in) annotation (Line(points={{159,2},{124,2},{124,
+          88},{0,88},{0,68}}, color={0,0,127}));
+  connect(source.p0_var, const2.y) annotation (Line(points={{-108,186},{-158,
+          186},{-158,6},{-163,6}},              color={0,0,127}));
+  connect(source.outlet, flowResistance.inlet) annotation (Line(
+      points={{-96,180},{-80,180}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(const2.y, source1.p0_var) annotation (Line(points={{-163,6},{-158,6},
+          {-158,126},{-108,126}},
+                               color={0,0,127}));
+  connect(multiSensor_Tpm3.outlet, flowResistance6.inlet) annotation (Line(
+      points={{46,180},{66,180}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sink1.inlet, flowResistance6.outlet) annotation (Line(
+      points={{96,180},{86,180}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm5.outlet, flowResistance1.inlet) annotation (Line(
+      points={{46,120},{68,120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sink2.inlet, flowResistance1.outlet) annotation (Line(
+      points={{96,120},{88,120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(source1.outlet, flowResistance2.inlet) annotation (Line(
+      points={{-96,120},{-80,120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm4.inlet, flowResistance2.outlet) annotation (Line(
+      points={{-40,120},{-60,120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(source2.outlet, flowResistance3.inlet) annotation (Line(
+      points={{-96,60},{-80,60}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm7.inlet, flowResistance3.outlet) annotation (Line(
+      points={{-40,60},{-60,60}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sink3.inlet, flowResistance4.outlet) annotation (Line(
+      points={{96,60},{80,60}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm8.outlet, flowResistance4.inlet) annotation (Line(
+      points={{46,60},{60,60}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(reference.u_in, ramp.y) annotation (Line(points={{0,188},{0,208},{150,
+          208},{150,2},{159,2}}, color={0,0,127}));
+  connect(reference1.inlet, multiSensor_Tpm1.outlet) annotation (Line(
+      points={{-10,-40},{-20,-40}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm6.inlet, reference1.outlet) annotation (Line(
+      points={{26,-40},{10,-40}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(flowResistance5.outlet, multiSensor_Tpm1.inlet) annotation (Line(
+      points={{-60,-40},{-40,-40}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(dp_ref1.inlet, multiSensor_Tpm9.outlet) annotation (Line(
+      points={{-10,-100},{-20,-100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm10.inlet, dp_ref1.outlet) annotation (Line(
+      points={{26,-100},{10,-100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(rho_ref1.inlet, multiSensor_Tpm11.outlet) annotation (Line(
+      points={{-10,-160},{-20,-160}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm12.inlet, rho_ref1.outlet) annotation (Line(
+      points={{26,-160},{10,-160}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(source5.p0_var, const2.y) annotation (Line(points={{-108,-154},{-158,
+          -154},{-158,6},{-163,6}},
+                                color={0,0,127}));
+  connect(ramp.y, dp_ref1.u_in) annotation (Line(points={{159,2},{124,2},{124,
+          -72},{0,-72},{0,-92}}, color={0,0,127}));
+  connect(ramp.y, rho_ref1.u_in) annotation (Line(points={{159,2},{124,2},{124,
+          -132},{0,-132},{0,-152}}, color={0,0,127}));
+  connect(source3.p0_var, const2.y) annotation (Line(points={{-108,-34},{-158,
+          -34},{-158,6},{-163,6}}, color={0,0,127}));
+  connect(source3.outlet, flowResistance5.inlet) annotation (Line(
+      points={{-96,-40},{-80,-40}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(const2.y,source4. p0_var) annotation (Line(points={{-163,6},{-158,6},
+          {-158,-94},{-108,-94}},
+                               color={0,0,127}));
+  connect(multiSensor_Tpm6.outlet,flowResistance7. inlet) annotation (Line(
+      points={{46,-40},{66,-40}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sink4.inlet,flowResistance7. outlet) annotation (Line(
+      points={{96,-40},{86,-40}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm10.outlet, flowResistance8.inlet) annotation (Line(
+      points={{46,-100},{68,-100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sink5.inlet,flowResistance8. outlet) annotation (Line(
+      points={{96,-100},{88,-100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(source4.outlet,flowResistance9. inlet) annotation (Line(
+      points={{-96,-100},{-80,-100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm9.inlet,flowResistance9. outlet) annotation (Line(
+      points={{-40,-100},{-60,-100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(source5.outlet, flowResistance10.inlet) annotation (Line(
+      points={{-96,-160},{-80,-160}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm11.inlet, flowResistance10.outlet) annotation (Line(
+      points={{-40,-160},{-60,-160}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sink6.inlet, flowResistance11.outlet) annotation (Line(
+      points={{96,-160},{80,-160}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(multiSensor_Tpm12.outlet, flowResistance11.inlet) annotation (Line(
+      points={{46,-160},{60,-160}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(reference1.u_in, ramp.y)
+    annotation (Line(points={{0,-32},{0,2},{159,2}}, color={0,0,127}));
+  annotation (Diagram(coordinateSystem(extent={{-180,-200},{180,220}})),
+    experiment(
+      StopTime=20,
+      Interval=0.02,
+   Tolerance=1e-6,
+      __Dymola_Algorithm="Dassl"),
+    Icon(coordinateSystem(extent={{-180,-200},{180,220}})),
+    Documentation(info="<html>
+<p>Test for the BasicControlValve.</p>
+<p>Owner: <a href=\"mailto:niels.weber@dlr.de\">Niels Weber</a></p>
+</html>"));
+end ValveReferenceValues;

--- a/ThermofluidStream/FlowControl/Tests/ValveReferenceValues.mo
+++ b/ThermofluidStream/FlowControl/Tests/ValveReferenceValues.mo
@@ -413,15 +413,41 @@ equation
       thickness=0.5));
   connect(reference1.u_in, ramp.y)
     annotation (Line(points={{0,-32},{0,2},{159,2}}, color={0,0,127}));
-  annotation (Diagram(coordinateSystem(extent={{-180,-200},{180,220}})),
+  annotation (Diagram(coordinateSystem(extent={{-180,-200},{180,220}}, grid={2,
+            2})),
     experiment(
       StopTime=20,
       Interval=0.02,
    Tolerance=1e-6,
       __Dymola_Algorithm="Dassl"),
-    Icon(coordinateSystem(extent={{-180,-200},{180,220}})),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}})),
     Documentation(info="<html>
-<p>Test for the BasicControlValve.</p>
-<p>Owner: <a href=\"mailto:niels.weber@dlr.de\">Niels Weber</a></p>
+<p>
+This test model verifies the safeguards for the reference values
+<code>dp_ref</code> and <code>rho_ref</code> in
+<code>BasicControlValve</code> and <code>SpecificValveType</code>.
+</p>
+<p>
+When a valve is parameterized using <code>Kvs</code>,
+<code>Cvs_US</code>, or <code>Cvs_UK</code>, the reference values must
+remain at their defaults:
+</p>
+<ul>
+<li><code>dp_ref = 1 bar</code></li>
+<li><code>rho_ref = 1000 kg/m3</code></li>
+</ul>
+<p>
+The model contains correctly parameterized reference valves as well as
+valves with modified reference values. The latter use
+<code>assertionLevel = AssertionLevel.warning</code>, allowing the
+simulation to continue while demonstrating the corresponding assertion
+messages.
+</p>
+<p>
+The test verifies that modifying <code>dp_ref</code> or
+<code>rho_ref</code> for standardized flow coefficients is detected,
+while valves using the default reference values do not trigger these
+assertions.
+</p>
 </html>"));
 end ValveReferenceValues;

--- a/ThermofluidStream/FlowControl/Tests/package.order
+++ b/ThermofluidStream/FlowControl/Tests/package.order
@@ -5,3 +5,4 @@ SpecificValveType
 MCV
 PCV
 Switch
+ValveReferenceValues

--- a/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.FlowControl;
 model BasicControlValve "Basic valve model with optional flow characteristics for incompressible fluids"
 
-  extends ThermofluidStream.Undirected.FlowControl.Internal.PartialValve;
+  extends ThermofluidStream.Undirected.FlowControl.Internal.PartialValve (final enable_dp_rho_ref = flowCoefficient==FlowCoeffType.m_flow_set);
 
   import FlowCoeffType = ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic;
 
@@ -27,6 +27,8 @@ model BasicControlValve "Basic valve model with optional flow characteristics fo
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.Cvs_UK)));
   parameter SI.MassFlowRate m_flow_ref_set = 0 "Reference mass flow rate"
     annotation(Dialog(group = "Valve parameters",enable = (flowCoefficient ==FlowCoeffType.m_flow_set)));
+  parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
+    annotation(Dialog(tab="Advanced"), HideResult=true);
 
 protected
   final parameter SI.VolumeFlowRate V_flow_ref=
@@ -36,6 +38,23 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow rate";
 
 initial equation
+  if flowCoefficient <> FlowCoeffType.m_flow_set then
+    assert(
+      abs(dp_ref/1e5 - 1) <= Modelica.Constants.eps,
+      "In \"" + getInstanceName()
+      + "\": dp_ref must remain at its default value of 1 bar when "
+      + "m_flow_ref_set is not used. Modifying dp_ref leads to incorrect "
+      + "model behavior. Remove the dp_ref modifier.",
+      level=assertionLevel);
+
+    assert(
+      abs(rho_ref/1000 - 1) <= Modelica.Constants.eps,
+      "In \"" + getInstanceName()
+      + "\": rho_ref must remain at its default value of 1000 kg/m3 when "
+      + "m_flow_ref_set is not used. Modifying rho_ref leads to incorrect "
+      + "model behavior. Remove the rho_ref modifier.",
+      level=assertionLevel);
+  end if;
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 (or negative value) shall not be used", level=AssertionLevel.error);
@@ -94,6 +113,17 @@ equation
 <p><br>The modeler has the ability to choose between different valve characteristics and flow coefficients.</p>
 <p>The three standard curve characteristics (linear, parabolic, equal-percentage) are implemented and can be chosen.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate can be set. </p>
-<p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+<p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p> 
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>. To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.Undirected.FlowControl.Tests.ValveReferenceValues_Undirected\">ValveReferenceValues_Undirected</a>.
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/BasicControlValve.mo
@@ -124,6 +124,6 @@ When using <code>Kvs</code>, <code>Cvs_US</code>, or
 <p>
 Changing these reference values currently leads to incorrect model
 behavior. The assertion level can be configured using
-<code>assertionLevel</code>. To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.Undirected.FlowControl.Tests.ValveReferenceValues_Undirected\">ValveReferenceValues_Undirected</a>.
+<code>assertionLevel</code>. To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.Undirected.FlowControl.Tests.ValveReferenceValues_Undirected\">ValveReferenceValues_Undirected</a></p>.
 </html>"));
 end BasicControlValve;

--- a/ThermofluidStream/Undirected/FlowControl/Internal/PartialValve.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Internal/PartialValve.mo
@@ -6,12 +6,12 @@ partial model PartialValve "Partial valve model"
   parameter Boolean invertInput = false "= true, if input u_in is inverted"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter Real k_min(unit="1", min = 0.001, max = 1) = 0.03 "Remaining flow at actuation signal u = 0 (fraction of maximum mass flow at u = 1)";
-
-
+  parameter Boolean enable_dp_rho_ref "Enables/ hides showing dp_ref and rho_ref"
+    annotation (HideResult=true);
   parameter SI.Pressure dp_ref=1e5 "Reference pressure difference"
-    annotation (Dialog(tab="Advanced", group="Reference values"));
+    annotation (Dialog(tab="Advanced", group="Reference values", enable = enable_dp_rho_ref));
   parameter Medium.Density rho_ref=1000 "Reference density"
-    annotation (Dialog(tab="Advanced", group="Reference values"));
+    annotation (Dialog(tab="Advanced", group="Reference values", enable = enable_dp_rho_ref));
 
   Modelica.Blocks.Interfaces.RealInput u_in(unit="1") "Valve control signal []"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={0,80})));

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -147,6 +147,5 @@ When using <code>Kvs</code>, <code>Cvs_US</code>, or
 Changing these reference values currently leads to incorrect model
 behavior. The assertion level can be configured using
 <code>assertionLevel</code>. To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.Undirected.FlowControl.Tests.ValveReferenceValues_Undirected\">ValveReferenceValues_Undirected</a>. </p>
-</p> 
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -137,9 +137,6 @@ equation
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
 <h5>Reference values for standardized flow coefficients</h5>
-<p>When using <code>Kvs</code>, <code>Cvs_US</code>, or <code>Cvs_UK</code>, the default values <code>dp_ref = 1 bar</code> and <code>rho_ref = 1000 kg/m3</code> must not be modified. </p>
-<p>Changing these reference values currently leads to incorrect model behavior. The assertion level can be configured using <code>assertionLevel</code>. 
-<h5>Reference values for standardized flow coefficients</h5>
 <p>
 When using <code>Kvs</code>, <code>Cvs_US</code>, or
 <code>Cvs_UK</code>, the default values

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.FlowControl;
 model SpecificValveType "Specific technical valve types"
 
-  extends ThermofluidStream.Undirected.FlowControl.Internal.PartialValve;
+  extends ThermofluidStream.FlowControl.Internal.PartialValve (final enable_dp_rho_ref = flowCoefficient==FlowCoeffType.m_flow_set);
 
   import FlowCoeffType = ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypes;
 

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -1,7 +1,7 @@
 within ThermofluidStream.Undirected.FlowControl;
 model SpecificValveType "Specific technical valve types"
 
-  extends ThermofluidStream.FlowControl.Internal.PartialValve (final enable_dp_rho_ref = flowCoefficient==FlowCoeffType.m_flow_set);
+  extends ThermofluidStream.Undirected.FlowControl.Internal.PartialValve (final enable_dp_rho_ref = flowCoefficient==FlowCoeffType.m_flow_set);
 
   import FlowCoeffType = ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypes;
 

--- a/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
+++ b/ThermofluidStream/Undirected/FlowControl/SpecificValveType.mo
@@ -24,6 +24,8 @@ model SpecificValveType "Specific technical valve types"
   //Set valve data as parameter
   parameter SI.Diameter d_valve = 0 "Flow diameter"
     annotation (Dialog(group="Valve parameters", enable=(flowCoefficient== FlowCoeffType.flowDiameter)));
+  parameter AssertionLevel assertionLevel=AssertionLevel.error "Assertion level for invalid reference values"
+    annotation(Dialog(tab="Advanced"), HideResult=true);
 
 protected
   constant ZetaValueRecord valveData;
@@ -48,6 +50,25 @@ protected
     else m_flow_ref_set/rho_ref "Reference volume flow rate";
 
 initial equation
+  if flowCoefficient == FlowCoeffType.Kvs or
+     flowCoefficient == FlowCoeffType.Cvs_US or
+     flowCoefficient == FlowCoeffType.Cvs_UK then
+    assert(
+      abs(dp_ref/1e5 - 1) <= Modelica.Constants.eps,
+      "In \"" + getInstanceName()
+      + "\": dp_ref must remain at its default value of 1 bar when using "
+      + "Kvs, Cvs_US, or Cvs_UK. Modifying dp_ref leads to incorrect "
+      + "model behavior. Remove the dp_ref modifier.",
+      level=assertionLevel);
+
+    assert(
+      abs(rho_ref/1000 - 1) <= Modelica.Constants.eps,
+      "In \"" + getInstanceName()
+      + "\": rho_ref must remain at its default value of 1000 kg/m3 when "
+      + "using Kvs, Cvs_US, or Cvs_UK. Modifying rho_ref leads to incorrect "
+      + "model behavior. Remove the rho_ref modifier.",
+      level=assertionLevel);
+  end if;
   //this if clause shall ensure that valid parameters have been entered
   if flowCoefficient == FlowCoeffType.Kvs then
     assert(Kvs > 0, "Invalid coefficient for Kvs. Default value 0 shall not be used", level=AssertionLevel.error);
@@ -115,5 +136,20 @@ equation
 <p><br>The technical type of the valve can be chosen (e.g. sliding valve). The characteristic curve is then set accordingly from a table for the zeta (flow resistance) values dependent on the valve opening.</p>
 <p><br>To conclude the parameterization, a flow coefficient has to be set. Most data sheets of valves deliver a corresponding &quot;KVs (CVs)&quot;-Value. Otherwise a nominal mass-flow rate or a flow-diameter can be set. </p>
 <p>For incompressible flow, the reference values for density (1g/cm3) and pressure (1bar) should be unchanged.</p>
+<h5>Reference values for standardized flow coefficients</h5>
+<p>When using <code>Kvs</code>, <code>Cvs_US</code>, or <code>Cvs_UK</code>, the default values <code>dp_ref = 1 bar</code> and <code>rho_ref = 1000 kg/m3</code> must not be modified. </p>
+<p>Changing these reference values currently leads to incorrect model behavior. The assertion level can be configured using <code>assertionLevel</code>. 
+<h5>Reference values for standardized flow coefficients</h5>
+<p>
+When using <code>Kvs</code>, <code>Cvs_US</code>, or
+<code>Cvs_UK</code>, the default values
+<code>dp_ref = 1 bar</code> and
+<code>rho_ref = 1000 kg/m3</code> must not be modified.
+</p>
+<p>
+Changing these reference values currently leads to incorrect model
+behavior. The assertion level can be configured using
+<code>assertionLevel</code>. To test this behavior, a test model has been setup in <a href=\"modelica://ThermofluidStream.Undirected.FlowControl.Tests.ValveReferenceValues_Undirected\">ValveReferenceValues_Undirected</a>. </p>
+</p> 
 </html>"));
 end SpecificValveType;

--- a/ThermofluidStream/Undirected/FlowControl/Tests/ValveReferenceValues_Undirected.mo
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/ValveReferenceValues_Undirected.mo
@@ -1,0 +1,246 @@
+within ThermofluidStream.Undirected.FlowControl.Tests;
+model ValveReferenceValues_Undirected
+  "Test for Reference Values in Basic and Specific Valve in undirected flow"
+  extends Modelica.Icons.Example;
+
+  replaceable package medium = ThermofluidStream.Media.myMedia.Water.ConstantPropertyLiquidWater
+    constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium
+    "Medium package"
+    annotation (choicesAllMatching=true, Documentation(info="<html>
+<p>
+Medium package used in the Test.
+</p>
+</html>"));
+
+  inner ThermofluidStream.DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-12,10},{8,30}})));
+  Boundaries.BoundaryRear             boundaryRear(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,170},{-96,190}})));
+  ThermofluidStream.Undirected.FlowControl.BasicControlValve reference(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    dp_ref=200000,
+    redeclare function valveCharacteristics =
+        ThermofluidStream.FlowControl.Internal.ControlValve.linearCharacteristics,
+    flowCoefficient=ThermofluidStream.FlowControl.Internal.Types.FlowCoefficientTypesBasic.m_flow_set,
+    Kvs=5,
+    Cvs_UK=0.1,
+    m_flow_ref_set=1)
+    annotation (Placement(transformation(extent={{-10,170},{10,190}})));
+
+  Boundaries.BoundaryFore           boundaryFore(
+                                          redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,170},{116,190}})));
+  Modelica.Blocks.Sources.Ramp ramp(
+    height=1,
+    duration=10,
+    offset=0,
+    startTime=5)
+    annotation (Placement(transformation(extent={{180,-8},{160,12}})));
+  Boundaries.BoundaryRear             boundaryRear2(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,110},{-96,130}})));
+  ThermofluidStream.Undirected.FlowControl.BasicControlValve dp_ref(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    invertInput=false,
+    dp_ref=200000,
+    rho_ref(displayUnit="kg/m3"),
+    Kvs=5,
+    redeclare function valveCharacteristics =
+        ThermofluidStream.FlowControl.Internal.ControlValve.parabolicCharacteristics,
+    Cvs_UK=0.1,
+    m_flow_ref_set=0.1,
+    assertionLevel=AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-10,110},{10,130}})));
+
+  Boundaries.BoundaryFore           boundaryFore2(
+                                          redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,110},{116,130}})));
+  Boundaries.BoundaryRear             boundaryRear3(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,50},{-96,70}})));
+  ThermofluidStream.Undirected.FlowControl.BasicControlValve rho_ref(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    rho_ref=10000,
+    Kvs=5,
+    redeclare function valveCharacteristics =
+        ThermofluidStream.FlowControl.Internal.ControlValve.equalPercentageCharacteristics,
+    assertionLevel=AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-10,50},{10,70}})));
+
+  Boundaries.BoundaryFore           boundaryFore3(
+                                          redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,50},{116,70}})));
+  Modelica.Blocks.Sources.Constant const2(k=1.1e5)
+    annotation (Placement(transformation(extent={{-184,-4},{-164,16}})));
+  Boundaries.BoundaryRear boundaryRear4(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,-50},{-96,-30}})));
+  ThermofluidStream.Undirected.FlowControl.SpecificValveType
+                                                  reference1(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    Kvs=5) annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
+  Boundaries.BoundaryFore boundaryFore4(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,-50},{116,-30}})));
+  Boundaries.BoundaryRear boundaryRear5(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,-110},{-96,-90}})));
+  ThermofluidStream.Undirected.FlowControl.SpecificValveType
+                                                  dp_ref1(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    invertInput=false,
+    dp_ref=200000,
+    rho_ref(displayUnit="kg/m3"),
+    Kvs=5,
+    m_flow_ref_set=0.1,
+    assertionLevel=AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
+  Boundaries.BoundaryFore boundaryFore5(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,-110},{116,-90}})));
+  Boundaries.BoundaryRear boundaryRear1(
+    redeclare package Medium = medium,
+    pressureFromInput=true,
+    T0_par(displayUnit="K") = 300)
+    annotation (Placement(transformation(extent={{-116,-170},{-96,-150}})));
+  ThermofluidStream.Undirected.FlowControl.SpecificValveType
+                                                  rho_ref1(
+    redeclare package Medium = medium,
+    initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
+    rho_ref=10000,
+    Kvs=5,
+    assertionLevel=AssertionLevel.warning)
+    annotation (Placement(transformation(extent={{-10,-170},{10,-150}})));
+  Boundaries.BoundaryFore boundaryFore1(redeclare package Medium = medium,
+      p0_par=100000)
+    annotation (Placement(transformation(extent={{96,-170},{116,-150}})));
+equation
+  connect(boundaryRear3.p0_var, const2.y) annotation (Line(points={{-108,66},{-158,
+          66},{-158,6},{-163,6}}, color={0,0,127}));
+  connect(ramp.y, dp_ref.u_in) annotation (Line(points={{159,2},{124,2},{124,
+          148},{0,148},{0,128}}, color={0,0,127}));
+  connect(ramp.y, rho_ref.u_in) annotation (Line(points={{159,2},{124,2},{124,
+          88},{0,88},{0,68}}, color={0,0,127}));
+  connect(boundaryRear.p0_var, const2.y) annotation (Line(points={{-108,186},{-158,
+          186},{-158,6},{-163,6}}, color={0,0,127}));
+  connect(const2.y, boundaryRear2.p0_var) annotation (Line(points={{-163,6},{-158,
+          6},{-158,126},{-108,126}}, color={0,0,127}));
+  connect(reference.u_in, ramp.y) annotation (Line(points={{0,188},{0,208},{150,
+          208},{150,2},{159,2}}, color={0,0,127}));
+  connect(boundaryRear1.p0_var, const2.y) annotation (Line(points={{-108,-154},
+          {-158,-154},{-158,6},{-163,6}}, color={0,0,127}));
+  connect(ramp.y, dp_ref1.u_in) annotation (Line(points={{159,2},{124,2},{124,
+          -72},{0,-72},{0,-92}}, color={0,0,127}));
+  connect(ramp.y, rho_ref1.u_in) annotation (Line(points={{159,2},{124,2},{124,
+          -132},{0,-132},{0,-152}}, color={0,0,127}));
+  connect(boundaryRear4.p0_var, const2.y) annotation (Line(points={{-108,-34},{
+          -158,-34},{-158,6},{-163,6}}, color={0,0,127}));
+  connect(const2.y, boundaryRear5.p0_var) annotation (Line(points={{-163,6},{-158,
+          6},{-158,-94},{-108,-94}}, color={0,0,127}));
+  connect(reference1.u_in, ramp.y)
+    annotation (Line(points={{0,-32},{0,2},{159,2}}, color={0,0,127}));
+  connect(boundaryRear.fore, reference.rear) annotation (Line(
+      points={{-96,180},{-10,180}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(reference.fore, boundaryFore.rear) annotation (Line(
+      points={{10,180},{96,180}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(dp_ref.rear, boundaryRear2.fore) annotation (Line(
+      points={{-10,120},{-96,120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(dp_ref.fore, boundaryFore2.rear) annotation (Line(
+      points={{10,120},{96,120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(boundaryRear3.fore, rho_ref.rear) annotation (Line(
+      points={{-96,60},{-10,60}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(rho_ref.fore, boundaryFore3.rear) annotation (Line(
+      points={{10,60},{96,60}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(boundaryRear4.fore, reference1.rear) annotation (Line(
+      points={{-96,-40},{-10,-40}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(reference1.fore, boundaryFore4.rear) annotation (Line(
+      points={{10,-40},{96,-40}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(boundaryRear5.fore, dp_ref1.rear) annotation (Line(
+      points={{-96,-100},{-10,-100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(dp_ref1.fore, boundaryFore5.rear) annotation (Line(
+      points={{10,-100},{96,-100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(boundaryRear1.fore, rho_ref1.rear) annotation (Line(
+      points={{-96,-160},{-10,-160}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(rho_ref1.fore, boundaryFore1.rear) annotation (Line(
+      points={{10,-160},{96,-160}},
+      color={28,108,200},
+      thickness=0.5));
+  annotation (Diagram(coordinateSystem(extent={{-180,-200},{180,220}}, grid={2,
+            2})),
+    experiment(
+      StopTime=20,
+      Interval=0.02,
+   Tolerance=1e-6,
+      __Dymola_Algorithm="Dassl"),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}})),
+    Documentation(info="<html>
+<p>
+This test model verifies the safeguards for the reference values
+<code>dp_ref</code> and <code>rho_ref</code> in
+<code>BasicControlValve</code> and <code>SpecificValveType</code>.
+</p>
+<p>
+When a valve is parameterized using <code>Kvs</code>,
+<code>Cvs_US</code>, or <code>Cvs_UK</code>, the reference values must
+remain at their defaults:
+</p>
+<ul>
+<li><code>dp_ref = 1 bar</code></li>
+<li><code>rho_ref = 1000 kg/m3</code></li>
+</ul>
+<p>
+The model contains correctly parameterized reference valves as well as
+valves with modified reference values. The latter use
+<code>assertionLevel = AssertionLevel.warning</code>, allowing the
+simulation to continue while demonstrating the corresponding assertion
+messages.
+</p>
+<p>
+The test verifies that modifying <code>dp_ref</code> or
+<code>rho_ref</code> for standardized flow coefficients is detected,
+while valves using the default reference values do not trigger these
+assertions.
+</p>
+</html>"));
+end ValveReferenceValues_Undirected;

--- a/ThermofluidStream/Undirected/FlowControl/Tests/package.order
+++ b/ThermofluidStream/Undirected/FlowControl/Tests/package.order
@@ -3,3 +3,4 @@ TanValve
 BasicControlValve
 SpecificValveType
 MCV
+ValveReferenceValues_Undirected


### PR DESCRIPTION
## Description

This merge request adds safeguards for the reference values `dp_ref` and `rho_ref` in `BasicControlValve` and `SpecificValveType`.

When `flowCoefficient` is set to `Kvs`, `Cvs_US`, or `Cvs_UK`, the models now assert that:

- `dp_ref` remains at its default value of `1 bar`
- `rho_ref` remains at its default value of `1000 kg/m3`

Changing these parameters currently leads to incorrect model behavior. The assertion messages therefore instruct the user to remove the corresponding modifier.

A configurable `assertionLevel` parameter was added so that the checks can be evaluated as errors or warnings.

## Additional changes

- Added the affected valve instance name to the new assertion messages.
- Added documentation describing the restrictions on `dp_ref` and `rho_ref`.
- Added a test model covering valid and invalid reference-value parameterizations.
- Updated `package.order` for the new test model.
- Kept the existing valve equations, flow-coefficient conversions, and coefficient validation unchanged.

## Validation

The following cases were checked:

- default `dp_ref` and `rho_ref` with `Kvs`
- modified `dp_ref` with `Kvs`
- modified `rho_ref` with `Cvs_US`
- configurable warning behavior through `assertionLevel`
- no new reference-value assertion for other flow-coefficient types

Closes #280.