### PR TITLE
Improve SimpleAirCycle example

### DIFF
--- a/ThermofluidStream/Examples/SimpleAirCycle.mo
+++ b/ThermofluidStream/Examples/SimpleAirCycle.mo
@@ -2,64 +2,63 @@ within ThermofluidStream.Examples;
 model SimpleAirCycle "Basic bootstrap cooling cycle"
   extends Modelica.Icons.Example;
 
-  replaceable package Medium = ThermofluidStream.Media.myMedia.Air.MoistAir constrainedby ThermofluidStream.Media.myMedia.Interfaces.PartialMedium
-    "Medium (ram and bleed air)"
-    annotation(choicesAllMatching = true);
+  replaceable package Medium = ThermofluidStream.Media.myMedia.Air.MoistAir constrainedby
+    ThermofluidStream.Media.myMedia.Interfaces.PartialMedium "Medium (ram and bleed air)" annotation (
+      choicesAllMatching=true);
+  parameter SI.Radius r=0.07 "Ram air duct radius";
 
-  parameter SI.Radius r=0.07   "Ram air duct radius";
-  inner DropOfCommons dropOfCommons(assertionLevel = AssertionLevel.warning,
+  inner ThermofluidStream.DropOfCommons dropOfCommons(
+    assertionLevel=AssertionLevel.warning,
     displayInstanceNames=true,
-    displayParameters=true)
-    annotation (Placement(transformation(extent={{-10,60},{10,80}})));
+    displayParameters=true) annotation (Placement(transformation(extent={{-10,60},{10,80}})));
 
   ThermofluidStream.Utilities.Icons.DLRLogo dLRLogo annotation (Placement(transformation(extent={{-18,102},{18,138}})));
-  Boundaries.Source bleedInlet(
+  ThermofluidStream.Boundaries.Source bleedInlet(
     redeclare package Medium = Medium,
     T0_par=473.15,
     p0_par=220000,
     Xi0_par={0}) annotation (Placement(transformation(extent={{-4,-130},{-24,-110}})));
-  Boundaries.Sink packDischarge(redeclare package Medium = Medium, p0_par=80000)
-    annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=90,
-        origin={-54,116})));
-  Boundaries.Source ramInlet(
+  ThermofluidStream.Boundaries.Sink packDischarge(redeclare package Medium = Medium, p0_par=80000) annotation (
+      Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=180,
+        origin={-130,100})));
+  ThermofluidStream.Boundaries.Source ramInlet(
     redeclare package Medium = Medium,
-    T0_par=243.15,
-    p0_par=25000,
+    T0_par=238.65,
+    p0_par=37600,
     Xi0_par={0}) annotation (Placement(transformation(extent={{-160,40},{-140,60}})));
-  Boundaries.DynamicPressureInflow dynamicPressure(
+  ThermofluidStream.Boundaries.DynamicPressureInflow dynamicPressure(
     displayInstanceName=false,
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=0,
     assumeConstantDensity=false,
     velocityFromInput=false,
-    v_in_par=230,
+    v_in_par=155,
     A_par=r^2*Modelica.Constants.pi,
     displayOutletArea=false) annotation (Placement(transformation(extent={{-120,40},{-100,60}})));
-  Boundaries.Sink ramOutlet(
+  ThermofluidStream.Boundaries.Sink ramOutlet(
     redeclare package Medium = Medium,
     pressureFromInput=false,
-    p0_par=30000) annotation (Placement(transformation(
+    p0_par=37600) annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=0,
-        origin={-130,-120})));
-  Processes.Compressor compressor(
+        origin={-150,-120})));
+  ThermofluidStream.Processes.Compressor compressor(
     redeclare package Medium = Medium,
     omega_from_input=false,
     initPhi=false,
-    redeclare function dp_tau_compressor =
-        Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+    redeclare function dp_tau_compressor = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=2500,
         skew=1,
         m_flow_ref=1,
         eta=0.9))
-                annotation (Placement(transformation(
+    annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={-54,0})));
-  Processes.Turbine turbine(
+        origin={-54,6})));
+  ThermofluidStream.Processes.Turbine turbine(
     redeclare package Medium = Medium,
     L=5e2,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
@@ -69,27 +68,17 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     omega_0=0,
     initPhi=true,
     phi_0=0,
-    redeclare function dp_tau_turbine = Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+    redeclare function dp_tau_turbine = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=Modelica.Constants.inf,
         m_flow_ref=0.36,
         skew=-0.2,
         k=2,
         eta=0.93))
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={-54,60})));
-  HeatExchangers.CounterFlowNTU                   mainHex(
-    redeclare package MediumA = Medium,
-    redeclare package MediumB = Medium,
-    A=2,
-    k_NTU=200,
-    L=1,
-    TC=10,
-    displaykNTU=false) annotation (Placement(transformation(
-        extent={{10,10},{-10,-10}},
-        rotation=270,
-        origin={-60,30})));
-  HeatExchangers.CounterFlowNTU                   primaryHex(
+        origin={-54,66})));
+  ThermofluidStream.HeatExchangers.CounterFlowNTU mainHex(
     redeclare package MediumA = Medium,
     redeclare package MediumB = Medium,
     A=3,
@@ -99,68 +88,78 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     displaykNTU=false) annotation (Placement(transformation(
         extent={{10,10},{-10,-10}},
         rotation=270,
-        origin={-60,-30})));
-  Processes.Fan fan(redeclare package Medium = Medium,     redeclare function dp_tau_fan =
-        Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+        origin={-60,34})));
+  ThermofluidStream.HeatExchangers.CounterFlowNTU primaryHex(
+    redeclare package MediumA = Medium,
+    redeclare package MediumB = Medium,
+    A=2,
+    k_NTU=200,
+    L=1,
+    TC=10,
+    displaykNTU=false) annotation (Placement(transformation(
+        extent={{10,10},{-10,-10}},
+        rotation=270,
+        origin={-60,-22})));
+  ThermofluidStream.Processes.Fan fan(redeclare package Medium = Medium, redeclare function dp_tau_fan =
+        ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=500,
         skew=1,
         m_flow_ref=0.21,
-        eta=0.7))
-                annotation (Placement(transformation(
+        eta=0.7)) annotation (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=270,
-        origin={-66,-90})));
-  Processes.FlowResistance pipe(
+        origin={-66,-82})));
+  ThermofluidStream.Processes.FlowResistance pipe(
     redeclare package Medium = Medium,
     r=r,
-    l=20,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (material=
-            ThermofluidStream.Processes.Internal.Material.steel))
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
+    l=5,
+    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland
+      "Laminar-turbulent (Haaland1983)",
+    pressureDropUnit=ThermofluidStream.Types.PressureUnit.kPa,
+    pressureDropSignificantDigits=2) annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
         rotation=90,
-        origin={-66,-60})));
-  Processes.FlowResistance outflowLoss(
+        origin={-66,-54})));
+  ThermofluidStream.Processes.FlowResistance outflowLoss(
     redeclare package Medium = Medium,
     r=r,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
+    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
     computeL=false,
-    L_value=0) annotation (Placement(transformation(extent={{-80,-110},{-100,-130}})));
-  Boundaries.Source bleedInlet1(
+    L_value=0) annotation (Placement(transformation(extent={{-110,-110},{-130,-130}})));
+  ThermofluidStream.Boundaries.Source bleedInlet1(
     redeclare package Medium = Medium,
     T0_par=473.15,
     p0_par=220000,
     Xi0_par={0}) annotation (Placement(transformation(extent={{4,-130},{24,-110}})));
-  Boundaries.Sink packDischarge1(redeclare package Medium = Medium, p0_par=
-        80000)
+  ThermofluidStream.Boundaries.Sink packDischarge1(redeclare package Medium = Medium, p0_par=80000)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
-        rotation=90,
-        origin={52,118})));
-  Boundaries.Source ramInlet1(
+        rotation=0,
+        origin={130,100})));
+  ThermofluidStream.Boundaries.Source ramInlet1(
     redeclare package Medium = Medium,
-    T0_par=243.15,
-    p0_par=25000,
+    T0_par=238.65,
+    p0_par=37600,
     Xi0_par={0}) annotation (Placement(transformation(extent={{160,40},{140,60}})));
-  Boundaries.DynamicPressureInflow dynamicPressure1(
+  ThermofluidStream.Boundaries.DynamicPressureInflow dynamicPressure1(
     displayInstanceName=false,
     redeclare package Medium = Medium,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
     m_flow_0=0,
     assumeConstantDensity=false,
     velocityFromInput=false,
-    v_in_par=230,
+    v_in_par=155,
     A_par=r^2*Modelica.Constants.pi,
-    displayOutletArea=false) annotation (Placement(transformation(extent={{120,40},{100,60}})));
-  Boundaries.Sink ramOutlet1(
+    displayOutletArea=false) annotation (Placement(transformation(extent={{126,40},{106,60}})));
+  ThermofluidStream.Boundaries.Sink ramOutlet1(
     redeclare package Medium = Medium,
     pressureFromInput=false,
-    p0_par=30000)
-    annotation (Placement(transformation(
+    p0_par=37600) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
-        origin={120,-120})));
-  Processes.Turbine turbine1(
+        origin={150,-120})));
+  ThermofluidStream.Processes.Turbine turbine1(
     redeclare package Medium = Medium,
     L=5e2,
     initM_flow=ThermofluidStream.Utilities.Types.InitializationMethods.state,
@@ -170,16 +169,17 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     omega_0=0,
     initPhi=true,
     phi_0=0,
-    redeclare function dp_tau_turbine = Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+    redeclare function dp_tau_turbine = ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=Modelica.Constants.inf,
         m_flow_ref=0.3658,
         skew=-0.2,
         k=2,
         eta=0.93))
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
+    annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
         rotation=270,
         origin={52,60})));
-  HeatExchangers.CounterFlowNTU                   hex(
+  ThermofluidStream.HeatExchangers.CounterFlowNTU hex(
     redeclare package MediumA = Medium,
     redeclare package MediumB = Medium,
     A=5,
@@ -191,31 +191,102 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
         extent={{-10,10},{10,-10}},
         rotation=270,
         origin={58,0})));
-  Processes.Fan fan1(redeclare package Medium = Medium,     redeclare function dp_tau_fan =
-        Processes.Internal.TurboComponent.dp_tau_const_isentrop (
+  ThermofluidStream.Processes.Fan fan1(redeclare package Medium = Medium, redeclare function dp_tau_fan =
+        ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=1000,
         skew=1,
-        eta=0.7))
-                annotation (Placement(transformation(
+        eta=0.7)) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={64,-90})));
-  Processes.FlowResistance pipe1(
+        origin={64,-72})));
+  ThermofluidStream.Processes.FlowResistance pipe1(
     redeclare package Medium = Medium,
     r=r,
-    l=20,
-    redeclare function pLoss = Processes.Internal.FlowResistance.laminarTurbulentPressureLoss (material=
-            ThermofluidStream.Processes.Internal.Material.steel))
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+    l=5,
+    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.laminarTurbulentPressureLossHaaland
+      "Laminar-turbulent (Haaland1983)",
+    pressureDropUnit=ThermofluidStream.Types.PressureUnit.kPa,
+    pressureDropSignificantDigits=2) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={64,-60})));
-  Processes.FlowResistance outflowLoss1(
+        origin={64,-42})));
+  ThermofluidStream.Processes.FlowResistance outflowLoss1(
     redeclare package Medium = Medium,
     r=r,
     l=1,
-    redeclare function pLoss = Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
+    redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
     computeL=false,
-    L_value=0) annotation (Placement(transformation(extent={{80,-110},{100,-130}})));
+    L_value=0) annotation (Placement(transformation(extent={{112,-110},{132,-130}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm packDischargeSensor(
+    redeclare package Medium = Medium,
+    digits=2,
+    temperatureUnit="degC",
+    pressureUnit="bar") annotation (Placement(transformation(extent={{-80,100},{-100,120}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm packDischargeSensor1(
+    redeclare package Medium = Medium,
+    digits=2,
+    temperatureUnit="degC",
+    pressureUnit="bar") annotation (Placement(transformation(extent={{82,100},{102,120}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm ramOutSensor(
+    redeclare package Medium = Medium,
+    digits=2,
+    temperatureUnit="degC",
+    pressureUnit="bar") annotation (Placement(transformation(extent={{-80,-120},{-100,-100}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm ramOutSensor1(
+    redeclare package Medium = Medium,
+    digits=2,
+    temperatureUnit="degC",
+    pressureUnit="bar") annotation (Placement(transformation(extent={{80,-120},{100,-100}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm ramInletSensor(
+    redeclare package Medium = Medium,
+    digits=2,
+    temperatureUnit="degC",
+    pressureUnit="bar") annotation (Placement(transformation(extent={{-90,50},{-70,70}})));
+  ThermofluidStream.Sensors.MultiSensor_Tpm ramInletSensor1(
+    redeclare package Medium = Medium,
+    digits=2,
+    temperatureUnit="degC",
+    pressureUnit="bar") annotation (Placement(transformation(extent={{92,50},{72,70}})));
+  ThermofluidStream.Utilities.showRealValue CoolingPower_kW(
+    description="Cooling Power [kW]",
+    use_numberPort=false,
+    number=-turbine.m_flow*1.005*(packDischarge.inlet.state.T - bleedInlet.outlet.state.T),
+    significantDigits=3) annotation (Placement(transformation(extent={{-160,-40},{-100,-20}})));
+  ThermofluidStream.Utilities.showRealValue CoolingPower_kW1(
+    description="Cooling Power [kW]",
+    use_numberPort=false,
+    number=-turbine1.m_flow*1.005*(packDischarge1.inlet.state.T - bleedInlet1.outlet.state.T),
+    significantDigits=3) annotation (Placement(transformation(extent={{100,-40},{160,-20}})));
+  Sensors.SingleSensorSelect sensorMainHXRam(
+    redeclare package Medium = Medium,
+    digits=3,
+    quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
+    annotation (Placement(transformation(extent={{-72,-6},{-92,14}})));
+  Sensors.SingleSensorSelect sensorHXRam1(
+    redeclare package Medium = Medium,
+    digits=2,
+    quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
+    annotation (Placement(transformation(extent={{74,-26},{94,-6}})));
+  Sensors.SingleSensorSelect sensorPrimaryHXRam(
+    redeclare package Medium = Medium,
+    digits=3,
+    quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
+    annotation (Placement(transformation(extent={{-72,-48},{-92,-28}})));
+  Sensors.SingleSensorSelect sensorMainHX(
+    redeclare package Medium = Medium,
+    digits=3,
+    quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
+    annotation (Placement(transformation(extent={{-46,40},{-26,60}})));
+  Sensors.SingleSensorSelect sensorPrimaryHX(
+    redeclare package Medium = Medium,
+    digits=3,
+    quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
+    annotation (Placement(transformation(extent={{-48,-18},{-28,2}})));
+  Sensors.SingleSensorSelect sensorMainHX1(
+    redeclare package Medium = Medium,
+    digits=2,
+    quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
+    annotation (Placement(transformation(extent={{46,20},{26,40}})));
 equation
   connect(ramInlet.outlet, dynamicPressure.inlet)
     annotation (Line(
@@ -224,53 +295,42 @@ equation
       thickness=0.5));
   connect(pipe.outlet, fan.inlet)
     annotation (Line(
-      points={{-66,-70},{-66,-80}},
-      color={28,108,200},
-      thickness=0.5));
-  connect(fan.outlet, outflowLoss.inlet)
-    annotation (Line(
-      points={{-66,-100},{-66,-120},{-80,-120}},
+      points={{-66,-64},{-66,-72}},
       color={28,108,200},
       thickness=0.5));
   connect(bleedInlet.outlet, primaryHex.inletA)
     annotation (Line(
-      points={{-24,-120},{-54,-120},{-54,-40}},
+      points={{-24,-120},{-54,-120},{-54,-32}},
       color={28,108,200},
       thickness=0.5));
   connect(primaryHex.outletA, compressor.inlet)
     annotation (Line(
-      points={{-54,-20},{-54,-10}},
+      points={{-54,-12},{-54,-4}},
       color={28,108,200},
       thickness=0.5));
   connect(compressor.outlet, mainHex.inletA)
     annotation (Line(
-      points={{-54,10},{-54,20}},
+      points={{-54,16},{-54,24}},
       color={28,108,200},
       thickness=0.5));
   connect(mainHex.outletA, turbine.inlet)
     annotation (Line(
-      points={{-54,40},{-54,44},{-54,44},{-54,50}},
-      color={28,108,200},
-      thickness=0.5));
-  connect(dynamicPressure.outlet, mainHex.inletB)
-    annotation (Line(
-      points={{-100,50},{-66,50},{-66,40}},
+      points={{-54,44},{-54,56}},
       color={28,108,200},
       thickness=0.5));
   connect(mainHex.outletB, primaryHex.inletB)
     annotation (Line(
-      points={{-66,20},{-66,-20}},
+      points={{-66,24},{-66,-12}},
       color={28,108,200},
       thickness=0.5));
   connect(primaryHex.outletB, pipe.inlet)
     annotation (Line(
-      points={{-66,-40},{-66,-50}},
+      points={{-66,-32},{-66,-44}},
       color={28,108,200},
       thickness=0.5));
-  connect(fan.flange, compressor.flange)
-    annotation (Line(points={{-56,-90},{-38,-90},{-38,0},{-44,0},{-44,-6.10623e-16}}, color={0,0,0}));
+  connect(fan.flange, compressor.flange) annotation (Line(points={{-56,-82},{-26,-82},{-26,6},{-44,6}}, color={0,0,0}));
   connect(turbine.flange, compressor.flange)
-    annotation (Line(points={{-44,60},{-38,60},{-38,-6.10623e-16},{-44,-6.10623e-16}}, color={0,0,0}));
+    annotation (Line(points={{-44,66},{-26,66},{-26,6},{-44,6}}, color={0,0,0}));
   connect(bleedInlet1.outlet, hex.inletB)
     annotation (Line(
       points={{24,-120},{52,-120},{52,-10}},
@@ -281,49 +341,120 @@ equation
       points={{52,10},{52,50}},
       color={28,108,200},
       thickness=0.5));
-  connect(turbine1.outlet, packDischarge1.inlet)
-    annotation (Line(
-      points={{52,70},{52,108}},
-      color={28,108,200},
-      thickness=0.5));
   connect(ramInlet1.outlet, dynamicPressure1.inlet)
     annotation (Line(
-      points={{140,50},{120,50}},
-      color={28,108,200},
-      thickness=0.5));
-  connect(dynamicPressure1.outlet, hex.inletA)
-    annotation (Line(
-      points={{100,50},{64,50},{64,10}},
+      points={{140,50},{126,50}},
       color={28,108,200},
       thickness=0.5));
   connect(hex.outletA, pipe1.inlet)
     annotation (Line(
-      points={{64,-10},{64,-50}},
+      points={{64,-10},{64,-32}},
       color={28,108,200},
       thickness=0.5));
   connect(pipe1.outlet, fan1.inlet)
     annotation (Line(
-      points={{64,-70},{64,-80}},
-      color={28,108,200},
-      thickness=0.5));
-  connect(fan1.outlet, outflowLoss1.inlet)
-    annotation (Line(
-      points={{64,-100},{64,-120},{80,-120}},
+      points={{64,-52},{64,-62}},
       color={28,108,200},
       thickness=0.5));
   connect(outflowLoss1.outlet, ramOutlet1.inlet)
     annotation (Line(
-      points={{100,-120},{110,-120}},
+      points={{132,-120},{140,-120}},
       color={28,108,200},
       thickness=0.5));
-  connect(turbine1.flange, fan1.flange) annotation (Line(points={{42,60},{34,60},{34,-90},{54,-90}}, color={0,0,0}));
+  connect(turbine1.flange, fan1.flange) annotation (Line(points={{42,60},{22,60},{22,-72},{54,-72}}, color={0,0,0}));
   connect(ramOutlet.inlet, outflowLoss.outlet)
     annotation (Line(
-      points={{-120,-120},{-100,-120}},
+      points={{-140,-120},{-130,-120}},
       color={28,108,200},
       thickness=0.5));
-  connect(packDischarge.inlet, turbine.outlet) annotation (Line(
-      points={{-54,106},{-54,70}},
+  connect(packDischarge.inlet, packDischargeSensor.outlet)
+    annotation (Line(
+      points={{-120,100},{-100,100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(packDischargeSensor.inlet, turbine.outlet)
+    annotation (Line(
+      points={{-80,100},{-54,100},{-54,76}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(turbine1.outlet, packDischargeSensor1.inlet)
+    annotation (Line(
+      points={{52,70},{52,100},{82,100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(packDischargeSensor1.outlet, packDischarge1.inlet)
+    annotation (Line(
+      points={{102,100},{120,100}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(fan.outlet, ramOutSensor.inlet)
+    annotation (Line(
+      points={{-66,-92},{-66,-120},{-80,-120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(ramOutSensor.outlet, outflowLoss.inlet)
+    annotation (Line(
+      points={{-100,-120},{-110,-120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(fan1.outlet, ramOutSensor1.inlet)
+    annotation (Line(
+      points={{64,-82},{64,-120},{80,-120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(ramOutSensor1.outlet, outflowLoss1.inlet)
+    annotation (Line(
+      points={{100,-120},{112,-120}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(dynamicPressure.outlet, ramInletSensor.inlet)
+    annotation (Line(
+      points={{-100,50},{-90,50}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(ramInletSensor.outlet, mainHex.inletB)
+    annotation (Line(
+      points={{-70,50},{-66,50},{-66,44}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(dynamicPressure1.outlet, ramInletSensor1.inlet)
+    annotation (Line(
+      points={{106,50},{92,50}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(ramInletSensor1.outlet, hex.inletA)
+    annotation (Line(
+      points={{72,50},{64,50},{64,10}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sensorMainHXRam.inlet, mainHex.outletB)
+    annotation (Line(
+      points={{-72,4},{-66,4},{-66,24}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sensorHXRam1.inlet, hex.outletA)
+    annotation (Line(
+      points={{74,-16},{64,-16},{64,-10}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(primaryHex.outletB, sensorPrimaryHXRam.inlet)
+    annotation (Line(
+      points={{-66,-32},{-66,-38},{-72,-38}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(primaryHex.outletA, sensorPrimaryHX.inlet)
+    annotation (Line(
+      points={{-54,-12},{-54,-8},{-48,-8}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(sensorMainHX.inlet, mainHex.outletA)
+    annotation (Line(
+      points={{-46,50},{-54,50},{-54,44}},
+      color={28,108,200},
+      thickness=0.5));
+  connect(hex.outletB, sensorMainHX1.inlet)
+    annotation (Line(
+      points={{52,10},{52,30},{46,30}},
       color={28,108,200},
       thickness=0.5));
   annotation (
@@ -332,31 +463,44 @@ equation
       Tolerance=1e-6,
       Interval=0.1),
     Icon(coordinateSystem(extent={{-100,-100},{100,100}})),
-    Diagram(
-      coordinateSystem(preserveAspectRatio=false, extent={{-160,-140},{160,140}}),
-      graphics={
+    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-160,-140},{160,140}}), graphics={
         Text(
-          extent={{-90,90},{-30,80}},
+          extent={{-158,0},{-96,-20}},
           textColor={28,108,200},
           textString="three wheel bootstrap"),
-        Rectangle(extent={{30,80},{90,-106}}, lineColor={28,108,200},
+        Rectangle(
+          extent={{18,80},{98,-96}},
+          lineColor={28,108,200},
           fillColor={239,248,255},
           fillPattern=FillPattern.Solid),
         Text(
-          extent={{30,90},{90,80}},
+          extent={{102,0},{158,-20}},
           textColor={28,108,200},
           textString="simple cycle"),
-        Rectangle(extent={{-90,80},{-30,-106}},
-                                              lineColor={28,108,200},
+        Rectangle(
+          extent={{-94,80},{-20,-96}},
+          lineColor={28,108,200},
           fillColor={239,248,255},
           fillPattern=FillPattern.Solid)}),
     Documentation(info="<html>
 <p>
-Very simple implementation of a bootstrap air cycle used in an aircraft&apos;s
-environmental control system (ecs).
+Simple implementation of a <strong>bootstrap air cycle</strong> used in aircraft environmental control systems (ECS).
 </p>
 <p>
-<br>Owner: <a href=\"mailto:michael.meissner@dlr.de\">Michael Mei&szlig;ner</a>
+Two configurations are implemented: a <strong>three-wheel bootstrap cycle</strong> on the left and a <strong>simple cycle</strong> on the right.
 </p>
-</html>"));
+
+<p>
+<strong>Boundary Conditions:</strong>
+</p>
+<ul>
+<li><strong>Ram Air Inlet</strong> (T = -34.5 °C, p = 0.376 bar): Static ambient conditions at <strong>25,000 ft</strong> in <strong>ISA0</strong> atmosphere.</li>
+<li><strong>Bleed Air Inlet</strong> (T = 200 °C, p = 2.2 bar): Typical engine bleed air conditions. In conventional ECS packs, bleed air is the source of fresh air for the cabin.</li>
+<li><strong>Pack Discharge</strong> (p = 0.8 bar): Typical cabin pressure in cruise.</li>
+<li><strong>Dynamic Pressure Inflow</strong> (v = 155 m/s): Aircraft true airspeed in cruise. This component accounts for dynamic effects due to the aircraft's speed.</li>
+</ul>
+<p>
+Owner: <a href=\"mailto:michael.meissner@dlr.de\">Michael Meißner</a>
+</p>
+</html>", revisions=""));
 end SimpleAirCycle;

--- a/ThermofluidStream/Examples/SimpleAirCycle.mo
+++ b/ThermofluidStream/Examples/SimpleAirCycle.mo
@@ -12,22 +12,23 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     displayInstanceNames=true,
     displayParameters=true) annotation (Placement(transformation(extent={{-10,60},{10,80}})));
 
-  ThermofluidStream.Utilities.Icons.DLRLogo dLRLogo annotation (Placement(transformation(extent={{-18,102},{18,138}})));
+  ThermofluidStream.Utilities.Icons.DLRLogo dLRLogo annotation (Placement(transformation(extent={{-18,114},
+            {18,150}})));
   ThermofluidStream.Boundaries.Source bleedInlet(
     redeclare package Medium = Medium,
     T0_par=473.15,
     p0_par=220000,
-    Xi0_par={0}) annotation (Placement(transformation(extent={{-4,-130},{-24,-110}})));
+    Xi0_par={0}) annotation (Placement(transformation(extent={{-4,-168},{-24,-148}})));
   ThermofluidStream.Boundaries.Sink bleedOutlet(redeclare package Medium = Medium, p0_par=80000) annotation (Placement(
         transformation(
         extent={{-10,10},{10,-10}},
         rotation=180,
-        origin={-130,100})));
+        origin={-130,112})));
   ThermofluidStream.Boundaries.Source ramInlet(
     redeclare package Medium = Medium,
     T0_par=238.65,
     p0_par=37600,
-    Xi0_par={0}) annotation (Placement(transformation(extent={{-160,60},{-140,80}})));
+    Xi0_par={0}) annotation (Placement(transformation(extent={{-160,50},{-140,70}})));
   ThermofluidStream.Boundaries.DynamicPressureInflow dynamicPressure(
     displayInstanceName=false,
     redeclare package Medium = Medium,
@@ -37,14 +38,15 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     velocityFromInput=false,
     v_in_par=155,
     A_par=r^2*Modelica.Constants.pi,
-    displayOutletArea=false) annotation (Placement(transformation(extent={{-120,60},{-100,80}})));
+    displayOutletArea=false) annotation (Placement(transformation(extent={{-120,50},
+            {-100,70}})));
   ThermofluidStream.Boundaries.Sink ramOutlet(
     redeclare package Medium = Medium,
     pressureFromInput=false,
     p0_par=37600) annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=0,
-        origin={-150,-120})));
+        origin={-150,-158})));
   ThermofluidStream.Processes.Compressor compressor(
     redeclare package Medium = Medium,
     omega_from_input=false,
@@ -57,7 +59,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={-54,6})));
+        origin={-54,0})));
   ThermofluidStream.Processes.Turbine turbine(
     redeclare package Medium = Medium,
     L=5e2,
@@ -77,7 +79,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={-54,66})));
+        origin={-54,80})));
   ThermofluidStream.HeatExchangers.CounterFlowNTU mainHex(
     redeclare package MediumA = Medium,
     redeclare package MediumB = Medium,
@@ -88,7 +90,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     displaykNTU=false) annotation (Placement(transformation(
         extent={{10,10},{-10,-10}},
         rotation=270,
-        origin={-60,34})));
+        origin={-60,36})));
   ThermofluidStream.HeatExchangers.CounterFlowNTU primaryHex(
     redeclare package MediumA = Medium,
     redeclare package MediumB = Medium,
@@ -99,7 +101,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     displaykNTU=false) annotation (Placement(transformation(
         extent={{10,10},{-10,-10}},
         rotation=270,
-        origin={-60,-22})));
+        origin={-60,-42})));
   ThermofluidStream.Processes.Fan fan(redeclare package Medium = Medium, redeclare function dp_tau_fan =
         ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=500,
@@ -108,7 +110,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
         eta=0.7)) annotation (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=270,
-        origin={-66,-82})));
+        origin={-66,-122})));
   ThermofluidStream.Processes.FlowResistance pipe(
     redeclare package Medium = Medium,
     r=r,
@@ -119,29 +121,29 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     pressureDropSignificantDigits=2) annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=90,
-        origin={-66,-54})));
+        origin={-66,-90})));
   ThermofluidStream.Processes.FlowResistance outflowLoss(
     redeclare package Medium = Medium,
     r=r,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
     computeL=false,
-    L_value=0) annotation (Placement(transformation(extent={{-110,-110},{-130,-130}})));
+    L_value=0) annotation (Placement(transformation(extent={{-110,-148},{-130,-168}})));
   ThermofluidStream.Boundaries.Source bleedInlet1(
     redeclare package Medium = Medium,
     T0_par=473.15,
     p0_par=220000,
-    Xi0_par={0}) annotation (Placement(transformation(extent={{4,-130},{24,-110}})));
+    Xi0_par={0}) annotation (Placement(transformation(extent={{4,-168},{24,-148}})));
   ThermofluidStream.Boundaries.Sink bleedOutlet1(redeclare package Medium = Medium, p0_par=80000)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
-        origin={130,100})));
+        origin={130,112})));
   ThermofluidStream.Boundaries.Source ramInlet1(
     redeclare package Medium = Medium,
     T0_par=238.65,
     p0_par=37600,
-    Xi0_par={0}) annotation (Placement(transformation(extent={{160,60},{140,80}})));
+    Xi0_par={0}) annotation (Placement(transformation(extent={{160,50},{140,70}})));
   ThermofluidStream.Boundaries.DynamicPressureInflow dynamicPressure1(
     displayInstanceName=false,
     redeclare package Medium = Medium,
@@ -151,14 +153,15 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     velocityFromInput=false,
     v_in_par=155,
     A_par=r^2*Modelica.Constants.pi,
-    displayOutletArea=false) annotation (Placement(transformation(extent={{126,60},{106,80}})));
+    displayOutletArea=false) annotation (Placement(transformation(extent={{126,50},
+            {106,70}})));
   ThermofluidStream.Boundaries.Sink ramOutlet1(
     redeclare package Medium = Medium,
     pressureFromInput=false,
     p0_par=37600) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
-        origin={150,-120})));
+        origin={150,-158})));
   ThermofluidStream.Processes.Turbine turbine1(
     redeclare package Medium = Medium,
     L=5e2,
@@ -178,7 +181,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=270,
-        origin={52,60})));
+        origin={52,80})));
   ThermofluidStream.HeatExchangers.CounterFlowNTU hex(
     redeclare package MediumA = Medium,
     redeclare package MediumB = Medium,
@@ -190,7 +193,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     annotation (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=270,
-        origin={58,0})));
+        origin={58,-4})));
   ThermofluidStream.Processes.Fan fan1(redeclare package Medium = Medium, redeclare function dp_tau_fan =
         ThermofluidStream.Processes.Internal.TurboComponent.dp_tau_const_isentrop (
         omega_ref=1000,
@@ -198,7 +201,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
         eta=0.7)) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={64,-72})));
+        origin={64,-100})));
   ThermofluidStream.Processes.FlowResistance pipe1(
     redeclare package Medium = Medium,
     r=r,
@@ -209,54 +212,62 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     pressureDropSignificantDigits=2) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={64,-42})));
+        origin={64,-58})));
   ThermofluidStream.Processes.FlowResistance outflowLoss1(
     redeclare package Medium = Medium,
     r=r,
     l=1,
     redeclare function pLoss = ThermofluidStream.Processes.Internal.FlowResistance.zetaPressureLoss (zeta=1),
     computeL=false,
-    L_value=0) annotation (Placement(transformation(extent={{112,-110},{132,-130}})));
+    L_value=0) annotation (Placement(transformation(extent={{112,-148},{132,-168}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm packDischargeSensor(
     redeclare package Medium = Medium,
     digits=2,
     temperatureUnit="degC",
-    pressureUnit="bar") annotation (Placement(transformation(extent={{-80,100},{-100,120}})));
+    pressureUnit="bar") annotation (Placement(transformation(extent={{-80,112},{
+            -100,132}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm packDischargeSensor1(
     redeclare package Medium = Medium,
     digits=2,
     temperatureUnit="degC",
-    pressureUnit="bar") annotation (Placement(transformation(extent={{82,100},{102,120}})));
+    pressureUnit="bar") annotation (Placement(transformation(extent={{82,112},{102,
+            132}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm ramOutSensor(
     redeclare package Medium = Medium,
     digits=2,
     temperatureUnit="degC",
-    pressureUnit="bar") annotation (Placement(transformation(extent={{-80,-120},{-100,-100}})));
+    pressureUnit="bar") annotation (Placement(transformation(extent={{-80,-158},
+            {-100,-138}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm ramOutSensor1(
     redeclare package Medium = Medium,
     digits=2,
     temperatureUnit="degC",
-    pressureUnit="bar") annotation (Placement(transformation(extent={{80,-120},{100,-100}})));
+    pressureUnit="bar") annotation (Placement(transformation(extent={{80,-158},{
+            100,-138}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm ramInletSensor(
     redeclare package Medium = Medium,
     digits=2,
     temperatureUnit="degC",
-    pressureUnit="bar") annotation (Placement(transformation(extent={{-90,70},{-70,90}})));
+    pressureUnit="bar") annotation (Placement(transformation(extent={{-90,60},{-70,
+            80}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm ramInletSensor1(
     redeclare package Medium = Medium,
     digits=2,
     temperatureUnit="degC",
-    pressureUnit="bar") annotation (Placement(transformation(extent={{92,70},{72,90}})));
+    pressureUnit="bar") annotation (Placement(transformation(extent={{92,60},{72,
+            80}})));
   ThermofluidStream.Utilities.showRealValue CoolingPower_kW(
     description="Cooling Power [kW]",
     use_numberPort=false,
     number=turbine.m_flow*1.005*(bleedInlet.outlet.state.T - bleedOutlet.inlet.state.T),
-    significantDigits=3) annotation (Placement(transformation(extent={{-158,-2},{-98,18}})));
+    significantDigits=3) annotation (Placement(transformation(extent={{-178,0},{
+            -118,20}})));
   ThermofluidStream.Utilities.showRealValue CoolingPower_kW1(
     description="Cooling Power [kW]",
     use_numberPort=false,
     number=turbine1.m_flow*1.005*(bleedInlet1.outlet.state.T - bleedOutlet1.inlet.state.T),
-    significantDigits=3) annotation (Placement(transformation(extent={{98,0},{158,20}})));
+    significantDigits=3) annotation (Placement(transformation(extent={{120,0},{180,
+            20}})));
   Sensors.SingleSensorSelect sensorMainHXRam(
     redeclare package Medium = Medium,
     digits=3,
@@ -266,22 +277,22 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     digits=2,
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
-    annotation (Placement(transformation(extent={{74,-26},{94,-6}})));
+    annotation (Placement(transformation(extent={{74,-38},{94,-18}})));
   Sensors.SingleSensorSelect sensorPrimaryHXRam(
     redeclare package Medium = Medium,
     digits=3,
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
-    annotation (Placement(transformation(extent={{-72,-48},{-92,-28}})));
+    annotation (Placement(transformation(extent={{-72,-76},{-92,-56}})));
   Sensors.SingleSensorSelect sensorMainHX(
     redeclare package Medium = Medium,
     digits=3,
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
-    annotation (Placement(transformation(extent={{-46,40},{-26,60}})));
+    annotation (Placement(transformation(extent={{-46,48},{-26,68}})));
   Sensors.SingleSensorSelect sensorPrimaryHX(
     redeclare package Medium = Medium,
     digits=3,
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
-    annotation (Placement(transformation(extent={{-48,-18},{-28,2}})));
+    annotation (Placement(transformation(extent={{-48,-32},{-28,-12}})));
   Sensors.SingleSensorSelect sensorMainHX1(
     redeclare package Medium = Medium,
     digits=2,
@@ -296,215 +307,225 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     description="Fan Pressure Ratio",
     use_numberPort=false,
     number=fan.p_out/fan.p_in,
-    significantDigits=3) annotation (Placement(transformation(extent={{-158,-62},{-98,-42}})));
+    significantDigits=3) annotation (Placement(transformation(extent={{-178,-60},
+            {-118,-40}})));
   ThermofluidStream.Utilities.showRealValue fan1Pr(
     description="Fan1 Pressure Ratio",
     use_numberPort=false,
     number=fan1.p_out/fan1.p_in,
-    significantDigits=3) annotation (Placement(transformation(extent={{98,-40},{158,-20}})));
+    significantDigits=3) annotation (Placement(transformation(extent={{120,-40},
+            {180,-20}})));
   ThermofluidStream.Utilities.showRealValue cmpPr(
     description="Compressor Pressure Ratio",
     use_numberPort=false,
     number=compressor.p_out/compressor.p_in,
-    significantDigits=3) annotation (Placement(transformation(extent={{-158,-20},{-98,0}})));
+    significantDigits=3) annotation (Placement(transformation(extent={{-178,-18},
+            {-118,2}})));
   ThermofluidStream.Utilities.showRealValue turbinePr(
     description="Turbine Pressure Ratio",
     use_numberPort=false,
-    number=turbine.p_out/turbine.p_in,
-    significantDigits=3) annotation (Placement(transformation(extent={{-158,-40},{-98,-20}})));
+    number=turbine.p_in/turbine.p_out,
+    significantDigits=3) annotation (Placement(transformation(extent={{-178,-38},
+            {-118,-18}})));
   ThermofluidStream.Utilities.showRealValue turbine1Pr(
     description="Turbine1 Pressure Ratio",
     use_numberPort=false,
-    number=turbine1.p_out/turbine1.p_in,
-    significantDigits=3) annotation (Placement(transformation(extent={{98,-20},{158,0}})));
+    number=turbine1.p_in/turbine1.p_out,
+    significantDigits=3) annotation (Placement(transformation(extent={{120,-20},
+            {180,0}})));
   ThermofluidStream.Utilities.showRealValue hexEffectiveness(
-    description="Heat Exchanger Effectiveness",
+    description="HX Effectiveness",
     use_numberPort=false,
     number=hex.effectiveness,
-    significantDigits=3) annotation (Placement(transformation(extent={{98,-60},{158,-40}})));
+    significantDigits=3) annotation (Placement(transformation(extent={{120,-60},
+            {180,-40}})));
   ThermofluidStream.Utilities.showRealValue mainHexEffectiveness(
-    description="Main Heat Exchanger Effectiveness",
+    description="Main HX Effectiveness",
     use_numberPort=false,
     number=mainHex.effectiveness,
-    significantDigits=3) annotation (Placement(transformation(extent={{-158,-80},{-98,-60}})));
+    significantDigits=3) annotation (Placement(transformation(extent={{-178,-78},
+            {-118,-58}})));
   ThermofluidStream.Utilities.showRealValue primaryHexEffectiveness(
-    description="Primary Heat Exchanger Effectiveness",
+    description="Primary HX Effectiveness",
     use_numberPort=false,
     number=primaryHex.effectiveness,
-    significantDigits=3) annotation (Placement(transformation(extent={{-158,-100},{-98,-80}})));
+    significantDigits=3) annotation (Placement(transformation(extent={{-178,-98},
+            {-118,-78}})));
 equation
   connect(ramInlet.outlet, dynamicPressure.inlet)
     annotation (Line(
-      points={{-140,70},{-120,70}},
+      points={{-140,60},{-120,60}},
       color={28,108,200},
       thickness=0.5));
   connect(pipe.outlet, fan.inlet)
     annotation (Line(
-      points={{-66,-64},{-66,-72}},
+      points={{-66,-100},{-66,-112}},
       color={28,108,200},
       thickness=0.5));
   connect(bleedInlet.outlet, primaryHex.inletA)
     annotation (Line(
-      points={{-24,-120},{-54,-120},{-54,-32}},
+      points={{-24,-158},{-54,-158},{-54,-52}},
       color={28,108,200},
       thickness=0.5));
   connect(primaryHex.outletA, compressor.inlet)
     annotation (Line(
-      points={{-54,-12},{-54,-4}},
+      points={{-54,-32},{-54,-10}},
       color={28,108,200},
       thickness=0.5));
   connect(compressor.outlet, mainHex.inletA)
     annotation (Line(
-      points={{-54,16},{-54,24}},
+      points={{-54,10},{-54,26}},
       color={28,108,200},
       thickness=0.5));
   connect(mainHex.outletA, turbine.inlet)
     annotation (Line(
-      points={{-54,44},{-54,56}},
+      points={{-54,46},{-54,70}},
       color={28,108,200},
       thickness=0.5));
   connect(mainHex.outletB, primaryHex.inletB)
     annotation (Line(
-      points={{-66,24},{-66,-12}},
+      points={{-66,26},{-66,-32}},
       color={28,108,200},
       thickness=0.5));
   connect(primaryHex.outletB, pipe.inlet)
     annotation (Line(
-      points={{-66,-32},{-66,-44}},
+      points={{-66,-52},{-66,-80}},
       color={28,108,200},
       thickness=0.5));
-  connect(fan.flange, compressor.flange) annotation (Line(points={{-56,-82},{-26,-82},{-26,6},{-44,6}}, color={0,0,0}));
+  connect(fan.flange, compressor.flange) annotation (Line(points={{-56,-122},{-26,
+          -122},{-26,0},{-44,0}},                                                                       color={0,0,0}));
   connect(turbine.flange, compressor.flange)
-    annotation (Line(points={{-44,66},{-26,66},{-26,6},{-44,6}}, color={0,0,0}));
+    annotation (Line(points={{-44,80},{-26,80},{-26,0},{-44,0}}, color={0,0,0}));
   connect(bleedInlet1.outlet, hex.inletB)
     annotation (Line(
-      points={{24,-120},{52,-120},{52,-10}},
+      points={{24,-158},{52,-158},{52,-14}},
       color={28,108,200},
       thickness=0.5));
   connect(hex.outletB, turbine1.inlet)
     annotation (Line(
-      points={{52,10},{52,50}},
+      points={{52,6},{52,70}},
       color={28,108,200},
       thickness=0.5));
   connect(ramInlet1.outlet, dynamicPressure1.inlet)
     annotation (Line(
-      points={{140,70},{126,70}},
+      points={{140,60},{126,60}},
       color={28,108,200},
       thickness=0.5));
   connect(hex.outletA, pipe1.inlet)
     annotation (Line(
-      points={{64,-10},{64,-32}},
+      points={{64,-14},{64,-48}},
       color={28,108,200},
       thickness=0.5));
   connect(pipe1.outlet, fan1.inlet)
     annotation (Line(
-      points={{64,-52},{64,-62}},
+      points={{64,-68},{64,-90}},
       color={28,108,200},
       thickness=0.5));
   connect(outflowLoss1.outlet, ramOutlet1.inlet)
     annotation (Line(
-      points={{132,-120},{140,-120}},
+      points={{132,-158},{140,-158}},
       color={28,108,200},
       thickness=0.5));
-  connect(turbine1.flange, fan1.flange) annotation (Line(points={{42,60},{22,60},{22,-72},{54,-72}}, color={0,0,0}));
+  connect(turbine1.flange, fan1.flange) annotation (Line(points={{42,80},{22,80},
+          {22,-100},{54,-100}},                                                                      color={0,0,0}));
   connect(ramOutlet.inlet, outflowLoss.outlet)
     annotation (Line(
-      points={{-140,-120},{-130,-120}},
+      points={{-140,-158},{-130,-158}},
       color={28,108,200},
       thickness=0.5));
   connect(bleedOutlet.inlet, packDischargeSensor.outlet)
     annotation (Line(
-      points={{-120,100},{-100,100}},
+      points={{-120,112},{-100,112}},
       color={28,108,200},
       thickness=0.5));
   connect(packDischargeSensor.inlet, turbine.outlet)
     annotation (Line(
-      points={{-80,100},{-54,100},{-54,76}},
+      points={{-80,112},{-54,112},{-54,90}},
       color={28,108,200},
       thickness=0.5));
   connect(turbine1.outlet, packDischargeSensor1.inlet)
     annotation (Line(
-      points={{52,70},{52,100},{82,100}},
+      points={{52,90},{52,112},{82,112}},
       color={28,108,200},
       thickness=0.5));
   connect(packDischargeSensor1.outlet, bleedOutlet1.inlet)
     annotation (Line(
-      points={{102,100},{120,100}},
+      points={{102,112},{120,112}},
       color={28,108,200},
       thickness=0.5));
   connect(fan.outlet, ramOutSensor.inlet)
     annotation (Line(
-      points={{-66,-92},{-66,-120},{-80,-120}},
+      points={{-66,-132},{-66,-158},{-80,-158}},
       color={28,108,200},
       thickness=0.5));
   connect(ramOutSensor.outlet, outflowLoss.inlet)
     annotation (Line(
-      points={{-100,-120},{-110,-120}},
+      points={{-100,-158},{-110,-158}},
       color={28,108,200},
       thickness=0.5));
   connect(fan1.outlet, ramOutSensor1.inlet)
     annotation (Line(
-      points={{64,-82},{64,-120},{80,-120}},
+      points={{64,-110},{64,-158},{80,-158}},
       color={28,108,200},
       thickness=0.5));
   connect(ramOutSensor1.outlet, outflowLoss1.inlet)
     annotation (Line(
-      points={{100,-120},{112,-120}},
+      points={{100,-158},{112,-158}},
       color={28,108,200},
       thickness=0.5));
   connect(dynamicPressure.outlet, ramInletSensor.inlet)
     annotation (Line(
-      points={{-100,70},{-90,70}},
+      points={{-100,60},{-90,60}},
       color={28,108,200},
       thickness=0.5));
   connect(ramInletSensor.outlet, mainHex.inletB)
     annotation (Line(
-      points={{-70,70},{-66,70},{-66,44}},
+      points={{-70,60},{-66,60},{-66,46}},
       color={28,108,200},
       thickness=0.5));
   connect(dynamicPressure1.outlet, ramInletSensor1.inlet)
     annotation (Line(
-      points={{106,70},{92,70}},
+      points={{106,60},{92,60}},
       color={28,108,200},
       thickness=0.5));
   connect(ramInletSensor1.outlet, hex.inletA)
     annotation (Line(
-      points={{72,70},{64,70},{64,10}},
+      points={{72,60},{64,60},{64,6}},
       color={28,108,200},
       thickness=0.5));
   connect(sensorMainHXRam.inlet, mainHex.outletB)
     annotation (Line(
-      points={{-72,4},{-66,4},{-66,24}},
+      points={{-72,4},{-66,4},{-66,26}},
       color={28,108,200},
       thickness=0.5));
   connect(sensorHXRam1.inlet, hex.outletA)
     annotation (Line(
-      points={{74,-16},{64,-16},{64,-10}},
+      points={{74,-28},{64,-28},{64,-14}},
       color={28,108,200},
       thickness=0.5));
   connect(primaryHex.outletB, sensorPrimaryHXRam.inlet)
     annotation (Line(
-      points={{-66,-32},{-66,-38},{-72,-38}},
+      points={{-66,-52},{-66,-66},{-72,-66}},
       color={28,108,200},
       thickness=0.5));
   connect(primaryHex.outletA, sensorPrimaryHX.inlet)
     annotation (Line(
-      points={{-54,-12},{-54,-8},{-48,-8}},
+      points={{-54,-32},{-54,-22},{-48,-22}},
       color={28,108,200},
       thickness=0.5));
   connect(sensorMainHX.inlet, mainHex.outletA)
     annotation (Line(
-      points={{-46,50},{-54,50},{-54,44}},
+      points={{-46,58},{-54,58},{-54,46}},
       color={28,108,200},
       thickness=0.5));
   connect(hex.outletB, sensorMainHX1.inlet)
     annotation (Line(
-      points={{52,10},{52,30},{46,30}},
+      points={{52,6},{52,30},{46,30}},
       color={28,108,200},
       thickness=0.5));
   connect(sensorCompressor.inlet, compressor.outlet)
     annotation (Line(
-      points={{-48,20},{-54,20},{-54,16}},
+      points={{-48,20},{-54,20},{-54,10}},
       color={28,108,200},
       thickness=0.5));
   annotation (
@@ -512,26 +533,39 @@ equation
       StopTime=100,
       Tolerance=1e-6,
       Interval=0.1),
-    Icon(coordinateSystem(extent={{-100,-100},{100,100}})),
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-160,-140},{160,140}}), graphics={
+    Icon(coordinateSystem),
+    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-200,-180},{200,
+            180}}),                                                                      graphics={
         Text(
-          extent={{-158,40},{-96,20}},
-          textColor={28,108,200},
-          textString="three wheel bootstrap"),
+          extent={{-158,174},{-42,124}},
+          textColor={0,0,0},
+          textString="Three wheel bootstrap"),
         Rectangle(
-          extent={{18,92},{98,-96}},
+          extent={{18,100},{96,-134}},
           lineColor={28,108,200},
           fillColor={239,248,255},
           fillPattern=FillPattern.Solid),
         Text(
-          extent={{102,40},{158,20}},
-          textColor={28,108,200},
-          textString="simple cycle"),
+          extent={{64,162},{134,136}},
+          textColor={0,0,0},
+          textString="Simple cycle"),
         Rectangle(
-          extent={{-94,92},{-20,-96}},
+          extent={{-94,100},{-20,-134}},
           lineColor={28,108,200},
           fillColor={239,248,255},
-          fillPattern=FillPattern.Solid)}),
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{102,24},{196,-96}},
+          fillColor={244,244,244},
+          fillPattern=FillPattern.Solid,
+          lineColor={182,182,182},
+          pattern=LinePattern.None),
+        Rectangle(
+          extent={{-194,24},{-100,-96}},
+          fillColor={244,244,244},
+          fillPattern=FillPattern.Solid,
+          lineColor={182,182,182},
+          pattern=LinePattern.None)}),
     Documentation(info="<html>
 <p>Simple implementation of a <strong>bootstrap air cycle</strong> used in aircraft environmental control systems (ECS). </p>
 <p>In this example, all bypasses, such as temperature control valves, and dehumidification components are not considered. Consequently, the two bleed sinks do not correspond to real ECS pack outlets.</p>

--- a/ThermofluidStream/Examples/SimpleAirCycle.mo
+++ b/ThermofluidStream/Examples/SimpleAirCycle.mo
@@ -18,8 +18,8 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     T0_par=473.15,
     p0_par=220000,
     Xi0_par={0}) annotation (Placement(transformation(extent={{-4,-130},{-24,-110}})));
-  ThermofluidStream.Boundaries.Sink packDischarge(redeclare package Medium = Medium, p0_par=80000) annotation (
-      Placement(transformation(
+  ThermofluidStream.Boundaries.Sink bleedOutlet(redeclare package Medium = Medium, p0_par=80000) annotation (Placement(
+        transformation(
         extent={{-10,10},{10,-10}},
         rotation=180,
         origin={-130,100})));
@@ -27,7 +27,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     T0_par=238.65,
     p0_par=37600,
-    Xi0_par={0}) annotation (Placement(transformation(extent={{-160,40},{-140,60}})));
+    Xi0_par={0}) annotation (Placement(transformation(extent={{-160,60},{-140,80}})));
   ThermofluidStream.Boundaries.DynamicPressureInflow dynamicPressure(
     displayInstanceName=false,
     redeclare package Medium = Medium,
@@ -37,7 +37,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     velocityFromInput=false,
     v_in_par=155,
     A_par=r^2*Modelica.Constants.pi,
-    displayOutletArea=false) annotation (Placement(transformation(extent={{-120,40},{-100,60}})));
+    displayOutletArea=false) annotation (Placement(transformation(extent={{-120,60},{-100,80}})));
   ThermofluidStream.Boundaries.Sink ramOutlet(
     redeclare package Medium = Medium,
     pressureFromInput=false,
@@ -132,7 +132,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     T0_par=473.15,
     p0_par=220000,
     Xi0_par={0}) annotation (Placement(transformation(extent={{4,-130},{24,-110}})));
-  ThermofluidStream.Boundaries.Sink packDischarge1(redeclare package Medium = Medium, p0_par=80000)
+  ThermofluidStream.Boundaries.Sink bleedOutlet1(redeclare package Medium = Medium, p0_par=80000)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
@@ -141,7 +141,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     T0_par=238.65,
     p0_par=37600,
-    Xi0_par={0}) annotation (Placement(transformation(extent={{160,40},{140,60}})));
+    Xi0_par={0}) annotation (Placement(transformation(extent={{160,60},{140,80}})));
   ThermofluidStream.Boundaries.DynamicPressureInflow dynamicPressure1(
     displayInstanceName=false,
     redeclare package Medium = Medium,
@@ -151,7 +151,7 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     velocityFromInput=false,
     v_in_par=155,
     A_par=r^2*Modelica.Constants.pi,
-    displayOutletArea=false) annotation (Placement(transformation(extent={{126,40},{106,60}})));
+    displayOutletArea=false) annotation (Placement(transformation(extent={{126,60},{106,80}})));
   ThermofluidStream.Boundaries.Sink ramOutlet1(
     redeclare package Medium = Medium,
     pressureFromInput=false,
@@ -241,22 +241,22 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     redeclare package Medium = Medium,
     digits=2,
     temperatureUnit="degC",
-    pressureUnit="bar") annotation (Placement(transformation(extent={{-90,50},{-70,70}})));
+    pressureUnit="bar") annotation (Placement(transformation(extent={{-90,70},{-70,90}})));
   ThermofluidStream.Sensors.MultiSensor_Tpm ramInletSensor1(
     redeclare package Medium = Medium,
     digits=2,
     temperatureUnit="degC",
-    pressureUnit="bar") annotation (Placement(transformation(extent={{92,50},{72,70}})));
+    pressureUnit="bar") annotation (Placement(transformation(extent={{92,70},{72,90}})));
   ThermofluidStream.Utilities.showRealValue CoolingPower_kW(
     description="Cooling Power [kW]",
     use_numberPort=false,
-    number=-turbine.m_flow*1.005*(packDischarge.inlet.state.T - bleedInlet.outlet.state.T),
-    significantDigits=3) annotation (Placement(transformation(extent={{-160,-40},{-100,-20}})));
+    number=turbine.m_flow*1.005*(bleedInlet.outlet.state.T - bleedOutlet.inlet.state.T),
+    significantDigits=3) annotation (Placement(transformation(extent={{-158,-2},{-98,18}})));
   ThermofluidStream.Utilities.showRealValue CoolingPower_kW1(
     description="Cooling Power [kW]",
     use_numberPort=false,
-    number=-turbine1.m_flow*1.005*(packDischarge1.inlet.state.T - bleedInlet1.outlet.state.T),
-    significantDigits=3) annotation (Placement(transformation(extent={{100,-40},{160,-20}})));
+    number=turbine1.m_flow*1.005*(bleedInlet1.outlet.state.T - bleedOutlet1.inlet.state.T),
+    significantDigits=3) annotation (Placement(transformation(extent={{98,0},{158,20}})));
   Sensors.SingleSensorSelect sensorMainHXRam(
     redeclare package Medium = Medium,
     digits=3,
@@ -287,10 +287,55 @@ model SimpleAirCycle "Basic bootstrap cooling cycle"
     digits=2,
     quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
     annotation (Placement(transformation(extent={{46,20},{26,40}})));
+  Sensors.SingleSensorSelect sensorCompressor(
+    redeclare package Medium = Medium,
+    digits=3,
+    quantity=ThermofluidStream.Sensors.Internal.Types.Quantities.T_C)
+    annotation (Placement(transformation(extent={{-48,10},{-28,30}})));
+  ThermofluidStream.Utilities.showRealValue fanPr(
+    description="Fan Pressure Ratio",
+    use_numberPort=false,
+    number=fan.p_out/fan.p_in,
+    significantDigits=3) annotation (Placement(transformation(extent={{-158,-62},{-98,-42}})));
+  ThermofluidStream.Utilities.showRealValue fan1Pr(
+    description="Fan1 Pressure Ratio",
+    use_numberPort=false,
+    number=fan1.p_out/fan1.p_in,
+    significantDigits=3) annotation (Placement(transformation(extent={{98,-40},{158,-20}})));
+  ThermofluidStream.Utilities.showRealValue cmpPr(
+    description="Compressor Pressure Ratio",
+    use_numberPort=false,
+    number=compressor.p_out/compressor.p_in,
+    significantDigits=3) annotation (Placement(transformation(extent={{-158,-20},{-98,0}})));
+  ThermofluidStream.Utilities.showRealValue turbinePr(
+    description="Turbine Pressure Ratio",
+    use_numberPort=false,
+    number=turbine.p_out/turbine.p_in,
+    significantDigits=3) annotation (Placement(transformation(extent={{-158,-40},{-98,-20}})));
+  ThermofluidStream.Utilities.showRealValue turbine1Pr(
+    description="Turbine1 Pressure Ratio",
+    use_numberPort=false,
+    number=turbine1.p_out/turbine1.p_in,
+    significantDigits=3) annotation (Placement(transformation(extent={{98,-20},{158,0}})));
+  ThermofluidStream.Utilities.showRealValue hexEffectiveness(
+    description="Heat Exchanger Effectiveness",
+    use_numberPort=false,
+    number=hex.effectiveness,
+    significantDigits=3) annotation (Placement(transformation(extent={{98,-60},{158,-40}})));
+  ThermofluidStream.Utilities.showRealValue mainHexEffectiveness(
+    description="Main Heat Exchanger Effectiveness",
+    use_numberPort=false,
+    number=mainHex.effectiveness,
+    significantDigits=3) annotation (Placement(transformation(extent={{-158,-80},{-98,-60}})));
+  ThermofluidStream.Utilities.showRealValue primaryHexEffectiveness(
+    description="Primary Heat Exchanger Effectiveness",
+    use_numberPort=false,
+    number=primaryHex.effectiveness,
+    significantDigits=3) annotation (Placement(transformation(extent={{-158,-100},{-98,-80}})));
 equation
   connect(ramInlet.outlet, dynamicPressure.inlet)
     annotation (Line(
-      points={{-140,50},{-120,50}},
+      points={{-140,70},{-120,70}},
       color={28,108,200},
       thickness=0.5));
   connect(pipe.outlet, fan.inlet)
@@ -343,7 +388,7 @@ equation
       thickness=0.5));
   connect(ramInlet1.outlet, dynamicPressure1.inlet)
     annotation (Line(
-      points={{140,50},{126,50}},
+      points={{140,70},{126,70}},
       color={28,108,200},
       thickness=0.5));
   connect(hex.outletA, pipe1.inlet)
@@ -367,7 +412,7 @@ equation
       points={{-140,-120},{-130,-120}},
       color={28,108,200},
       thickness=0.5));
-  connect(packDischarge.inlet, packDischargeSensor.outlet)
+  connect(bleedOutlet.inlet, packDischargeSensor.outlet)
     annotation (Line(
       points={{-120,100},{-100,100}},
       color={28,108,200},
@@ -382,7 +427,7 @@ equation
       points={{52,70},{52,100},{82,100}},
       color={28,108,200},
       thickness=0.5));
-  connect(packDischargeSensor1.outlet, packDischarge1.inlet)
+  connect(packDischargeSensor1.outlet, bleedOutlet1.inlet)
     annotation (Line(
       points={{102,100},{120,100}},
       color={28,108,200},
@@ -409,22 +454,22 @@ equation
       thickness=0.5));
   connect(dynamicPressure.outlet, ramInletSensor.inlet)
     annotation (Line(
-      points={{-100,50},{-90,50}},
+      points={{-100,70},{-90,70}},
       color={28,108,200},
       thickness=0.5));
   connect(ramInletSensor.outlet, mainHex.inletB)
     annotation (Line(
-      points={{-70,50},{-66,50},{-66,44}},
+      points={{-70,70},{-66,70},{-66,44}},
       color={28,108,200},
       thickness=0.5));
   connect(dynamicPressure1.outlet, ramInletSensor1.inlet)
     annotation (Line(
-      points={{106,50},{92,50}},
+      points={{106,70},{92,70}},
       color={28,108,200},
       thickness=0.5));
   connect(ramInletSensor1.outlet, hex.inletA)
     annotation (Line(
-      points={{72,50},{64,50},{64,10}},
+      points={{72,70},{64,70},{64,10}},
       color={28,108,200},
       thickness=0.5));
   connect(sensorMainHXRam.inlet, mainHex.outletB)
@@ -457,6 +502,11 @@ equation
       points={{52,10},{52,30},{46,30}},
       color={28,108,200},
       thickness=0.5));
+  connect(sensorCompressor.inlet, compressor.outlet)
+    annotation (Line(
+      points={{-48,20},{-54,20},{-54,16}},
+      color={28,108,200},
+      thickness=0.5));
   annotation (
     experiment(
       StopTime=100,
@@ -465,42 +515,34 @@ equation
     Icon(coordinateSystem(extent={{-100,-100},{100,100}})),
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-160,-140},{160,140}}), graphics={
         Text(
-          extent={{-158,0},{-96,-20}},
+          extent={{-158,40},{-96,20}},
           textColor={28,108,200},
           textString="three wheel bootstrap"),
         Rectangle(
-          extent={{18,80},{98,-96}},
+          extent={{18,92},{98,-96}},
           lineColor={28,108,200},
           fillColor={239,248,255},
           fillPattern=FillPattern.Solid),
         Text(
-          extent={{102,0},{158,-20}},
+          extent={{102,40},{158,20}},
           textColor={28,108,200},
           textString="simple cycle"),
         Rectangle(
-          extent={{-94,80},{-20,-96}},
+          extent={{-94,92},{-20,-96}},
           lineColor={28,108,200},
           fillColor={239,248,255},
           fillPattern=FillPattern.Solid)}),
     Documentation(info="<html>
-<p>
-Simple implementation of a <strong>bootstrap air cycle</strong> used in aircraft environmental control systems (ECS).
-</p>
-<p>
-Two configurations are implemented: a <strong>three-wheel bootstrap cycle</strong> on the left and a <strong>simple cycle</strong> on the right.
-</p>
-
-<p>
-<strong>Boundary Conditions:</strong>
-</p>
+<p>Simple implementation of a <b>bootstrap air cycle</b> used in aircraft environmental control systems (ECS). </p>
+<p>In this example, all bypasses, such as temperature control valves, and dehumidification components are not considered. Consequently, the two bleed sinks do not correspond to real ECS pack outlets.</p>
+<p>Two configurations are implemented: a <b>three-wheel bootstrap cycle</b> on the left and a <b>simple cycle</b> on the right. </p>
+<p><b>Boundary Conditions:</b> </p>
 <ul>
-<li><strong>Ram Air Inlet</strong> (T = -34.5 °C, p = 0.376 bar): Static ambient conditions at <strong>25,000 ft</strong> in <strong>ISA0</strong> atmosphere.</li>
-<li><strong>Bleed Air Inlet</strong> (T = 200 °C, p = 2.2 bar): Typical engine bleed air conditions. In conventional ECS packs, bleed air is the source of fresh air for the cabin.</li>
-<li><strong>Pack Discharge</strong> (p = 0.8 bar): Typical cabin pressure in cruise.</li>
-<li><strong>Dynamic Pressure Inflow</strong> (v = 155 m/s): Aircraft true airspeed in cruise. This component accounts for dynamic effects due to the aircraft's speed.</li>
+<li><b>Ram Air Inlet</b> (T = -34.5 &deg;C, p = 0.376 bar): Static ambient conditions at <b>25000 ft</b> in <b>ISA0</b> atmosphere.</li>
+<li><b>Bleed Air Inlet</b> (T = 200 &deg;C, p = 2.2 bar): Typical engine bleed air conditions. In conventional ECS packs, bleed air is the source of fresh air for the cabin.</li>
+<li><b>Bleed Air Outlet</b> (p = 0.8 bar): Typical cabin pressure at cruise.</li>
+<li><b>Dynamic Pressure Inflow</b> (v = 155 m/s): Aircraft true airspeed at cruise. This component accounts for dynamic effects due to the aircraft&apos;s speed.</li>
 </ul>
-<p>
-Owner: <a href=\"mailto:michael.meissner@dlr.de\">Michael Meißner</a>
-</p>
+<p>Owner: <a href=\"mailto:michael.meissner@dlr.de\">Michael Mei&szlig;ner</a> </p>
 </html>", revisions=""));
 end SimpleAirCycle;

--- a/ThermofluidStream/Examples/SimpleAirCycle.mo
+++ b/ThermofluidStream/Examples/SimpleAirCycle.mo
@@ -533,15 +533,15 @@ equation
           fillColor={239,248,255},
           fillPattern=FillPattern.Solid)}),
     Documentation(info="<html>
-<p>Simple implementation of a <b>bootstrap air cycle</b> used in aircraft environmental control systems (ECS). </p>
+<p>Simple implementation of a <strong>bootstrap air cycle</strong> used in aircraft environmental control systems (ECS). </p>
 <p>In this example, all bypasses, such as temperature control valves, and dehumidification components are not considered. Consequently, the two bleed sinks do not correspond to real ECS pack outlets.</p>
-<p>Two configurations are implemented: a <b>three-wheel bootstrap cycle</b> on the left and a <b>simple cycle</b> on the right. </p>
-<p><b>Boundary Conditions:</b> </p>
+<p>Two configurations are implemented: a <strong>three-wheel bootstrap cycle</strong> on the left and a <strong>simple cycle</strong> on the right. </p>
+<p><strong>Boundary Conditions:</strong> </p>
 <ul>
-<li><b>Ram Air Inlet</b> (T = -34.5 &deg;C, p = 0.376 bar): Static ambient conditions at <b>25000 ft</b> in <b>ISA0</b> atmosphere.</li>
-<li><b>Bleed Air Inlet</b> (T = 200 &deg;C, p = 2.2 bar): Typical engine bleed air conditions. In conventional ECS packs, bleed air is the source of fresh air for the cabin.</li>
-<li><b>Bleed Air Outlet</b> (p = 0.8 bar): Typical cabin pressure at cruise.</li>
-<li><b>Dynamic Pressure Inflow</b> (v = 155 m/s): Aircraft true airspeed at cruise. This component accounts for dynamic effects due to the aircraft&apos;s speed.</li>
+<li><strong>Ram Air Inlet</strong> (T = -34.5 &deg;C, p = 0.376 bar): Static ambient conditions at <strong>25000 ft</strong> in <strong>ISA0</strong> atmosphere.</li>
+<li><strong>Bleed Air Inlet</strong> (T = 200 &deg;C, p = 2.2 bar): Typical engine bleed air conditions. In conventional ECS packs, bleed air is the source of fresh air for the cabin.</li>
+<li><strong>Bleed Air Outlet</strong> (p = 0.8 bar): Typical cabin pressure at cruise.</li>
+<li><strong>Dynamic Pressure Inflow</strong> (v = 155 m/s): Aircraft true airspeed at cruise. This component accounts for dynamic effects due to the aircraft&apos;s speed.</li>
 </ul>
 <p>Owner: <a href=\"mailto:michael.meissner@dlr.de\">Michael Mei&szlig;ner</a> </p>
 </html>", revisions=""));


### PR DESCRIPTION
- Change boundary conditions to represent a cruise phase of a regional aircraft at 25000ft, mach 0.5, in ISA0 atmosphere
- Add sensors to display the main temperatures and mass flow
- Add the cooling power provided by each pack for comparison
- Improve documentation
- Reduce the size of the flow resistances inside the ram air channels
- Auto-format text layer to clean it

Closes #320, closes #217 