### PR TITLE
AccelerationBoundary and Static head fix for OM

### DIFF
--- a/ThermofluidStream/Boundaries/AccelerationBoundary.mo
+++ b/ThermofluidStream/Boundaries/AccelerationBoundary.mo
@@ -1,8 +1,11 @@
 within ThermofluidStream.Boundaries;
 model AccelerationBoundary "Sets and broadcasts acceleration vector, default is
   fixed in negative z-direction with length of DropOfCommons.g"
-  SI.Acceleration a[3];
+
+  extends ThermofluidStream.Utilities.DropOfCommonsPlus;
+
   parameter Boolean setFromInputs = false annotation (choices(checkBox=true), Evaluate=true);
+
   SI.Acceleration ax = 0
   annotation(Dialog(group="Time varying output signal",enable=not setFromInputs));
   SI.Acceleration ay = 0
@@ -15,14 +18,23 @@ model AccelerationBoundary "Sets and broadcasts acceleration vector, default is
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Modelica.Blocks.Interfaces.RealInput uz if setFromInputs
     annotation (Placement(transformation(extent={{-120,-80},{-80,-40}})));
+
+  output SI.Acceleration a[3];
+
 protected
-  outer ThermofluidStream.DropOfCommons dropOfCommons;
+  Modelica.Blocks.Interfaces.RealInput ax_int annotation(HideResult=true);
+  Modelica.Blocks.Interfaces.RealInput ay_int annotation(HideResult=true);
+  Modelica.Blocks.Interfaces.RealInput az_int annotation(HideResult=true);
+
 equation
-  connect(ux,a[1]);
-  connect(uy,a[2]);
-  connect(uz,a[3]);
+  a={ax_int,ay_int,az_int};
+  connect(ax_int,ux);
+  connect(ay_int,uy);
+  connect(az_int,uz);
   if not setFromInputs then
-    a={ax,ay,az};
+    ax_int = ax;
+    ay_int = ay;
+    az_int = az;
   end if;
   annotation (defaultComponentName="acceleration",
     defaultComponentPrefixes="inner",

--- a/ThermofluidStream/Processes/StaticHead.mo
+++ b/ThermofluidStream/Processes/StaticHead.mo
@@ -2,6 +2,10 @@ within ThermofluidStream.Processes;
 model StaticHead "Static head model"
   extends ThermofluidStream.Interfaces.SISOFlow(final L=L_value, final clip_p_out=true);
 
+protected
+  outer ThermofluidStream.Boundaries.AccelerationBoundary acceleration;
+
+public
   parameter SI.Length fromPosition[3]
     "Coordinates for the position the static head is computed from" annotation (Dialog(group="Geometry",
         enable=true));
@@ -10,18 +14,20 @@ model StaticHead "Static head model"
         enable=true));
 
   parameter ThermofluidStream.Utilities.Units.Inertance L_value=dropOfCommons.L
-    "Inertance of pipe" annotation (Dialog(tab="Advanced", enable=not computeL));
+    "Inertance of pipe" annotation (Dialog(tab="Advanced"));
 
   parameter Medium.Density rho_min=dropOfCommons.rho_min
     "Minimal input density" annotation (Dialog(tab="Advanced"));
 
-    SI.Length staticHead "static head in m";
-    SI.Pressure staticHead_Pa_relative "static head measured i Pa, taking current acceleration and limitations into account";
- parameter Boolean displayPositions=true "show positions in icon";
+  parameter Boolean displayPositions=true "show positions in icon";
+
+  SI.Length staticHead "static head in m";
+  SI.Pressure staticHead_Pa_relative "static head measured i Pa, taking current acceleration and limitations into account";
+
 protected
   Medium.Density rho_in=max(rho_min, Medium.density(inlet.state))
     "Density of medium entering";
-    outer ThermofluidStream.Boundaries.AccelerationBoundary acceleration;
+
 equation
   dp = -(fromPosition - toPosition)*acceleration.a*rho_in;
   h_out = h_in;


### PR DESCRIPTION
Fix the models `AccelerationBoundary` and `StaticHead` to ensure they simulate in OpenModelica.

**AccelerationBoundary**
- Add internal connectors to switch between parameter inputs and real inputs without issue in OM 
- Add `output` to the acceleration vector `a`.

**StaticHead**
- Remove `enable = not computeL` from the inertance parameter annotation
- Extends `DropOfCommonsPlus` instead of just having `outer dropOfCommons`
- Reorganize the text layer to fit Modelica Specification

Regression tests passed and test models which use these 2 components now run in OM.
Closes #385 